### PR TITLE
Restoring Bidi functionality without relying on BidiOrder class.

### DIFF
--- a/openpdf/src/main/java/com/lowagie/text/pdf/ArabicLigaturizer.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/ArabicLigaturizer.java
@@ -54,7 +54,6 @@ package com.lowagie.text.pdf;
  *
  * @author Paulo Soares (psoares@consiste.pt)
  */
-@Deprecated
 public class ArabicLigaturizer {
     
     static boolean isVowel(char s) {
@@ -555,20 +554,75 @@ public class ArabicLigaturizer {
                     }
                 }
                 break;
-                
+
                 case DIGITS_EN2AN_INIT_LR:
+                    shapeToArabicDigitsWithContext(text, 0, length, digitBase, false);
                     break;
-                    
+
                 case DIGITS_EN2AN_INIT_AL:
+                    shapeToArabicDigitsWithContext(text, 0, length, digitBase, true);
                     break;
-                    
+
                 default:
                     break;
             }
         }
     }
-    
-     private static final char ALEF = 0x0627;
+
+    /**
+     * Given an array of characters, process a section of it, and replace
+     * European numeral characters (0-9) with Arabic numeral characters
+     * (depending on the {@code digitBase}) if the characters are preceded by
+     * Arabic characters.
+     * 
+     * @param dest
+     *            The array of characters to be processed. Must not be
+     *            {@code null}, and must have a length greater than {@code 0}.
+     * @param start
+     *            The start index of the characters to be processed. The value
+     *            must be greater than, or equal to, {@code 0} and less than the
+     *            length of the array {@code dest}.
+     * @param length
+     *            The number of characters to process. {@code length} +
+     *            {@code start} must be less than, or equal to, the length of
+     *            the array {@code dest}.
+     * @param digitBase
+     *            The code of the character which represents the numeral 0 into
+     *            which the European numbers should be converted. For instance,
+     *            Arabic-Indic digits begin at {@code '\u0660'}, and Eastern
+     *            Arabic-Indic digits (Persian and Urdu) begin at
+     *            {@code '\u06f0'}.
+     * @param lastStrongWasAL
+     *            A boolean flag indicating whether or not the character
+     *            preceding the array of characters to be processed was an
+     *            Arabic character, or not.
+     */
+    static void shapeToArabicDigitsWithContext(char[] dest, int start, int length, char digitBase, boolean lastStrongWasAL) {
+        digitBase -= '0'; // move common adjustment out of loop
+
+        int limit = start + length;
+        for (int i = start; i < limit; ++i) {
+            char ch = dest[i];
+            switch (Character.getDirectionality(ch)) {
+                case Character.DIRECTIONALITY_LEFT_TO_RIGHT:
+                case Character.DIRECTIONALITY_RIGHT_TO_LEFT:
+                    lastStrongWasAL = false;
+                    break;
+                case Character.DIRECTIONALITY_RIGHT_TO_LEFT_ARABIC:
+                    lastStrongWasAL = true;
+                    break;
+                case Character.DIRECTIONALITY_EUROPEAN_NUMBER:
+                    if (lastStrongWasAL && ch <= '\u0039') {
+                        dest[i] = (char) (ch + digitBase);
+                    }
+                    break;
+                default:
+                    break;
+            }
+        }
+    }
+
+    private static final char ALEF = 0x0627;
     private static final char ALEFHAMZA = 0x0623;
     private static final char ALEFHAMZABELOW = 0x0625;
     private static final char ALEFMADDA = 0x0622;

--- a/openpdf/src/main/java/com/lowagie/text/pdf/BidiLine.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/BidiLine.java
@@ -48,6 +48,7 @@
 
 package com.lowagie.text.pdf;
 
+import java.text.Bidi;
 import java.util.ArrayList;
 
 import com.lowagie.text.Chunk;
@@ -178,6 +179,22 @@ public class BidiLine {
         totalTextLength = trimRight(0, totalTextLength - 1) + 1;
         if (totalTextLength == 0) {
         	return true;
+        }
+        
+        if (runDirection == PdfWriter.RUN_DIRECTION_LTR || runDirection == PdfWriter.RUN_DIRECTION_RTL) {
+            if (orderLevels.length < totalTextLength) {
+                orderLevels = new byte[pieceSize];
+                indexChars = new int[pieceSize];
+            }
+            ArabicLigaturizer.processNumbers(text, 0, totalTextLength, arabicOptions);
+            Bidi bidi = new Bidi(new String(text),
+                                 (byte) (runDirection == PdfWriter.RUN_DIRECTION_RTL ? Bidi.DIRECTION_RIGHT_TO_LEFT : Bidi.DIRECTION_LEFT_TO_RIGHT));
+            for (int k = 0; k < totalTextLength; ++k) {
+                orderLevels[k] = (byte) bidi.getLevelAt(k);
+                indexChars[k] = k;
+            }
+            doArabicShapping();
+            mirrorGlyphs();
         }
         
         totalTextLength = trimRightEx(0, totalTextLength - 1) + 1;

--- a/openpdf/src/main/java/com/lowagie/text/pdf/PdfWriter.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/PdfWriter.java
@@ -2744,16 +2744,13 @@ public class PdfWriter extends DocWriter implements
     /** Do not use bidirectional reordering. */
     public static final int RUN_DIRECTION_NO_BIDI = 1;
 
-    /* TODO: There are currently some issues with RUN_DIRECTION_LTR and RUN_DIRECTION_RTL which will be fixed in a future release. */
     /** Use bidirectional reordering with left-to-right
      * preferential run direction.
      */
-    @Deprecated
     public static final int RUN_DIRECTION_LTR = 2;
     /** Use bidirectional reordering with right-to-left
      * preferential run direction.
      */
-    @Deprecated
     public static final int RUN_DIRECTION_RTL = 3;
 
     protected int runDirection = RUN_DIRECTION_NO_BIDI;


### PR DESCRIPTION
`java.lang.Character` and `java.text.Bidi` provide the functionality which was previously dependent on BidiOrder.

This should address issue #122.