### PR TITLE
Fix: Floating point format was incorrect for extracted text

### DIFF
--- a/openpdf/src/main/java/com/lowagie/text/pdf/parser/Word.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/parser/Word.java
@@ -86,7 +86,7 @@ public class Word extends ParsedTextImpl {
 	}
 
 	private static String formatPercent(float f) {
-		return String.format("%f.2%%", f);
+		return String.format("%.2f%%", f);
 	}
 
 	/**


### PR DESCRIPTION
Was concatenating .2 to number, rather than limiting precision.