### PR TITLE
PdfGraphics2D.java: Add missing public keyword on constructor

### DIFF
--- a/openpdf/src/main/java/com/lowagie/text/pdf/PdfGraphics2D.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/PdfGraphics2D.java
@@ -186,10 +186,18 @@ public class PdfGraphics2D extends Graphics2D {
     }
     
     /**
+     * Shortcut constructor for PDFGraphics2D.
+     *
+     */
+    public PdfGraphics2D(PdfContentByte cb, float width, float height) {
+        this(cb, width, height, null, false, false, 0);
+    }
+    
+    /**
      * Constructor for PDFGraphics2D.
      *
      */
-    PdfGraphics2D(PdfContentByte cb, float width, float height, FontMapper fontMapper, boolean onlyShapes, boolean convertImagesToJPEG, float quality) {
+    public PdfGraphics2D(PdfContentByte cb, float width, float height, FontMapper fontMapper, boolean onlyShapes, boolean convertImagesToJPEG, float quality) {
         super();
         dg2.setRenderingHint(RenderingHints.KEY_FRACTIONALMETRICS, RenderingHints.VALUE_FRACTIONALMETRICS_ON);
         setRenderingHint(RenderingHints.KEY_FRACTIONALMETRICS, RenderingHints.VALUE_FRACTIONALMETRICS_ON);


### PR DESCRIPTION
When calling the main PdfGraphics2D constructor, an error was given
saying that it was private. Adding the public keyword fixed this.

Adding a three item constructor, because it is common to just use
the Content, width, and height without other parameters. This
keeps code tidy by not having null, false, false, 0 all the time.

Signed-off by: Jonathan Scruggs (j.scruggs@gmail.com)