### PR TITLE
Handle ACROFORM that is PdfNull

### DIFF
--- a/openpdf/src/main/java/com/lowagie/text/pdf/PdfStamperImp.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/PdfStamperImp.java
@@ -163,17 +163,20 @@ class PdfStamperImp extends PdfWriter {
         PdfDictionary pages = (PdfDictionary)PdfReader.getPdfObject(catalog.get(PdfName.PAGES));
         pages.put(PdfName.ITXT, new PdfString(Document.getRelease()));
         markUsed(pages);
-        PdfDictionary acroForm = (PdfDictionary)PdfReader.getPdfObject(catalog.get(PdfName.ACROFORM), reader.getCatalog());
-        if (acroFields != null && acroFields.getXfa().isChanged()) {
-            markUsed(acroForm);
-            if (!flat)
-                acroFields.getXfa().setXfa(this);
-        }
-        if (sigFlags != 0) {
-            if (acroForm != null) {
-                acroForm.put(PdfName.SIGFLAGS, new PdfNumber(sigFlags));
+        PdfObject acroFormObject = PdfReader.getPdfObject(catalog.get(PdfName.ACROFORM), reader.getCatalog());
+        if (acroFormObject instanceof PdfDictionary) {
+            PdfDictionary acroForm = (PdfDictionary) acroFormObject;
+            if (acroFields != null && acroFields.getXfa().isChanged()) {
                 markUsed(acroForm);
-                markUsed(catalog);
+                if (!flat)
+                    acroFields.getXfa().setXfa(this);
+            }
+            if (sigFlags != 0) {
+                if (acroForm != null) {
+                    acroForm.put(PdfName.SIGFLAGS, new PdfNumber(sigFlags));
+                    markUsed(acroForm);
+                    markUsed(catalog);
+                }
             }
         }
         closed = true;


### PR DESCRIPTION
Instead of a PdfDictionary - as generated by iTextSharp 5. 

Unfortunately the offending PDF was generated by a third party and contains confidential information.