### PR TITLE
Add Closeable to PdfReader, to allow try-with-resources.

### DIFF
--- a/openpdf/src/main/java/com/lowagie/text/pdf/PdfReader.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/PdfReader.java
@@ -62,6 +62,7 @@ import com.lowagie.text.pdf.internal.PdfViewerPreferencesImp;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
+import java.io.Closeable;
 import java.io.DataInputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -86,7 +87,7 @@ import java.util.zip.InflaterInputStream;
  * @author Paulo Soares (psoares@consiste.pt)
  * @author Kazuya Ujihara
  */
-public class PdfReader implements PdfViewerPreferences {
+public class PdfReader implements PdfViewerPreferences, Closeable {
 
   static final PdfName pageInhCandidates[] = { PdfName.MEDIABOX,
       PdfName.ROTATE, PdfName.RESOURCES, PdfName.CROPBOX };


### PR DESCRIPTION
Adds `Closeable` to main parser class, to ease use in Java 7 as:

```Java
try (PdfReader pdf = …) {
    pdf.use…
}
```

This is as simple as declaring it, because the existing `close()` already follows the correct semantics.

This could make sense also in other classes, but not all, e.g. `PdfStamper`'s close currently says:

> If closing a signed document with an external signature the closing must be done in the `PdfSignatureAppearance` instance.

and using `Closeable` it would be done automatically at the end of the `try`.