### PR TITLE
Added configuration for the Maven release plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -145,6 +145,9 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-release-plugin</artifactId>
                 <version>${maven.release.plugin.version}</version>
+                <configuration>
+                    <autoVersionSubmodules>true</autoVersionSubmodules>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
This will use the same version number across all of the modules, it will have to be entered only once (or you use `-DdevelopmentVersion=...` and `-DreleaseVersion=...` as command line parameters when calling `mvn release:prepare`).