### PR TITLE
Make com.twelvemonkeys.imageio imageio-tiff an optional maven dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,13 +54,13 @@ Make sure that your contributions can be released with a dual LGPL and MPL licen
 ### Required Dependencies: ###
 
  - [Juniversalchardet](https://github.com/albfernandez/juniversalchardet)
- - [TwelveMonkeys imageio-tiff](https://github.com/haraldk/TwelveMonkeys/)
 
 ### Optional: ###
 
   - [BouncyCastle](https://www.bouncycastle.org/) 1.60
     - Provider
     - PKIX/CMS
+ - [TwelveMonkeys imageio-tiff](https://github.com/haraldk/TwelveMonkeys/) - optional if TIFF image support is needed.    
  - JUnit 4 - for unit testing
  - JFreeChart - for testing graphical examples
    - JFreeChart

--- a/openpdf/pom.xml
+++ b/openpdf/pom.xml
@@ -40,6 +40,7 @@
             <groupId>com.twelvemonkeys.imageio</groupId>
             <artifactId>imageio-tiff</artifactId>
             <version>${imageio-tiff.version}</version>
+            <optional>true</optional>
         </dependency>
 
         <!-- Test Dependencies -->


### PR DESCRIPTION
Make com.twelvemonkeys.imageio imageio-tiff an optional maven dependency.

https://github.com/LibrePDF/OpenPDF/issues/115

https://github.com/haraldk/TwelveMonkeys/