### PR TITLE
Make Document and PdfWriter compatible with try-with-resources

### DIFF
--- a/openpdf/src/main/java/com/lowagie/text/Document.java
+++ b/openpdf/src/main/java/com/lowagie/text/Document.java
@@ -99,7 +99,7 @@ import java.util.List;
  * </BLOCKQUOTE>
  */
 
-public class Document implements DocListener {
+public class Document implements AutoCloseable, DocListener {
     
     // membervariables
     /**
@@ -442,6 +442,7 @@ public class Document implements DocListener {
      * Once all the content has been written in the body, you have to close the
      * body. After that nothing can be written to the body anymore.
      */
+    @Override
     public void close() {
         if (!close) {
             open = false;

--- a/openpdf/src/main/java/com/lowagie/text/pdf/PdfReader.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/PdfReader.java
@@ -3123,6 +3123,7 @@ public class PdfReader implements PdfViewerPreferences, Closeable {
   /**
    * Closes the reader
    */
+  @Override
   public void close() {
     if (!partial)
       return;

--- a/openpdf/src/main/java/com/lowagie/text/pdf/PdfWriter.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/PdfWriter.java
@@ -63,6 +63,7 @@ import com.lowagie.text.xml.xmp.XmpWriter;
 import java.awt.*;
 import java.awt.color.ICC_Profile;
 import java.io.ByteArrayOutputStream;
+import java.io.Closeable;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.security.cert.Certificate;
@@ -78,6 +79,7 @@ import java.util.List;
  */
 
 public class PdfWriter extends DocWriter implements
+    Closeable,
     PdfViewerPreferences,
     PdfEncryptionSettings,
     PdfVersion,
@@ -1146,6 +1148,7 @@ public class PdfWriter extends DocWriter implements
      * to the outputstream embedded in a Trailer.
      * @see com.lowagie.text.DocWriter#close()
      */
+    @Override
     public void close() {
         if (open) {
             if ((currentPageNumber - 1) != pageReferences.size())


### PR DESCRIPTION
Hello! :wave: 

This change makes Document and PdfWriter implement AutoCloseable interface either directly or indirectly. PdfWriter was made implement Closeable as Closeable is an I/O interface and PdfWriter already deals with I/O. This is similar to what PdfReader already does.

Document on the other hand doesn't do I/O so it was made to implement AutoCloseable interface.

Additionally all `close` methods have been marked with `@Override` annotation.