### PR TITLE
Modifications made by TIBCO Software for JasperReports >= 6.2

### DIFF
--- a/openpdf/src/main/java/com/lowagie/text/pdf/PdfContentByte.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/PdfContentByte.java
@@ -1438,13 +1438,11 @@ public class PdfContentByte {
         content.append("Tj").append_i(separator);
     }
     
-	// TIBCO Software #4 : Part 1 - START
 	public void showText(GlyphVector glyphVector) {
 		byte[] b = state.fontDetails.convertToBytes(glyphVector);
 		escapeString(b, content);
 		content.append("Tj").append_i(separator);
 	}
-	// TIBCO Software #4 : Part 1 - END
 	
     /**
      * Constructs a kern array for a text in a certain font
@@ -3025,13 +3023,11 @@ public class PdfContentByte {
      * @param struc the tagging structure
      */
     public void beginMarkedContentSequence(PdfStructureElement struc) {
-    	// TIBCO Software #4 : Part 1 - START
     	PdfDictionary dict = new PdfDictionary();
     	beginMarkedContentSequence(struc, dict);
     }
     
     public void beginMarkedContentSequence(PdfStructureElement struc, PdfDictionary dict) {
-    	// TIBCO Software #4 : Part 1 - END
         PdfObject obj = struc.get(PdfName.K);
         int mark = pdf.getMarkPoint();
         if (obj != null) {
@@ -3060,8 +3056,6 @@ public class PdfContentByte {
         }
         pdf.incMarkPoint();
         mcDepth++;
-        // TIBCO Software #4 : Part 1 - START
-        //content.append(struc.get(PdfName.S).getBytes()).append(" <</MCID ").append(mark).append(">> BDC").append_i(separator);
         dict.put(PdfName.MCID, new PdfNumber(mark));
         content.append(struc.get(PdfName.S).getBytes()).append(" ");
         try {
@@ -3071,7 +3065,6 @@ public class PdfContentByte {
         	throw new ExceptionConverter(e);
         }
         content.append(" BDC").append_i(separator);
-        // TIBCO Software #4 : Part 1 - END
     }
 
     /**

--- a/openpdf/src/main/java/com/lowagie/text/pdf/PdfDocument.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/PdfDocument.java
@@ -1399,13 +1399,10 @@ public class PdfDocument extends Document {
                         hangingCorrection = width - oldWidth;
                     }
                 }
-             // TIBCO Software #5 : Part 1 - START
-//                float baseFactor = width / (ratio * numberOfSpaces + lineLen - 1);
                 // if there's a single word on the line and we are using NO_SPACE_CHAR_RATIO,
                 // we don't want any character spacing
                 float baseFactor = (numberOfSpaces == 0 && ratio == PdfWriter.NO_SPACE_CHAR_RATIO) 
                 		? 0f : width / (ratio * numberOfSpaces + lineLen - 1);
-                // TIBCO Software #5 : Part 1 - END
                 baseWordSpacing = ratio * baseFactor;
                 baseCharacterSpacing = baseFactor;
                 lastBaseFactor = baseFactor;

--- a/openpdf/src/main/java/com/lowagie/text/pdf/PdfDocument.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/PdfDocument.java
@@ -1399,7 +1399,13 @@ public class PdfDocument extends Document {
                         hangingCorrection = width - oldWidth;
                     }
                 }
-                float baseFactor = width / (ratio * numberOfSpaces + lineLen - 1);
+             // TIBCO Software #5 : Part 1 - START
+//                float baseFactor = width / (ratio * numberOfSpaces + lineLen - 1);
+                // if there's a single word on the line and we are using NO_SPACE_CHAR_RATIO,
+                // we don't want any character spacing
+                float baseFactor = (numberOfSpaces == 0 && ratio == PdfWriter.NO_SPACE_CHAR_RATIO) 
+                		? 0f : width / (ratio * numberOfSpaces + lineLen - 1);
+                // TIBCO Software #5 : Part 1 - END
                 baseWordSpacing = ratio * baseFactor;
                 baseCharacterSpacing = baseFactor;
                 lastBaseFactor = baseFactor;

--- a/openpdf/src/main/java/com/lowagie/text/pdf/PdfGraphics2D.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/PdfGraphics2D.java
@@ -909,6 +909,9 @@ public class PdfGraphics2D extends Graphics2D {
         g2.paint = this.paint;
         g2.fillGState = this.fillGState;
         g2.currentFillGState = this.currentFillGState;
+        // TIBCO Software #3 : Part 1 - START
+        g2.currentStrokeGState = this.currentStrokeGState;
+        // TIBCO Software #3 : Part 1 - END
         g2.strokeGState = this.strokeGState;
         g2.background = this.background;
         g2.mediaTracker = this.mediaTracker;
@@ -1086,7 +1089,10 @@ public class PdfGraphics2D extends Graphics2D {
             followPath(s, CLIP);
         }
         paintFill = paintStroke = null;
-        currentFillGState = currentStrokeGState = 255;
+        // TIBCO Software #1 : Part 1 - START
+        //currentFillGState = currentStrokeGState = 255;
+        currentFillGState = currentStrokeGState = -1; // 255;
+        // TIBCO Software #1 : Part 1 - END
         oldStroke = strokeOne;
     }
     
@@ -1487,7 +1493,10 @@ public class PdfGraphics2D extends Graphics2D {
         } catch (Exception ex) {
             throw new IllegalArgumentException();
         }
-        if (currentFillGState != 255) {
+        // TIBCO Software #1 : Part 2 - START
+        //if (currentFillGState != 255) {
+        if (currentFillGState != 255 && currentFillGState != -1) {
+        	// TIBCO Software #1 : Part 2 - END
             PdfGState gs = fillGState[currentFillGState];
             cb.setGState(gs);
         }        
@@ -1613,10 +1622,28 @@ public class PdfGraphics2D extends Graphics2D {
                 PdfPatternPainter pattern = cb.createPattern(width, height);
                 image.setAbsolutePosition(0,0);
                 pattern.addImage(image);
-                if (fill)
+                // TIBCO Software #2 : Part 1 - START
+                //if (fill)
+                //    cb.setPatternFill(pattern);
+                //else
+                //    cb.setPatternStroke(pattern);
+                if (fill) {
+                	if (currentFillGState != 255){
+                		currentFillGState = 255;
+                		PdfGState gs = fillGState[255];
+						if (gs == null) {
+							gs = new PdfGState();
+							gs.setFillOpacity(1);
+							fillGState[255] = gs;
+						}
+						cb.setGState(gs);
+					}
                     cb.setPatternFill(pattern);
-                else
+                }
+                else {
                     cb.setPatternStroke(pattern);
+                }
+                // TIBCO Software #2 : Part 1 - END
             } catch (Exception ex) {
                 if (fill)
                     cb.setColorFill(Color.gray);

--- a/openpdf/src/main/java/com/lowagie/text/pdf/PdfGraphics2D.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/PdfGraphics2D.java
@@ -909,9 +909,7 @@ public class PdfGraphics2D extends Graphics2D {
         g2.paint = this.paint;
         g2.fillGState = this.fillGState;
         g2.currentFillGState = this.currentFillGState;
-        // TIBCO Software #3 : Part 1 - START
         g2.currentStrokeGState = this.currentStrokeGState;
-        // TIBCO Software #3 : Part 1 - END
         g2.strokeGState = this.strokeGState;
         g2.background = this.background;
         g2.mediaTracker = this.mediaTracker;
@@ -1089,10 +1087,7 @@ public class PdfGraphics2D extends Graphics2D {
             followPath(s, CLIP);
         }
         paintFill = paintStroke = null;
-        // TIBCO Software #1 : Part 1 - START
-        //currentFillGState = currentStrokeGState = 255;
-        currentFillGState = currentStrokeGState = -1; // 255;
-        // TIBCO Software #1 : Part 1 - END
+        currentFillGState = currentStrokeGState = -1;
         oldStroke = strokeOne;
     }
     
@@ -1493,10 +1488,7 @@ public class PdfGraphics2D extends Graphics2D {
         } catch (Exception ex) {
             throw new IllegalArgumentException();
         }
-        // TIBCO Software #1 : Part 2 - START
-        //if (currentFillGState != 255) {
         if (currentFillGState != 255 && currentFillGState != -1) {
-        	// TIBCO Software #1 : Part 2 - END
             PdfGState gs = fillGState[currentFillGState];
             cb.setGState(gs);
         }        
@@ -1622,11 +1614,7 @@ public class PdfGraphics2D extends Graphics2D {
                 PdfPatternPainter pattern = cb.createPattern(width, height);
                 image.setAbsolutePosition(0,0);
                 pattern.addImage(image);
-                // TIBCO Software #2 : Part 1 - START
-                //if (fill)
-                //    cb.setPatternFill(pattern);
-                //else
-                //    cb.setPatternStroke(pattern);
+
                 if (fill) {
                 	if (currentFillGState != 255){
                 		currentFillGState = 255;
@@ -1643,7 +1631,6 @@ public class PdfGraphics2D extends Graphics2D {
                 else {
                     cb.setPatternStroke(pattern);
                 }
-                // TIBCO Software #2 : Part 1 - END
             } catch (Exception ex) {
                 if (fill)
                     cb.setColorFill(Color.gray);

--- a/openpdf/src/main/java/com/lowagie/text/pdf/TrueTypeFont.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/TrueTypeFont.java
@@ -672,7 +672,9 @@ class TrueTypeFont extends BaseFont {
                 readCMaps();
                 readKerning();
                 readBbox();
-                GlyphWidths = null;
+                // TIBCO Software #4 : Part 1 - START
+                // GlyphWidths = null;
+                // TIBCO Software #4 : Part 1 - END
             }
         }
         finally {

--- a/openpdf/src/main/java/com/lowagie/text/pdf/TrueTypeFont.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/TrueTypeFont.java
@@ -672,9 +672,6 @@ class TrueTypeFont extends BaseFont {
                 readCMaps();
                 readKerning();
                 readBbox();
-                // TIBCO Software #4 : Part 1 - START
-                // GlyphWidths = null;
-                // TIBCO Software #4 : Part 1 - END
             }
         }
         finally {

--- a/openpdf/src/main/java/com/lowagie/text/pdf/TrueTypeFontUnicode.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/TrueTypeFontUnicode.java
@@ -50,13 +50,17 @@
 package com.lowagie.text.pdf;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.HashMap;
-import com.lowagie.text.error_messages.MessageLocalization;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
 
 import com.lowagie.text.DocumentException;
 import com.lowagie.text.Utilities;
+import com.lowagie.text.error_messages.MessageLocalization;
 
 /** Represents a True Type font with Unicode encoding. All the character
  * in the font can be used directly by using the encoding Identity-H or
@@ -70,6 +74,10 @@ class TrueTypeFontUnicode extends TrueTypeFont implements Comparator{
      * <CODE>true</CODE> if the encoding is vertical.
      */    
     boolean vertical = false;
+    
+    // TIBCO Software #4 : Part 1 - START
+    Map inverseCmap;
+    // TIBCO Software #4 : Part 1 - END
     
     /**
      * Creates a new TrueType font addressed by Unicode characters. The font
@@ -117,6 +125,34 @@ class TrueTypeFontUnicode extends TrueTypeFont implements Comparator{
         vertical = enc.endsWith("V");
     }
     
+    // TIBCO Software #4 : Part 1 - START
+	void readCMaps() throws DocumentException, IOException {
+		super.readCMaps();
+
+		Map cmap = null;
+		if (cmapExt != null) {
+			cmap = cmapExt;
+		} else if (cmap31 != null) {
+			cmap = cmap31;
+		}
+
+		if (cmap != null) {
+			inverseCmap = new HashMap<Integer, Integer>();
+			for (Iterator iterator = cmap.entrySet().iterator(); iterator.hasNext();) {
+				Map.Entry entry = (Map.Entry) iterator.next();
+				Integer code = (Integer) entry.getKey();
+				int[] metrics = (int[]) entry.getValue();
+				inverseCmap.put(Integer.valueOf(metrics[0]), code);
+			}
+		}
+	}
+    
+	protected Integer getCharacterCode(int code) {
+		return inverseCmap == null ? null : (Integer) inverseCmap.get(Integer.valueOf(code));
+    }
+    
+	// TIBCO Software #4 : Part 1 - END
+	
     /**
      * Gets the width of a <CODE>char</CODE> in normalized 1000 units.
      * @param char1 the unicode <CODE>char</CODE> to get the width of
@@ -174,6 +210,9 @@ class TrueTypeFontUnicode extends TrueTypeFont implements Comparator{
      * @return the stream representing this CMap or <CODE>null</CODE>
      */    
     private PdfStream getToUnicode(Object metrics[]) {
+    	// TIBCO Software #4 : Part 1 - START
+    	metrics = filterCmapMetrics(metrics);
+    	// TIBCO Software #4 : Part 1 - END
         if (metrics.length == 0)
             return null;
         StringBuffer buf = new StringBuffer(
@@ -215,6 +254,32 @@ class TrueTypeFontUnicode extends TrueTypeFont implements Comparator{
         return stream;
     }
     
+    // TIBCO Software #4 : Part 1 - START
+	private Object[] filterCmapMetrics(Object[] metrics) {
+		if (metrics.length == 0) {
+			return metrics;
+		}
+
+		List<int[]> cmapMetrics = new ArrayList<int[]>(metrics.length);
+		for (int i = 0; i < metrics.length; i++) {
+			int metric[] = (int[]) metrics[i];
+			// PdfContentByte.showText(GlyphVector) uses glyphs that might not
+			// map to a character.
+			// the glyphs are included in the metrics array, but we need to
+			// exclude them from the cmap.
+			if (metric.length >= 3) {
+				cmapMetrics.add(metric);
+			}
+		}
+
+		if (cmapMetrics.size() == metrics.length) {
+			return metrics;
+		}
+
+		return cmapMetrics.toArray();
+	}
+	// TIBCO Software #4 : Part 1 - END
+	
     private static String toHex4(int n) {
         String s = "0000" + Integer.toHexString(n);
         return s.substring(s.length() - 4);

--- a/openpdf/src/main/java/com/lowagie/text/pdf/TrueTypeFontUnicode.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/TrueTypeFontUnicode.java
@@ -75,9 +75,7 @@ class TrueTypeFontUnicode extends TrueTypeFont implements Comparator{
      */    
     boolean vertical = false;
     
-    // TIBCO Software #4 : Part 1 - START
     Map inverseCmap;
-    // TIBCO Software #4 : Part 1 - END
     
     /**
      * Creates a new TrueType font addressed by Unicode characters. The font
@@ -125,7 +123,6 @@ class TrueTypeFontUnicode extends TrueTypeFont implements Comparator{
         vertical = enc.endsWith("V");
     }
     
-    // TIBCO Software #4 : Part 1 - START
 	void readCMaps() throws DocumentException, IOException {
 		super.readCMaps();
 
@@ -151,7 +148,6 @@ class TrueTypeFontUnicode extends TrueTypeFont implements Comparator{
 		return inverseCmap == null ? null : (Integer) inverseCmap.get(Integer.valueOf(code));
     }
     
-	// TIBCO Software #4 : Part 1 - END
 	
     /**
      * Gets the width of a <CODE>char</CODE> in normalized 1000 units.
@@ -210,9 +206,7 @@ class TrueTypeFontUnicode extends TrueTypeFont implements Comparator{
      * @return the stream representing this CMap or <CODE>null</CODE>
      */    
     private PdfStream getToUnicode(Object metrics[]) {
-    	// TIBCO Software #4 : Part 1 - START
     	metrics = filterCmapMetrics(metrics);
-    	// TIBCO Software #4 : Part 1 - END
         if (metrics.length == 0)
             return null;
         StringBuffer buf = new StringBuffer(
@@ -254,7 +248,6 @@ class TrueTypeFontUnicode extends TrueTypeFont implements Comparator{
         return stream;
     }
     
-    // TIBCO Software #4 : Part 1 - START
 	private Object[] filterCmapMetrics(Object[] metrics) {
 		if (metrics.length == 0) {
 			return metrics;
@@ -278,7 +271,6 @@ class TrueTypeFontUnicode extends TrueTypeFont implements Comparator{
 
 		return cmapMetrics.toArray();
 	}
-	// TIBCO Software #4 : Part 1 - END
 	
     private static String toHex4(int n) {
         String s = "0000" + Integer.toHexString(n);

--- a/openpdf/src/main/java/com/lowagie/text/pdf/TrueTypeFontUnicode.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/TrueTypeFontUnicode.java
@@ -75,7 +75,7 @@ class TrueTypeFontUnicode extends TrueTypeFont implements Comparator{
      */    
     boolean vertical = false;
     
-    Map inverseCmap;
+    Map<Integer, Integer> inverseCmap;
     
     /**
      * Creates a new TrueType font addressed by Unicode characters. The font
@@ -139,13 +139,13 @@ class TrueTypeFontUnicode extends TrueTypeFont implements Comparator{
 				Map.Entry entry = (Map.Entry) iterator.next();
 				Integer code = (Integer) entry.getKey();
 				int[] metrics = (int[]) entry.getValue();
-				inverseCmap.put(Integer.valueOf(metrics[0]), code);
+				inverseCmap.put(metrics[0], code);
 			}
 		}
 	}
     
 	protected Integer getCharacterCode(int code) {
-		return inverseCmap == null ? null : (Integer) inverseCmap.get(Integer.valueOf(code));
+		return inverseCmap == null ? null : inverseCmap.get(code);
     }
     
 	


### PR DESCRIPTION
1. Fix for transparency issue with setClip method in PdfGraphics2D
2. Fix for transparency bleeding for Batik gradients
3. Fix for stroke opacity state in the create() method of
PdfGraphics2D
4. Method to directly write AWT GlyphVectors to PDF for Indic scripts
support
5. No character spacing in justified lines with a single word


Origin: 

https://sources.debian.net/patches/libitext-java/2.1.7-11/04_tibco-changes.patch/

http://jaspersoft.artifactoryonline.com/jaspersoft/third-party-ce-artifacts/com/lowagie/itext/2.1.7.js5/itext-2.1.7.js5-sources.jar