### PR TITLE
fixed problems to launch jUnit5 tests

### DIFF
--- a/openpdf/pom.xml
+++ b/openpdf/pom.xml
@@ -52,6 +52,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.junit.platform</groupId>
+            <artifactId>junit-platform-launcher</artifactId>
+            <version>1.4.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
             <version>${mockito.version}</version>


### PR DESCRIPTION
Without this additional dependency I've run into "No tests found using JUnit 5" caused by NoClassDefFoundError when using Run->As JUnit Test in Eclipse. After adding the dependency testing works as expected.