### PR TITLE
Updated OSGi mappings to include version number

### DIFF
--- a/openpdf/pom.xml
+++ b/openpdf/pom.xml
@@ -34,9 +34,9 @@
                     <unpackBundle>true</unpackBundle>
                     <instructions>
                         <!-- All com.lowagie.text.* packages are 'public' -->
-                        <Export-Package>com.lowagie.text.*</Export-Package>
+                        <Export-Package>com.lowagie.text.*;version="${project.version}"</Export-Package>
                         <!-- Declare the Bouncycastle dependencies as optional -->
-                        <Import-Package>org.bouncycastle.*;resolution:=optional,*</Import-Package>
+                        <Import-Package>org.bouncycastle.*;resolution:=optional,!com.lowagie.*,*</Import-Package>
                     </instructions>
                 </configuration>
             </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -212,7 +212,7 @@
                     <unpackBundle>true</unpackBundle>
                     <!-- All com.lowagie.* packages are 'public' -->
                     <instructions>
-                        <Export-Package>com.lowagie.*</Export-Package>
+                        <Export-Package>com.lowagie.*;version="${project.version}"</Export-Package>
                     </instructions>
                 </configuration>
             </plugin>


### PR DESCRIPTION
Also excluding some internal packages to make the mappings similar to the ones that were in the Springsource packages.