### PR TITLE
Added OSGi mappings for all projects

### DIFF
--- a/openpdf/pom.xml
+++ b/openpdf/pom.xml
@@ -24,4 +24,22 @@
         </dependency>
     </dependencies>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <configuration>
+                    <!-- unpack bundle, so humans can see the manifest without unpacking the jar -->
+                    <unpackBundle>true</unpackBundle>
+                    <instructions>
+                        <!-- All com.lowagie.text.* packages are 'public' -->
+                        <Export-Package>com.lowagie.text.*</Export-Package>
+                        <!-- Declare the Bouncycastle dependencies as optional -->
+                        <Import-Package>org.bouncycastle.*;resolution:=optional,*</Import-Package>
+                    </instructions>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -52,6 +52,7 @@
         <maven.release.plugin.version>2.5.1</maven.release.plugin.version>
         <maven.jar.plugin.version>2.5</maven.jar.plugin.version>
         <maven.plugin.repository.version>2.3.1</maven.plugin.repository.version>
+        <maven.plugin.bundle.version>3.2.0</maven.plugin.bundle.version>
     </properties>
     <!-- Support for compilation under java 8 -->
     <profiles>
@@ -149,6 +150,12 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
                 <version>${maven.jar.plugin.version}</version>
+                <configuration>
+                    <!-- Use the Bnd generated MANIFEST.MF in the jar -->
+                    <archive>
+                        <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+                    </archive>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -180,6 +187,31 @@
                  <nexusUrl>https://oss.sonatype.org/</nexusUrl>
                  <autoReleaseAfterClose>false</autoReleaseAfterClose>
               </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <version>${maven.plugin.bundle.version}</version>
+                <extensions>true</extensions>
+                <executions>
+                    <execution>
+                        <id>bundle-manifest</id>
+                        <phase>process-classes</phase>
+                        <!-- bind the manifest.mf generation after the 'compile' phase -->
+                        <goals>
+                            <goal>manifest</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <!-- unpack bundle, so humans can see the manifest without unpacking the jar -->
+                    <unpackBundle>true</unpackBundle>
+                    <!-- All com.lowagie.* packages are 'public' -->
+                    <instructions>
+                        <Export-Package>com.lowagie.*</Export-Package>
+                    </instructions>
+                </configuration>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
This will add `Export-Package` and `Import-Package` entries to the generated JAR files' MANIFEST.MF files, allowing to deploy the libraries as OSGi bundles on application servers supporting OSGi.

The Bouncycastle dependencies have been marked as optional, since they are only required for some use cases, and don't have to be deployed if that functionality is not used.

This is something that I need for our deployment case, and a few other people have asked for this as well, e.g. here: http://itext.2136553.n4.nabble.com/itext-as-OSGi-bundle-td3448295.html

An older version of iText was available as an OSGi bundle through Springsource: http://ebr.springsource.com/repository/app/bundle/version/detail?name=com.springsource.com.lowagie.text&version=2.0.8&searchType=bundlesByName&searchQuery=iText

This PR provides the same functionality with regards to the generated Manifest.

The bundle plugin is defined and used for all of the projects, but the important change is in the OpenPDF project, where the Bouncycastle dependencies are declared as optional. For the other projects, the default configuration from the parent project is used.

The Manifest for the OpenPDF JAR now includes the following section:

```
Bundle-Description: Open and Free PDF library.
Bundle-License: http://www.gnu.org/licenses/lgpl.html, http://www.mozill
 a.org/MPL/2.0/
Bundle-ManifestVersion: 2
Bundle-Name: openpdf
Bundle-SymbolicName: com.github.librepdf.openpdf
Bundle-Version: 1.0.1.SNAPSHOT
Created-By: Apache Maven Bundle Plugin
Export-Package: com.lowagie.text;uses:="com.lowagie.text.pdf,com.lowagie
 .text.pdf.draw";version="1.0.1",com.lowagie.text.error_messages;version
 ="1.0.1",com.lowagie.text.exceptions;version="1.0.1",com.lowagie.text.f
 actories;uses:="com.lowagie.text";version="1.0.1",com.lowagie.text.html
 ;version="1.0.1",com.lowagie.text.pdf;uses:="com.lowagie.text,com.lowag
 ie.text.pdf.collection,com.lowagie.text.pdf.crypto,com.lowagie.text.pdf
 .hyphenation,com.lowagie.text.pdf.interfaces,com.lowagie.text.pdf.inter
 nal,com.lowagie.text.xml.simpleparser,javax.xml.parsers,org.bouncycastl
 e.asn1,org.bouncycastle.cert.ocsp,org.bouncycastle.tsp,org.w3c.dom,org.
 xml.sax";version="1.0.1",com.lowagie.text.pdf.codec;uses:="com.lowagie.
 text,com.lowagie.text.pdf";version="1.0.1",com.lowagie.text.pdf.codec.w
 mf;uses:="com.lowagie.text,com.lowagie.text.pdf";version="1.0.1",com.lo
 wagie.text.pdf.collection;uses:="com.lowagie.text.pdf";version="1.0.1",
 com.lowagie.text.pdf.crypto;version="1.0.1",com.lowagie.text.pdf.draw;u
 ses:="com.lowagie.text,com.lowagie.text.pdf";version="1.0.1",com.lowagi
 e.text.pdf.events;uses:="com.lowagie.text,com.lowagie.text.pdf";version
 ="1.0.1",com.lowagie.text.pdf.fonts;version="1.0.1",com.lowagie.text.pd
 f.fonts.cmaps;version="1.0.1",com.lowagie.text.pdf.hyphenation;uses:="c
 om.lowagie.text.xml.simpleparser";version="1.0.1",com.lowagie.text.pdf.
 interfaces;uses:="com.lowagie.text,com.lowagie.text.pdf";version="1.0.1
 ",com.lowagie.text.pdf.internal;uses:="com.lowagie.text,com.lowagie.tex
 t.pdf,com.lowagie.text.pdf.interfaces";version="1.0.1",com.lowagie.text
 .pdf.parser;uses:="com.lowagie.text.pdf";version="1.0.1",com.lowagie.te
 xt.xml;uses:="org.w3c.dom";version="1.0.1",com.lowagie.text.xml.simplep
 arser;uses:="com.lowagie.text";version="1.0.1",com.lowagie.text.xml.xmp
 ;uses:="com.lowagie.text.pdf,org.w3c.dom,org.xml.sax";version="1.0.1"
Import-Package: org.bouncycastle.asn1;resolution:=optional;version="[1.5
 5,2)",org.bouncycastle.asn1.cmp;resolution:=optional;version="[1.55,2)"
 ,org.bouncycastle.asn1.cms;resolution:=optional;version="[1.55,2)",org.
 bouncycastle.asn1.ocsp;resolution:=optional;version="[1.55,2)",org.boun
 cycastle.asn1.pkcs;resolution:=optional;version="[1.55,2)",org.bouncyca
 stle.asn1.tsp;resolution:=optional;version="[1.55,2)",org.bouncycastle.
 asn1.x500;resolution:=optional;version="[1.55,2)",org.bouncycastle.asn1
 .x509;resolution:=optional;version="[1.55,2)",org.bouncycastle.cert;res
 olution:=optional;version="[1.55,2)",org.bouncycastle.cert.jcajce;resol
 ution:=optional;version="[1.55,2)",org.bouncycastle.cert.ocsp;resolutio
 n:=optional;version="[1.55,2)",org.bouncycastle.cms;resolution:=optiona
 l;version="[1.55,2)",org.bouncycastle.cms.jcajce;resolution:=optional;v
 ersion="[1.55,2)",org.bouncycastle.crypto;resolution:=optional;version=
 "[1.55,2)",org.bouncycastle.crypto.engines;resolution:=optional;version
 ="[1.55,2)",org.bouncycastle.crypto.modes;resolution:=optional;version=
 "[1.55,2)",org.bouncycastle.crypto.paddings;resolution:=optional;versio
 n="[1.55,2)",org.bouncycastle.crypto.params;resolution:=optional;versio
 n="[1.55,2)",org.bouncycastle.jce.provider;resolution:=optional;version
 ="[1.55,2)",org.bouncycastle.operator;resolution:=optional;version="[1.
 55,2)",org.bouncycastle.operator.jcajce;resolution:=optional;version="[
 1.55,2)",org.bouncycastle.tsp;resolution:=optional;version="[1.55,2)",c
 om.lowagie.text,com.lowagie.text.error_messages,com.lowagie.text.except
 ions,com.lowagie.text.factories,com.lowagie.text.html,com.lowagie.text.
 pdf,com.lowagie.text.pdf.codec,com.lowagie.text.pdf.codec.wmf,com.lowag
 ie.text.pdf.collection,com.lowagie.text.pdf.crypto,com.lowagie.text.pdf
 .draw,com.lowagie.text.pdf.events,com.lowagie.text.pdf.fonts,com.lowagi
 e.text.pdf.fonts.cmaps,com.lowagie.text.pdf.hyphenation,com.lowagie.tex
 t.pdf.interfaces,com.lowagie.text.pdf.internal,com.lowagie.text.xml,com
 .lowagie.text.xml.simpleparser,com.lowagie.text.xml.xmp,javax.crypto,ja
 vax.imageio,javax.imageio.metadata,javax.imageio.plugins.jpeg,javax.ima
 geio.stream,javax.xml.parsers,org.w3c.dom,org.xml.sax
Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=1.7))"
Tool: Bnd-3.2.0.201605172007
```

Please let me know whether this is an acceptable change. It shouldn't have an impact on the original functionality, it simply adds the above information (or similar, based on the analysis of the code) to each project's Manifest file, similar to what the Springsource project did.
