### PR TITLE
Updated Maven version to 1.0.1-SNAPSHOT

### DIFF
--- a/openpdf/pom.xml
+++ b/openpdf/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.github.bengolder</groupId>
         <artifactId>openpdf-parent</artifactId>
-        <version>1.0</version>
+        <version>1.0.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>openpdf</artifactId>

--- a/pdf-html/pom.xml
+++ b/pdf-html/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.github.bengolder</groupId>
         <artifactId>openpdf-parent</artifactId>
-        <version>1.0</version>
+        <version>1.0.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>pdf-html</artifactId>

--- a/pdf-rtf/pom.xml
+++ b/pdf-rtf/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.github.bengolder</groupId>
         <artifactId>openpdf-parent</artifactId>
-        <version>1.0</version>
+        <version>1.0.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>pdf-rtf</artifactId>

--- a/pdf-swing/pom.xml
+++ b/pdf-swing/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.github.bengolder</groupId>
         <artifactId>openpdf-parent</artifactId>
-        <version>1.0</version>
+        <version>1.0.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>pdf-swing</artifactId>

--- a/pdf-toolbox/pom.xml
+++ b/pdf-toolbox/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.github.bengolder</groupId>
         <artifactId>openpdf-parent</artifactId>
-        <version>1.0</version>
+        <version>1.0.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>pdf-toolbox</artifactId>

--- a/pdf-xml/pom.xml
+++ b/pdf-xml/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.github.bengolder</groupId>
         <artifactId>openpdf-parent</artifactId>
-        <version>1.0</version>
+        <version>1.0.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>pdf-xml</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <groupId>com.github.bengolder</groupId>
     <artifactId>openpdf-parent</artifactId>
     <packaging>pom</packaging>
-    <version>1.0</version>
+    <version>1.0.1-SNAPSHOT</version>
 
     <licenses>
         <license>


### PR DESCRIPTION
Updated the Maven version in all of the POM files to `1.0.1-SNAPSHOT` to follow the Maven standard.

This closes #7.
