### PR TITLE
Fix an issue with null URLs in Image.getInstance calls

### DIFF
--- a/openpdf/src/main/java/com/lowagie/text/Image.java
+++ b/openpdf/src/main/java/com/lowagie/text/Image.java
@@ -79,7 +79,7 @@ import com.lowagie.text.pdf.codec.CCITTG4Encoder;
 /**
  * An <CODE>Image</CODE> is the representation of a graphic element (JPEG, PNG
  * or GIF) that has to be inserted into the document
- * 
+ *
  * @see Element
  * @see Rectangle
  */
@@ -162,7 +162,7 @@ public abstract class Image extends Rectangle {
 	 * @since	2.1.5
 	 */
 	public static final int ORIGINAL_JBIG2 = 9;
-	
+
     // member variables
 
 	/** The image type. */
@@ -176,7 +176,7 @@ public abstract class Image extends Rectangle {
 
 	/** The bits per component of the raw image. It also flags a CCITT image. */
 	protected int bpc = 1;
-	
+
 	/** The template to be treated as an image. */
 	protected PdfTemplate template[] = new PdfTemplate[1];
 
@@ -203,7 +203,7 @@ public abstract class Image extends Rectangle {
 
 	/** This is the original height of the image taking rotation into account. */
 	protected float scaledHeight;
-	
+
     /**
      * The compression level of the content streams.
      * @since	2.1.3
@@ -217,10 +217,10 @@ public abstract class Image extends Rectangle {
 
 
 	// image from file or URL
-	
+
 	/**
 	 * Constructs an <CODE>Image</CODE> -object, using an <VAR>url </VAR>.
-	 * 
+	 *
 	 * @param url
 	 *            the <CODE>URL</CODE> where the image can be found.
 	 */
@@ -233,7 +233,7 @@ public abstract class Image extends Rectangle {
 
 	/**
 	 * Gets an instance of an Image.
-	 * 
+	 *
 	 * @param url
 	 *            an URL
 	 * @return an Image
@@ -244,6 +244,7 @@ public abstract class Image extends Rectangle {
 	public static Image getInstance(URL url) throws BadElementException,
             IOException {
 		InputStream is = null;
+		Image img = null;
 		try {
 			is = url.openStream();
 			int c1 = is.read();
@@ -259,30 +260,38 @@ public abstract class Image extends Rectangle {
 
 			is = null;
 			if (c1 == 'G' && c2 == 'I' && c3 == 'F') {
-				return ImageLoader.getGifImage(url);
+				img = ImageLoader.getGifImage(url);
+				return img;
 			}
 			if (c1 == 0xFF && c2 == 0xD8) {
-				return ImageLoader.getJpegImage(url);
+				img = ImageLoader.getJpegImage(url);
+				return img;
 			}
 			if (c1 == 0x00 && c2 == 0x00 && c3 == 0x00 && c4 == 0x0c) {
-				return ImageLoader.getJpeg2000Image(url);
+				img = ImageLoader.getJpeg2000Image(url);
+				return img;
 			}
 			if (c1 == 0xff && c2 == 0x4f && c3 == 0xff && c4 == 0x51) {
-				return ImageLoader.getJpeg2000Image(url);
+				img = ImageLoader.getJpeg2000Image(url);
+				return img;
 			}
 			if (c1 == PNGID[0] && c2 == PNGID[1]
 					&& c3 == PNGID[2] && c4 == PNGID[3]) {
-				return ImageLoader.getPngImage(url);
+				img = ImageLoader.getPngImage(url);
+				return img;
 			}
 			if (c1 == 0xD7 && c2 == 0xCD) {
-				return new ImgWMF(url);
+				img = new ImgWMF(url);
+				return img;
 			}
 			if (c1 == 'B' && c2 == 'M') {
-				return  ImageLoader.getBmpImage(url);
+				img = ImageLoader.getBmpImage(url);
+				return img;
 			}
 			if ((c1 == 'M' && c2 == 'M' && c3 == 0 && c4 == 42)
 					|| (c1 == 'I' && c2 == 'I' && c3 == 42 && c4 == 0)) {
-				return  ImageLoader.getTiffImage(url);
+				img = ImageLoader.getTiffImage(url);
+				return img;
 			}
 			if ( c1 == 0x97 && c2 == 'J' && c3 == 'B' && c4 == '2' &&
 					c5 == '\r' && c6 == '\n' && c7 == 0x1a && c8 == '\n' ) {
@@ -295,12 +304,16 @@ public abstract class Image extends Rectangle {
 			if (is != null) {
 				is.close();
 			}
+			if (img != null) {
+				// Make sure the URL is always set
+				img.setUrl(url);
+			}
 		}
 	}
 
 	/**
 	 * Gets an instance of an Image.
-	 * 
+	 *
 	 * @param filename
 	 *            a filename
 	 * @return an object of type <CODE>Gif</CODE>,<CODE>Jpeg</CODE> or
@@ -313,10 +326,10 @@ public abstract class Image extends Rectangle {
 			throws BadElementException, IOException {
 		return getInstance(Utilities.toURL(filename));
 	}
-    
+
 	/**
 	 * gets an instance of an Image
-	 * 
+	 *
 	 * @param imgb
 	 *            raw image date
 	 * @return an Image object
@@ -383,7 +396,7 @@ public abstract class Image extends Rectangle {
 
 	/**
 	 * Gets an instance of an Image in raw mode.
-	 * 
+	 *
 	 * @param width
 	 *            the width of the image in pixels
 	 * @param height
@@ -415,11 +428,11 @@ public abstract class Image extends Rectangle {
 		Image img = new ImgJBIG2(width, height, data, globals);
 		return img;
 	}
-	
+
 	/**
 	 * Creates an Image with CCITT G3 or G4 compression. It assumes that the
 	 * data bytes are already compressed.
-	 * 
+	 *
 	 * @param width
 	 *            the exact width of the image
 	 * @param height
@@ -450,7 +463,7 @@ public abstract class Image extends Rectangle {
 	/**
 	 * Creates an Image with CCITT G3 or G4 compression. It assumes that the
 	 * data bytes are already compressed.
-	 * 
+	 *
 	 * @param width
 	 *            the exact width of the image
 	 * @param height
@@ -487,7 +500,7 @@ public abstract class Image extends Rectangle {
 
 	/**
 	 * Gets an instance of an Image in raw mode.
-	 * 
+	 *
 	 * @param width
 	 *            the width of the image in pixels
 	 * @param height
@@ -521,10 +534,10 @@ public abstract class Image extends Rectangle {
 	}
 
 	// images from a PdfTemplate
-	
+
 	/**
 	 * gets an instance of an Image
-	 * 
+	 *
 	 * @param template
 	 *            a PdfTemplate that has to be wrapped in an Image object
 	 * @return an Image object
@@ -534,12 +547,12 @@ public abstract class Image extends Rectangle {
 			throws BadElementException {
 		return new ImgTemplate(template);
 	}
-    
+
     // images from a java.awt.Image
-    
+
 	/**
 	 * Gets an instance of an Image from a java.awt.Image.
-	 * 
+	 *
 	 * @param image
 	 *            the <CODE>java.awt.Image</CODE> to convert
 	 * @param color
@@ -555,14 +568,14 @@ public abstract class Image extends Rectangle {
 	 */
 	public static Image getInstance(java.awt.Image image, java.awt.Color color,
 			boolean forceBW) throws BadElementException, IOException {
-		
+
 		if(image instanceof BufferedImage){
 			BufferedImage bi = (BufferedImage) image;
 			if(bi.getType()==BufferedImage.TYPE_BYTE_BINARY) {
 				forceBW=true;
 			}
 		}
-		
+
 		java.awt.image.PixelGrabber pg = new java.awt.image.PixelGrabber(image,
 				0, 0, -1, -1, true);
 		try {
@@ -710,7 +723,7 @@ public abstract class Image extends Rectangle {
 
 	/**
 	 * Gets an instance of an Image from a java.awt.Image.
-	 * 
+	 *
 	 * @param image
 	 *            the <CODE>java.awt.Image</CODE> to convert
 	 * @param color
@@ -726,11 +739,11 @@ public abstract class Image extends Rectangle {
 			throws BadElementException, IOException {
 		return Image.getInstance(image, color, false);
 	}
-	
+
 	/**
 	 * Gets an instance of a Image from a java.awt.Image.
 	 * The image is added as a JPEG with a user defined quality.
-	 * 
+	 *
 	 * @param writer
 	 *            the <CODE>PdfWriter</CODE> object to which the image will be added
 	 * @param awtImage
@@ -745,7 +758,7 @@ public abstract class Image extends Rectangle {
 	public static Image getInstance(PdfWriter writer, java.awt.Image awtImage, float quality) throws BadElementException, IOException {
 		return getInstance(new PdfContentByte(writer), awtImage, quality);
 	}
-	
+
     /**
      * Gets an instance of a Image from a java.awt.Image.
      * The image is added as a JPEG with a user defined quality.
@@ -782,14 +795,14 @@ public abstract class Image extends Rectangle {
     }
 
     // image from indirect reference
-    
+
     /**
      * Holds value of property directReference.
      * An image is embedded into a PDF as an Image XObject.
      * This object is referenced by a PdfIndirectReference object.
      */
     private PdfIndirectReference directReference;
-    
+
     /**
      * Getter for property directReference.
      * @return Value of property directReference.
@@ -797,7 +810,7 @@ public abstract class Image extends Rectangle {
     public PdfIndirectReference getDirectReference() {
         return this.directReference;
     }
-    
+
     /**
      * Setter for property directReference.
      * @param directReference New value of property directReference.
@@ -805,13 +818,13 @@ public abstract class Image extends Rectangle {
     public void setDirectReference(PdfIndirectReference directReference) {
         this.directReference = directReference;
     }
-    
+
     /**
      * Reuses an existing image.
      * @param ref the reference to the image dictionary
      * @throws BadElementException on error
      * @return the image
-     */    
+     */
     public static Image getInstance(PRIndirectReference ref) throws BadElementException {
         PdfDictionary dic = (PdfDictionary)PdfReader.getPdfObjectRelease(ref);
         int width = ((PdfNumber)PdfReader.getPdfObjectRelease(dic.get(PdfName.WIDTH))).intValue();
@@ -836,10 +849,10 @@ public abstract class Image extends Rectangle {
     }
 
     // copy constructor
-    
+
 	/**
 	 * Constructs an <CODE>Image</CODE> -object, using an <VAR>url </VAR>.
-	 * 
+	 *
 	 * @param image
 	 *            another Image object.
 	 */
@@ -861,7 +874,7 @@ public abstract class Image extends Rectangle {
 		this.mySerialId = image.mySerialId;
 
         this.directReference = image.directReference;
-        
+
 		this.rotationRadians = image.rotationRadians;
         this.initialRotation = image.initialRotation;
         this.indentationLeft = image.indentationLeft;
@@ -879,7 +892,7 @@ public abstract class Image extends Rectangle {
 		this.dpiX = image.dpiX;
 		this.dpiY = image.dpiY;
 		this.XYRatio = image.XYRatio;
-		
+
 		this.colorspace = image.colorspace;
 		this.invert = image.invert;
 		this.profile = image.profile;
@@ -892,7 +905,7 @@ public abstract class Image extends Rectangle {
 
 	/**
 	 * gets an instance of an Image
-	 * 
+	 *
 	 * @param image
 	 *            an Image object
 	 * @return a new Image object
@@ -911,10 +924,10 @@ public abstract class Image extends Rectangle {
 	}
 
 	// implementation of the Element interface
-	
+
 	/**
 	 * Returns the type.
-	 * 
+	 *
 	 * @return a type
 	 */
 
@@ -935,7 +948,7 @@ public abstract class Image extends Rectangle {
 	/**
 	 * Returns <CODE>true</CODE> if the image is a <CODE>Jpeg</CODE>
 	 * -object.
-	 * 
+	 *
 	 * @return a <CODE>boolean</CODE>
 	 */
 
@@ -946,7 +959,7 @@ public abstract class Image extends Rectangle {
 	/**
 	 * Returns <CODE>true</CODE> if the image is a <CODE>ImgRaw</CODE>
 	 * -object.
-	 * 
+	 *
 	 * @return a <CODE>boolean</CODE>
 	 */
 
@@ -957,20 +970,20 @@ public abstract class Image extends Rectangle {
 	/**
 	 * Returns <CODE>true</CODE> if the image is an <CODE>ImgTemplate</CODE>
 	 * -object.
-	 * 
+	 *
 	 * @return a <CODE>boolean</CODE>
 	 */
 
 	public boolean isImgTemplate() {
 		return type == IMGTEMPLATE;
 	}
-	
+
 	// getters and setters
 
 	/**
 	 * Gets the <CODE>String</CODE> -representation of the reference to the
 	 * image.
-	 * 
+	 *
 	 * @return a <CODE>String</CODE>
 	 */
 
@@ -980,7 +993,7 @@ public abstract class Image extends Rectangle {
 
 	/**
 	 * Sets the url of the image
-	 * 
+	 *
 	 * @param url
 	 *            the url of the image
 	 */
@@ -993,7 +1006,7 @@ public abstract class Image extends Rectangle {
 	 * <P>
 	 * Remark: this only makes sense for Images of the type <CODE>RawImage
 	 * </CODE>.
-	 * 
+	 *
 	 * @return the raw data
 	 */
 	public byte[] getRawData() {
@@ -1005,7 +1018,7 @@ public abstract class Image extends Rectangle {
 	 * <P>
 	 * Remark: this only makes sense for Images of the type <CODE>RawImage
 	 * </CODE>.
-	 * 
+	 *
 	 * @return a bpc value
 	 */
 	public int getBpc() {
@@ -1017,7 +1030,7 @@ public abstract class Image extends Rectangle {
 	 * <P>
 	 * Remark: this only makes sense for Images of the type <CODE>ImgTemplate
 	 * </CODE>.
-	 * 
+	 *
 	 * @return the template
 	 */
 	public PdfTemplate getTemplateData() {
@@ -1026,7 +1039,7 @@ public abstract class Image extends Rectangle {
 
 	/**
 	 * Sets data from a PdfTemplate
-	 * 
+	 *
 	 * @param template
 	 *            the template with the content
 	 */
@@ -1036,7 +1049,7 @@ public abstract class Image extends Rectangle {
 
 	/**
 	 * Gets the alignment for the image.
-	 * 
+	 *
 	 * @return a value
 	 */
 	public int getAlignment() {
@@ -1045,7 +1058,7 @@ public abstract class Image extends Rectangle {
 
 	/**
 	 * Sets the alignment for the image.
-	 * 
+	 *
 	 * @param alignment
 	 *            the alignment
 	 */
@@ -1056,7 +1069,7 @@ public abstract class Image extends Rectangle {
 
 	/**
 	 * Gets the alternative text for the image.
-	 * 
+	 *
 	 * @return a <CODE>String</CODE>
 	 */
 
@@ -1066,7 +1079,7 @@ public abstract class Image extends Rectangle {
 
 	/**
 	 * Sets the alternative information for the image.
-	 * 
+	 *
 	 * @param alt
 	 *            the alternative information
 	 */
@@ -1077,7 +1090,7 @@ public abstract class Image extends Rectangle {
 
 	/**
 	 * Sets the absolute position of the <CODE>Image</CODE>.
-	 * 
+	 *
 	 * @param absoluteX
 	 * @param absoluteY
 	 */
@@ -1090,7 +1103,7 @@ public abstract class Image extends Rectangle {
 	/**
 	 * Checks if the <CODE>Images</CODE> has to be added at an absolute X
 	 * position.
-	 * 
+	 *
 	 * @return a boolean
 	 */
 	public boolean hasAbsoluteX() {
@@ -1099,7 +1112,7 @@ public abstract class Image extends Rectangle {
 
 	/**
 	 * Returns the absolute X position.
-	 * 
+	 *
 	 * @return a position
 	 */
 	public float getAbsoluteX() {
@@ -1109,7 +1122,7 @@ public abstract class Image extends Rectangle {
 	/**
 	 * Checks if the <CODE>Images</CODE> has to be added at an absolute
 	 * position.
-	 * 
+	 *
 	 * @return a boolean
 	 */
 	public boolean hasAbsoluteY() {
@@ -1118,7 +1131,7 @@ public abstract class Image extends Rectangle {
 
 	/**
 	 * Returns the absolute Y position.
-	 * 
+	 *
 	 * @return a position
 	 */
 	public float getAbsoluteY() {
@@ -1129,7 +1142,7 @@ public abstract class Image extends Rectangle {
 
 	/**
 	 * Gets the scaled width of the image.
-	 * 
+	 *
 	 * @return a value
 	 */
 	public float getScaledWidth() {
@@ -1138,7 +1151,7 @@ public abstract class Image extends Rectangle {
 
 	/**
 	 * Gets the scaled height of the image.
-	 * 
+	 *
 	 * @return a value
 	 */
 	public float getScaledHeight() {
@@ -1147,7 +1160,7 @@ public abstract class Image extends Rectangle {
 
 	/**
 	 * Gets the plain width of the image.
-	 * 
+	 *
 	 * @return a value
 	 */
 	public float getPlainWidth() {
@@ -1156,16 +1169,16 @@ public abstract class Image extends Rectangle {
 
 	/**
 	 * Gets the plain height of the image.
-	 * 
+	 *
 	 * @return a value
 	 */
 	public float getPlainHeight() {
 		return plainHeight;
 	}
-	
+
 	/**
 	 * Scale the image to an absolute width and an absolute height.
-	 * 
+	 *
 	 * @param newWidth
 	 *            the new width
 	 * @param newHeight
@@ -1182,7 +1195,7 @@ public abstract class Image extends Rectangle {
 
 	/**
 	 * Scale the image to an absolute width.
-	 * 
+	 *
 	 * @param newWidth
 	 *            the new width
 	 */
@@ -1196,7 +1209,7 @@ public abstract class Image extends Rectangle {
 
 	/**
 	 * Scale the image to an absolute height.
-	 * 
+	 *
 	 * @param newHeight
 	 *            the new height
 	 */
@@ -1210,7 +1223,7 @@ public abstract class Image extends Rectangle {
 
 	/**
 	 * Scale the image to a certain percentage.
-	 * 
+	 *
 	 * @param percent
 	 *            the scaling percentage
 	 */
@@ -1220,7 +1233,7 @@ public abstract class Image extends Rectangle {
 
 	/**
 	 * Scale the width and height of an image to a certain percentage.
-	 * 
+	 *
 	 * @param percentX
 	 *            the scaling percentage of the width
 	 * @param percentY
@@ -1237,7 +1250,7 @@ public abstract class Image extends Rectangle {
 
 	/**
 	 * Scales the image so that it fits a certain width and height.
-	 * 
+	 *
 	 * @param fitWidth
 	 *            the width to fit
 	 * @param fitHeight
@@ -1253,7 +1266,7 @@ public abstract class Image extends Rectangle {
 
 	/**
 	 * Returns the transformation matrix of the image.
-	 * 
+	 *
 	 * @return an array [AX, AY, BX, BY, CX, CY, DX, DY]
 	 */
 	public float[] matrix() {
@@ -1292,7 +1305,7 @@ public abstract class Image extends Rectangle {
 
 	/** a static that is used for attributing a unique id to each image. */
 	static long serialId = 0;
-	
+
 	/** Creates a new serial id. */
 	static protected synchronized Long getSerialId() {
 		++serialId;
@@ -1301,7 +1314,7 @@ public abstract class Image extends Rectangle {
 
 	/**
 	 * Returns a serial id for the Image (reuse the same image more than once)
-	 * 
+	 *
 	 * @return a serialId
 	 */
 	public Long getMySerialId() {
@@ -1312,7 +1325,7 @@ public abstract class Image extends Rectangle {
 
 	/** This is the rotation of the image in radians. */
 	protected float rotationRadians;
-    
+
     /** Holds value of property initialRotation. */
     private float initialRotation;
 
@@ -1328,10 +1341,10 @@ public abstract class Image extends Rectangle {
 		}
         return rot;
     }
-    
+
 	/**
 	 * Sets the rotation of the image in radians.
-	 * 
+	 *
 	 * @param r
 	 *            rotation in radians
 	 */
@@ -1348,7 +1361,7 @@ public abstract class Image extends Rectangle {
 
 	/**
 	 * Sets the rotation of the image in degrees.
-	 * 
+	 *
 	 * @param deg
 	 *            rotation in degrees
 	 */
@@ -1356,7 +1369,7 @@ public abstract class Image extends Rectangle {
 		double d = Math.PI;
 		setRotation(deg / 180 * (float) d);
 	}
-    
+
     /**
      * Getter for property initialRotation.
      * @return Value of property initialRotation.
@@ -1364,7 +1377,7 @@ public abstract class Image extends Rectangle {
     public float getInitialRotation() {
         return this.initialRotation;
     }
-    
+
     /**
      * Some image formats, like TIFF may present the images rotated that have
      * to be compensated.
@@ -1375,7 +1388,7 @@ public abstract class Image extends Rectangle {
         this.initialRotation = initialRotation;
         setRotation(old_rot);
     }
-    
+
     // indentations
 
 	/** the indentation to the left. */
@@ -1392,7 +1405,7 @@ public abstract class Image extends Rectangle {
 
 	/**
 	 * Gets the left indentation.
-	 * 
+	 *
 	 * @return the left indentation
 	 */
 	public float getIndentationLeft() {
@@ -1401,7 +1414,7 @@ public abstract class Image extends Rectangle {
 
 	/**
 	 * Sets the left indentation.
-	 * 
+	 *
 	 * @param f
 	 */
 	public void setIndentationLeft(float f) {
@@ -1410,7 +1423,7 @@ public abstract class Image extends Rectangle {
 
 	/**
 	 * Gets the right indentation.
-	 * 
+	 *
 	 * @return the right indentation
 	 */
 	public float getIndentationRight() {
@@ -1419,7 +1432,7 @@ public abstract class Image extends Rectangle {
 
 	/**
 	 * Sets the right indentation.
-	 * 
+	 *
 	 * @param f
 	 */
 	public void setIndentationRight(float f) {
@@ -1428,7 +1441,7 @@ public abstract class Image extends Rectangle {
 
 	/**
 	 * Gets the spacing before this image.
-	 * 
+	 *
 	 * @return the spacing
 	 */
 	public float getSpacingBefore() {
@@ -1437,7 +1450,7 @@ public abstract class Image extends Rectangle {
 
 	/**
 	 * Sets the spacing before this image.
-	 * 
+	 *
 	 * @param spacing
 	 *            the new spacing
 	 */
@@ -1448,7 +1461,7 @@ public abstract class Image extends Rectangle {
 
 	/**
 	 * Gets the spacing before this image.
-	 * 
+	 *
 	 * @return the spacing
 	 */
 	public float getSpacingAfter() {
@@ -1457,7 +1470,7 @@ public abstract class Image extends Rectangle {
 
 	/**
 	 * Sets the spacing after this image.
-	 * 
+	 *
 	 * @param spacing
 	 *            the new spacing
 	 */
@@ -1472,10 +1485,10 @@ public abstract class Image extends Rectangle {
 	 * Holds value of property widthPercentage.
 	 */
 	private float widthPercentage = 100;
-	
+
 	/**
 	 * Getter for property widthPercentage.
-	 * 
+	 *
 	 * @return Value of property widthPercentage.
 	 */
 	public float getWidthPercentage() {
@@ -1484,7 +1497,7 @@ public abstract class Image extends Rectangle {
 
 	/**
 	 * Setter for property widthPercentage.
-	 * 
+	 *
 	 * @param widthPercentage
 	 *            New value of property widthPercentage.
 	 */
@@ -1496,10 +1509,10 @@ public abstract class Image extends Rectangle {
 
 	/** if the annotation is not null the image will be clickable. */
 	protected Annotation annotation = null;
-	
+
 	/**
 	 * Sets the annotation of this Image.
-	 * 
+	 *
 	 * @param annotation
 	 *            the annotation
 	 */
@@ -1509,7 +1522,7 @@ public abstract class Image extends Rectangle {
 
 	/**
 	 * Gets the annotation.
-	 * 
+	 *
 	 * @return the annotation that is linked to this image
 	 */
 	public Annotation getAnnotation() {
@@ -1520,10 +1533,10 @@ public abstract class Image extends Rectangle {
 
     /** Optional Content layer to which we want this Image to belong. */
 	protected PdfOCG layer;
-	
+
 	/**
 	 * Gets the layer this image belongs to.
-	 * 
+	 *
 	 * @return the layer this image belongs to or <code>null</code> for no
 	 *         layer defined
 	 */
@@ -1533,7 +1546,7 @@ public abstract class Image extends Rectangle {
 
 	/**
 	 * Sets the layer this image belongs to.
-	 * 
+	 *
 	 * @param layer
 	 *            the layer this image belongs to
 	 */
@@ -1548,7 +1561,7 @@ public abstract class Image extends Rectangle {
 
 	/**
 	 * Getter for property interpolation.
-	 * 
+	 *
 	 * @return Value of property interpolation.
 	 */
 	public boolean isInterpolation() {
@@ -1558,14 +1571,14 @@ public abstract class Image extends Rectangle {
 	/**
 	 * Sets the image interpolation. Image interpolation attempts to produce a
 	 * smooth transition between adjacent sample values.
-	 * 
+	 *
 	 * @param interpolation
 	 *            New value of property interpolation.
 	 */
 	public void setInterpolation(boolean interpolation) {
 		this.interpolation = interpolation;
 	}
-	
+
 	// original type and data
 
 	/** Holds value of property originalType. */
@@ -1573,12 +1586,12 @@ public abstract class Image extends Rectangle {
 
 	/** Holds value of property originalData. */
 	protected byte[] originalData;
-	
+
 	/**
 	 * Getter for property originalType.
-	 * 
+	 *
 	 * @return Value of property originalType.
-	 *  
+	 *
 	 */
 	public int getOriginalType() {
 		return this.originalType;
@@ -1586,10 +1599,10 @@ public abstract class Image extends Rectangle {
 
 	/**
 	 * Setter for property originalType.
-	 * 
+	 *
 	 * @param originalType
 	 *            New value of property originalType.
-	 *  
+	 *
 	 */
 	public void setOriginalType(int originalType) {
 		this.originalType = originalType;
@@ -1597,9 +1610,9 @@ public abstract class Image extends Rectangle {
 
 	/**
 	 * Getter for property originalData.
-	 * 
+	 *
 	 * @return Value of property originalData.
-	 *  
+	 *
 	 */
 	public byte[] getOriginalData() {
 		return this.originalData;
@@ -1607,25 +1620,25 @@ public abstract class Image extends Rectangle {
 
 	/**
 	 * Setter for property originalData.
-	 * 
+	 *
 	 * @param originalData
 	 *            New value of property originalData.
-	 *  
+	 *
 	 */
 	public void setOriginalData(byte[] originalData) {
 		this.originalData = originalData;
 	}
 
 	// the following values are only set for specific types of images.
-	
+
 	/** Holds value of property deflated. */
 	protected boolean deflated = false;
 
 	/**
 	 * Getter for property deflated.
-	 * 
+	 *
 	 * @return Value of property deflated.
-	 *  
+	 *
 	 */
 	public boolean isDeflated() {
 		return this.deflated;
@@ -1633,16 +1646,16 @@ public abstract class Image extends Rectangle {
 
 	/**
 	 * Setter for property deflated.
-	 * 
+	 *
 	 * @param deflated
 	 *            New value of property deflated.
 	 */
 	public void setDeflated(boolean deflated) {
 		this.deflated = deflated;
 	}
-	
+
 	// DPI info
-	
+
 	/** Holds value of property dpiX. */
 	protected int dpiX = 0;
 
@@ -1651,7 +1664,7 @@ public abstract class Image extends Rectangle {
 
 	/**
 	 * Gets the dots-per-inch in the X direction. Returns 0 if not available.
-	 * 
+	 *
 	 * @return the dots-per-inch in the X direction
 	 */
 	public int getDpiX() {
@@ -1660,7 +1673,7 @@ public abstract class Image extends Rectangle {
 
 	/**
 	 * Gets the dots-per-inch in the Y direction. Returns 0 if not available.
-	 * 
+	 *
 	 * @return the dots-per-inch in the Y direction
 	 */
 	public int getDpiY() {
@@ -1669,7 +1682,7 @@ public abstract class Image extends Rectangle {
 
 	/**
 	 * Sets the dots per inch value
-	 * 
+	 *
 	 * @param dpiX
 	 *            dpi for x coordinates
 	 * @param dpiY
@@ -1679,15 +1692,15 @@ public abstract class Image extends Rectangle {
 		this.dpiX = dpiX;
 		this.dpiY = dpiY;
 	}
-	
+
 	// XY Ratio
-	
+
 	/** Holds value of property XYRatio. */
 	private float XYRatio = 0;
 
 	/**
 	 * Gets the X/Y pixel dimensionless aspect ratio.
-	 * 
+	 *
 	 * @return the X/Y pixel dimensionless aspect ratio
 	 */
 	public float getXYRatio() {
@@ -1696,14 +1709,14 @@ public abstract class Image extends Rectangle {
 
 	/**
 	 * Sets the X/Y pixel dimensionless aspect ratio.
-	 * 
+	 *
 	 * @param XYRatio
 	 *            the X/Y pixel dimensionless aspect ratio
 	 */
 	public void setXYRatio(float XYRatio) {
 		this.XYRatio = XYRatio;
 	}
-	
+
 	// color, colorspaces and transparency
 
 	/** this is the colorspace of a jpeg-image. */
@@ -1713,19 +1726,19 @@ public abstract class Image extends Rectangle {
 	 * Gets the colorspace for the image.
 	 * <P>
 	 * Remark: this only makes sense for Images of the type <CODE>Jpeg</CODE>.
-	 * 
+	 *
 	 * @return a colorspace value
 	 */
 	public int getColorspace() {
 		return colorspace;
 	}
-    
+
 	/** Image color inversion */
 	protected boolean invert = false;
 
 	/**
 	 * Getter for the inverted value
-	 * 
+	 *
 	 * @return true if the image is inverted
 	 */
 	public boolean isInverted() {
@@ -1734,7 +1747,7 @@ public abstract class Image extends Rectangle {
 
 	/**
 	 * Sets inverted true or false
-	 * 
+	 *
 	 * @param invert
 	 *            true or false
 	 */
@@ -1747,7 +1760,7 @@ public abstract class Image extends Rectangle {
 
 	/**
 	 * Tags this image with an ICC profile.
-	 * 
+	 *
 	 * @param profile
 	 *            the profile
 	 */
@@ -1757,7 +1770,7 @@ public abstract class Image extends Rectangle {
 
 	/**
 	 * Checks is the image has an ICC profile.
-	 * 
+	 *
 	 * @return the ICC profile or <CODE>null</CODE>
 	 */
 	public boolean hasICCProfile() {
@@ -1766,7 +1779,7 @@ public abstract class Image extends Rectangle {
 
 	/**
 	 * Gets the images ICC profile.
-	 * 
+	 *
 	 * @return the ICC profile
 	 */
 	public ICC_Profile getICCProfile() {
@@ -1775,10 +1788,10 @@ public abstract class Image extends Rectangle {
 
 	/** a dictionary with additional information */
 	private PdfDictionary additional = null;
-	
+
 	/**
 	 * Getter for the dictionary with additional information.
-	 * 
+	 *
 	 * @return a PdfDictionary with additional information.
 	 */
 	public PdfDictionary getAdditional() {
@@ -1787,7 +1800,7 @@ public abstract class Image extends Rectangle {
 
 	/**
 	 * Sets the /Colorspace key.
-	 * 
+	 *
 	 * @param additional
 	 *            a PdfDictionary with additional information.
 	 */
@@ -1797,7 +1810,7 @@ public abstract class Image extends Rectangle {
 
     /**
      * Replaces CalRGB and CalGray colorspaces with DeviceRGB and DeviceGray.
-     */    
+     */
     public void simplifyColorspace() {
         if (additional == null)
             return;
@@ -1822,7 +1835,7 @@ public abstract class Image extends Rectangle {
         }
         additional.put(PdfName.COLORSPACE, newValue);
     }
-	
+
 	/**
 	 * Gets a PDF Name from an array or returns the object that was passed.
 	 */
@@ -1840,7 +1853,7 @@ public abstract class Image extends Rectangle {
 
 	/** Is this image a mask? */
 	protected boolean mask = false;
-	
+
 	/** The image that serves as a mask for this image. */
 	protected Image imageMask;
 
@@ -1849,7 +1862,7 @@ public abstract class Image extends Rectangle {
 
 	/**
 	 * Returns <CODE>true</CODE> if this <CODE>Image</CODE> is a mask.
-	 * 
+	 *
 	 * @return <CODE>true</CODE> if this <CODE>Image</CODE> is a mask
 	 */
 	public boolean isMask() {
@@ -1858,7 +1871,7 @@ public abstract class Image extends Rectangle {
 
 	/**
 	 * Make this <CODE>Image</CODE> a mask.
-	 * 
+	 *
 	 * @throws DocumentException
 	 *             if this <CODE>Image</CODE> can not be a mask
 	 */
@@ -1871,7 +1884,7 @@ public abstract class Image extends Rectangle {
 	/**
 	 * Returns <CODE>true</CODE> if this <CODE>Image</CODE> has the
 	 * requisites to be a mask.
-	 * 
+	 *
 	 * @return <CODE>true</CODE> if this <CODE>Image</CODE> can be a mask
 	 */
 	public boolean isMaskCandidate() {
@@ -1884,7 +1897,7 @@ public abstract class Image extends Rectangle {
 
 	/**
 	 * Gets the explicit masking.
-	 * 
+	 *
 	 * @return the explicit masking
 	 */
 	public Image getImageMask() {
@@ -1893,7 +1906,7 @@ public abstract class Image extends Rectangle {
 
 	/**
 	 * Sets the explicit masking.
-	 * 
+	 *
 	 * @param mask
 	 *            the mask to be applied
 	 * @throws DocumentException
@@ -1910,9 +1923,9 @@ public abstract class Image extends Rectangle {
 
 	/**
 	 * Getter for property smask.
-	 * 
+	 *
 	 * @return Value of property smask.
-	 *  
+	 *
 	 */
 	public boolean isSmask() {
 		return this.smask;
@@ -1920,7 +1933,7 @@ public abstract class Image extends Rectangle {
 
 	/**
 	 * Setter for property smask.
-	 * 
+	 *
 	 * @param smask
 	 *            New value of property smask.
 	 */
@@ -1933,7 +1946,7 @@ public abstract class Image extends Rectangle {
 
 	/**
 	 * Returns the transparency.
-	 * 
+	 *
 	 * @return the transparency values
 	 */
 
@@ -1943,7 +1956,7 @@ public abstract class Image extends Rectangle {
 
 	/**
 	 * Sets the transparency values
-	 * 
+	 *
 	 * @param transparency
 	 *            the transparency values
 	 */

--- a/openpdf/src/test/java/com/lowagie/text/ImageTest.java
+++ b/openpdf/src/test/java/com/lowagie/text/ImageTest.java
@@ -1,0 +1,20 @@
+package com.lowagie.text;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import org.junit.jupiter.api.Test;
+
+class ImageTest {
+
+  @Test
+  void shouldReturnImageWithUrlForUrl() throws Exception {
+    final Image image = Image.getInstance(ClassLoader.getSystemResource("H.gif"));
+    assertNotNull(image.getUrl());
+  }
+
+  @Test
+  void shouldReturnImageWithUrlForPath() throws Exception {
+    final Image image = Image.getInstance(ClassLoader.getSystemResource("H.gif").getPath());
+    assertNotNull(image.getUrl());
+  }
+}


### PR DESCRIPTION
fixes issue 133

The PngImage (and similar) used to handle setting the
url of the image in the getInstance call. However, since
moving to the generic ImageLoader, this data has been
missing. This change applies the URL when called with
a URL or String path.