### PR TITLE
Some fixes and improvements

### DIFF
--- a/openpdf/src/main/java/com/lowagie/text/pdf/DocumentFont.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/DocumentFont.java
@@ -114,7 +114,12 @@ public class DocumentFont extends BaseFont {
         this.refFont = refFont;
         fontType = FONT_TYPE_DOCUMENT;
         font = (PdfDictionary)PdfReader.getPdfObject(refFont);
-        fontName = PdfName.decodeName(font.getAsName(PdfName.BASEFONT).toString());
+		PdfName asName = font.getAsName(PdfName.BASEFONT);
+		if (asName != null) {
+			fontName = PdfName.decodeName(asName.toString());
+		} else {
+			fontName = "badFontName";
+		}
         PdfName subType = font.getAsName(PdfName.SUBTYPE);
         if (PdfName.TYPE1.equals(subType) || PdfName.TRUETYPE.equals(subType))
             doType1TT();
@@ -131,24 +136,27 @@ public class DocumentFont extends BaseFont {
                     return;
                 }
             }
-            String enc = PdfName.decodeName(font.getAsName(PdfName.ENCODING).toString());
-            for (int k = 0; k < cjkEncs2.length; ++k) {
-                if (enc.startsWith(cjkEncs2[k])) {
-                    try {
-                        if (k > 3)
-                            k -= 4;
-                        cjkMirror = BaseFont.createFont(cjkNames2[k], cjkEncs2[k], false);
-                    }
-                    catch (Exception e) {
-                        throw new ExceptionConverter(e);
-                    }
-                    return;
-                }
-            }
-            if (PdfName.TYPE0.equals(subType) && enc.equals("Identity-H")) {
-                processType0(font);
-                isType0 = true;
-            }
+			PdfName encName = font.getAsName(PdfName.ENCODING);
+			if (encName != null) {
+				String enc = PdfName.decodeName(encName.toString());
+	            for (int k = 0; k < cjkEncs2.length; ++k) {
+	                if (enc.startsWith(cjkEncs2[k])) {
+	                    try {
+	                        if (k > 3)
+	                            k -= 4;
+	                        cjkMirror = BaseFont.createFont(cjkNames2[k], cjkEncs2[k], false);
+	                    }
+	                    catch (Exception e) {
+	                        throw new ExceptionConverter(e);
+	                    }
+	                    return;
+	                }
+	            }
+	            if (PdfName.TYPE0.equals(subType) && enc.equals("Identity-H")) {
+	                processType0(font);
+	                isType0 = true;
+	            }
+	        }
         }
     }
     
@@ -294,7 +302,8 @@ public class DocumentFont extends BaseFont {
                         if (obj.isNumber())
                             currentNumber = ((PdfNumber)obj).intValue();
                         else {
-                            int c[] = GlyphList.nameToUnicode(PdfName.decodeName(obj.toString()));
+							int c[] = GlyphList.nameToUnicode(PdfName
+									.decodeName(((PdfName) obj).toString()));
                             if (c != null && c.length > 0) {
                                 uni2byte.put(c[0], currentNumber);
                                 diffmap.put(c[0], currentNumber);

--- a/openpdf/src/main/java/com/lowagie/text/pdf/PRTokeniser.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/PRTokeniser.java
@@ -241,7 +241,7 @@ public class PRTokeniser {
         String n1 = null;
         String n2 = null;
         int ptr = 0;
-        while (nextToken()) {
+        while (nextToken() || level == 2) {
             if (type == TK_COMMENT)
                 continue;
             switch (level) {
@@ -288,6 +288,13 @@ public class PRTokeniser {
             stringValue = n1;
             return;
         }
+//                if (type == TK_ENDOFFILE && level > 0)
+//        	        {
+//        	            file.seek(ptr);
+//        	            type = TK_NUMBER;
+//        	            stringValue = n1;
+//        	        }
+
         throwError("Unexpected end of file");
         // if we hit here, the file is either corrupt (stream ended unexpectedly),
         // or the last token ended exactly at the end of a stream.  This last

--- a/openpdf/src/main/java/com/lowagie/text/pdf/PRTokeniser.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/PRTokeniser.java
@@ -349,6 +349,9 @@ public class PRTokeniser {
             case '<':
             {
                 int v1 = file.read();
+                while (isWhitespace(v1)) {
+                    v1 = file.read();
+                }
                 if (v1 == '<') {
                     type = TK_START_DIC;
                     break;

--- a/openpdf/src/main/java/com/lowagie/text/pdf/PdfReader.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/PdfReader.java
@@ -673,6 +673,9 @@ public class PdfReader implements PdfViewerPreferences {
   private void readDecryptedDocObj() throws IOException {
     if (encrypted)
       return;
+    if (trailer == null) {
+      return;
+    }
     PdfObject encDic = trailer.get(PdfName.ENCRYPT);
     if (encDic == null || encDic.toString().equals("null"))
       return;
@@ -1664,9 +1667,6 @@ public class PdfReader implements PdfViewerPreferences {
         }
       }
     }
-    if (trailer == null)
-      throw new InvalidPdfException(
-          MessageLocalization.getComposedMessage("trailer.not.found"));
     xref = new int[top * 2];
     for (int k = 0; k < top; ++k) {
       int obj[] = xr[k];

--- a/openpdf/src/main/java/com/lowagie/text/pdf/parser/MarkedUpTextAssembler.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/parser/MarkedUpTextAssembler.java
@@ -143,7 +143,7 @@ public class MarkedUpTextAssembler implements TextAssembler {
 			return null;
 		}
 		StringBuffer res = new StringBuffer();
-		if (_usePdfMarkupElements) {
+		if (_usePdfMarkupElements && !containingElementName.isEmpty()) {
 			res.append('<').append(containingElementName).append('>');
 		}
 		for (FinalText item : result) {
@@ -151,7 +151,7 @@ public class MarkedUpTextAssembler implements TextAssembler {
 		}
 		// important, as the stuff buffered in the result is now used up!
 		result.clear();
-		if (_usePdfMarkupElements) {
+		if (_usePdfMarkupElements && !containingElementName.isEmpty()) {
 			res.append("</");
 			int spacePos = containingElementName.indexOf(' ');
 			if (spacePos >= 0) {
@@ -204,8 +204,9 @@ public class MarkedUpTextAssembler implements TextAssembler {
 	/**
 	 * Captures text using a simplified algorithm for inserting hard returns and
 	 * spaces
-	 * 
-	 * @see com.lowagie.text.pdf.parser.GraphicsState,
+	 *
+	 * @see com.lowagie.text.pdf.parser.AbstractRenderListener#renderText(java.lang.String,
+	 *      com.lowagie.text.pdf.parser.GraphicsState,
 	 *      com.lowagie.text.pdf.parser.Matrix,
 	 *      com.lowagie.text.pdf.parser.Matrix)
 	 */
@@ -264,7 +265,8 @@ public class MarkedUpTextAssembler implements TextAssembler {
 
 	/**
 	 * Getter.
-	 * 
+	 *
+	 * @see SimpleTextExtractingPdfContentRenderListener#_reader
 	 * @return reader
 	 */
 	protected PdfReader getReader() {

--- a/openpdf/src/main/java/com/lowagie/text/pdf/parser/PdfContentStreamHandler.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/parser/PdfContentStreamHandler.java
@@ -684,9 +684,9 @@ public class PdfContentStreamHandler {
 		@Override
 		public void invoke(ArrayList<PdfObject> operands,
 				PdfContentStreamHandler handler, PdfDictionary resources) {
-			PdfName name = (PdfName) operands.get(0);
-			String realName = name.toString().substring(1);
-			if ("Artifact".equals(realName)) {
+			PdfName tagName = (PdfName) operands.get(0);
+			String realName = tagName.toString().substring(1).toLowerCase();
+			if ("artifact".equals(tagName) || "placedpdf".equals(tagName)) {
 				handler.pushContext(null);
 			} else {
 				handler.pushContext(realName);
@@ -710,8 +710,8 @@ public class PdfContentStreamHandler {
 		@Override
 		public void invoke(ArrayList<PdfObject> operands,
 				PdfContentStreamHandler handler, PdfDictionary resources) {
-			String tagName = operands.get(0).toString()
-					.substring(1).toLowerCase();
+			String tagName = ((PdfName) operands.get(0)).toString().substring(1)
+					.toLowerCase();
 			if ("artifact".equals(tagName) || "placedpdf".equals(tagName)
 					|| handler.contextNames.peek() == null) {
 				tagName = null;
@@ -719,15 +719,20 @@ public class PdfContentStreamHandler {
 				tagName = "ul";
 			}
 			PdfDictionary attrs = getBDCDictionary(operands, resources);
-			if (attrs != null) {
+			if (attrs != null && tagName != null) {
 				PdfString alternateText = attrs.getAsString(PdfName.E);
 				if (alternateText != null) {
 					handler.pushContext(tagName);
-					handler.textFragments.add(new FinalText(alternateText
-							.toString()));
+					handler.textFragments
+							.add(new FinalText(alternateText.toString()));
 					handler.popContext();
+					// ignore rest of the content of this element
 					handler.pushContext(null);
 					return;
+				} else if (attrs.get(PdfName.TYPE) != null) {
+					// ignore tag for non-tag marked content that sometimes
+					// shows up.
+					tagName = "";
 				}
 			}
 			handler.pushContext(tagName);

--- a/openpdf/src/main/java/com/lowagie/text/pdf/parser/PdfTextExtractor.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/parser/PdfTextExtractor.java
@@ -214,6 +214,9 @@ public class PdfTextExtractor {
 	public String getTextFromPage(int page, boolean useContainerMarkup)
 			throws IOException {
 		PdfDictionary pageDict = reader.getPageN(page);
+		if (pageDict == null) {
+			return ""; 
+		}
 		PdfDictionary resources = pageDict.getAsDict(PdfName.RESOURCES);
 
 		renderListener.reset();

--- a/openpdf/src/main/java/com/lowagie/text/pdf/parser/Word.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/parser/Word.java
@@ -85,10 +85,14 @@ public class Word extends ParsedTextImpl {
 		p.renderText(this);
 	}
 
+	private static String formatPercent(float f) {
+		return String.format("%f.2%%", f);
+	}
+
 	/**
 	 * Generate markup for this word. send the assembler a strings representing
 	 * a CSS style that will format us nicely.
-	 * 
+	 *
 	 * @param text
 	 *            passed in because we may have wanted to alter it, e.g. by
 	 *            trimming white space, or filtering characters or something.
@@ -124,7 +128,8 @@ public class Word extends ParsedTextImpl {
 		Vector endPoint = getEndPoint();
 		float pageWidth = clipBox.getWidth();
 		float pageHeight = clipBox.getHeight();
-		float leftPercent = (float) ((startPoint.get(0) - xOffset) / pageWidth * 100.0);
+		float leftPercent = (float) ((startPoint.get(0) - xOffset) / pageWidth
+				* 100.0);
 		float bottom = endPoint.get(1) + yOffset - getDescent();
 		float bottomPercent = bottom / pageHeight * 100f;
 		StringBuilder result = new StringBuilder();
@@ -135,9 +140,10 @@ public class Word extends ParsedTextImpl {
 		float heightPercent = height / pageHeight * 100.0f;
 		String myId = assembler.getWordId();
 		result.append("<span class=\"t-word\" style=\"bottom: ")
-				.append(bottomPercent).append("%; left: ").append(leftPercent)
-				.append("%; width: ").append(widthPercent)
-				.append("%; height: ").append(heightPercent).append("%;\"")
+				.append(formatPercent(bottomPercent)).append("; left: ")
+				.append(formatPercent(leftPercent)).append("; width: ")
+				.append(formatPercent(widthPercent)).append("; height: ")
+				.append(formatPercent(heightPercent)).append(";\"")
 				.append(" id=\"").append(myId).append("\">")
 				.append(escapeHTML(text)).append(" ");
 		result.append("</span> ");
@@ -158,8 +164,8 @@ public class Word extends ParsedTextImpl {
 	@Override
 	public FinalText getFinalText(PdfReader reader, int page,
 			TextAssembler assembler) {
-		return new FinalText(wordMarkup(getText().trim(), reader, page,
-				assembler));
+		return new FinalText(
+				wordMarkup(getText().trim(), reader, page, assembler));
 	}
 
 	@Override


### PR DESCRIPTION
I recently became aware of this fork, and a request that I consider submitting changes to it. I undid some code reformatting, and reapplied my changes. I intend to use this fork going forward, but I do need these changes.

This pull request is the set of changes that I made since you forked from me. They could be broken up into separate requests, I suppose, but they are pretty minimal and should be non-controversial (I hope).

+ A few changes are to the modified text extraction that I had written:
    +  I now return an empty string rather than null if there is no text in a document.

    + Text extraction returns markup representing the area taken by a word; this is now given with less precision, as results were very large, and the extra digits represented micrometers or less.

    + Marked sections that don't represent markup elements, and have no names or attributes are silently omitted (as they are useless). This is a more precise version of the policy to suppress "artifacts" (text that would not be appropriate for a screen reader).

I removed detection of missing "trailers" in a PDF, as they are not required by the standard  any longer.

Fixed an NPE on a bad font object, as well as some potential type issues.

The tokenizer would crash when finding permitted (but useless) stray spaces in hex constants; I did find PDFs "in the wild" that had such spaces. Now they are ignored.
