### PR TITLE
Migrating raw types to generics, fixed couple of deprecated calls

### DIFF
--- a/openpdf/src/main/java/com/lowagie/text/Annotation.java
+++ b/openpdf/src/main/java/com/lowagie/text/Annotation.java
@@ -52,6 +52,7 @@ package com.lowagie.text;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.Map;
 
 /**
  * An <CODE>Annotation</CODE> is a little note that can be added to a page on
@@ -141,7 +142,7 @@ public class Annotation implements Element {
     protected int annotationtype;
 
     /** This is the title of the <CODE>Annotation</CODE>. */
-    protected HashMap annotationAttributes = new HashMap();
+    protected Map<String, Object> annotationAttributes = new HashMap<>();
 
     /** This is the lower left x-value */
     protected float llx = Float.NaN;
@@ -578,7 +579,7 @@ public class Annotation implements Element {
      * 
      * @return a reference
      */
-    public HashMap attributes() {
+    public Map<String, Object> attributes() {
         return annotationAttributes;
     }
     

--- a/openpdf/src/main/java/com/lowagie/text/Chunk.java
+++ b/openpdf/src/main/java/com/lowagie/text/Chunk.java
@@ -53,6 +53,8 @@ import java.awt.Color;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.Map;
+
 import com.lowagie.text.error_messages.MessageLocalization;
 
 import com.lowagie.text.pdf.HyphenationEvent;
@@ -108,7 +110,7 @@ public class Chunk implements Element {
     protected Font font = null;
 
     /** Contains some of the attributes for this Chunk. */
-    protected HashMap attributes = null;
+    protected Map<String, Object> attributes = null;
 
     // constructors
 
@@ -132,7 +134,7 @@ public class Chunk implements Element {
             font = new Font(ck.font);
         }
         if (ck.attributes != null) {
-            attributes = new HashMap(ck.attributes);
+            attributes = new HashMap<>(ck.attributes);
         }
     }
     
@@ -420,7 +422,7 @@ public class Chunk implements Element {
      * @return the attributes for this <CODE>Chunk</CODE>
      */
 
-    public HashMap getAttributes() {
+    public Map<String, Object> getAttributes() {
         return attributes;
     }
 
@@ -428,7 +430,7 @@ public class Chunk implements Element {
      * Sets the attributes all at once.
      * @param    attributes    the attributes of a Chunk
      */
-    public void setAttributes(HashMap attributes) {
+    public void setAttributes(Map<String, Object> attributes) {
         this.attributes = attributes;
     }
 
@@ -444,7 +446,7 @@ public class Chunk implements Element {
 
     private Chunk setAttribute(String name, Object obj) {
         if (attributes == null)
-            attributes = new HashMap();
+            attributes = new HashMap<>();
         attributes.put(name, obj);
         return this;
     }
@@ -526,7 +528,7 @@ public class Chunk implements Element {
     public Chunk setUnderline(Color color, float thickness, float thicknessMul,
             float yPosition, float yPositionMul, int cap) {
         if (attributes == null)
-            attributes = new HashMap();
+            attributes = new HashMap<>();
         Object[] obj = {
                 color,
                 new float[]{thickness, thicknessMul, yPosition, yPositionMul, cap}};
@@ -560,8 +562,7 @@ public class Chunk implements Element {
      */
     public float getTextRise() {
         if (attributes != null && attributes.containsKey(SUBSUPSCRIPT)) {
-            Float f = (Float) attributes.get(SUBSUPSCRIPT);
-            return f;
+            return (Float) attributes.get(SUBSUPSCRIPT);
         }
         return 0.0f;
     }
@@ -898,8 +899,7 @@ public class Chunk implements Element {
      */
     public float getCharacterSpacing() {
         if (attributes != null && attributes.containsKey(CHAR_SPACING)) {
-            Float f = (Float) attributes.get(CHAR_SPACING);
-            return f;
+            return (Float) attributes.get(CHAR_SPACING);
         }
         return 0.0f;
     }

--- a/openpdf/src/main/java/com/lowagie/text/pdf/BaseField.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/BaseField.java
@@ -49,9 +49,8 @@ package com.lowagie.text.pdf;
 
 import java.awt.Color;
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.Iterator;
+import java.util.*;
+
 import com.lowagie.text.error_messages.MessageLocalization;
 
 import com.lowagie.text.DocumentException;
@@ -149,7 +148,7 @@ public abstract class BaseField {
     /** Holds value of property maxCharacterLength. */
     protected int maxCharacterLength;
 
-    private final static HashMap<PdfName, Integer> fieldKeys = new HashMap<>();
+    private final static Map<PdfName, Integer> fieldKeys = new HashMap<>();
 
     static {
         fieldKeys.putAll(PdfCopyFieldsImp.fieldKeys);
@@ -258,8 +257,8 @@ public abstract class BaseField {
         return app;
     }
 
-    protected static ArrayList getHardBreaks(String text) {
-        ArrayList arr = new ArrayList();
+    protected static List<String> getHardBreaks(String text) {
+        List<String> arr = new ArrayList<>();
         char[] cs = text.toCharArray();
         int len = cs.length;
         StringBuffer buf = new StringBuffer();
@@ -293,8 +292,8 @@ public abstract class BaseField {
         }
     }
 
-    protected static ArrayList breakLines(ArrayList breaks, BaseFont font, float fontSize, float width) {
-        ArrayList lines = new ArrayList();
+    protected static List<String> breakLines(ArrayList breaks, BaseFont font, float fontSize, float width) {
+        List<String> lines = new ArrayList<>();
         StringBuffer buf = new StringBuffer();
         for (Object aBreak : breaks) {
             buf.setLength(0);

--- a/openpdf/src/main/java/com/lowagie/text/pdf/FdfReader.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/FdfReader.java
@@ -49,13 +49,15 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
 import java.util.HashMap;
+import java.util.Map;
+
 /** Reads an FDF form and makes the fields available
  * @author Paulo Soares (psoares@consiste.pt)
  */
 public class FdfReader extends PdfReader {
 
-    private HashMap<String, PdfDictionary> fields;
-    String fileSpec;
+    private Map<String, PdfDictionary> fields;
+    private String fileSpec;
     PdfName encoding;
 
     /** Reads an FDF form.
@@ -155,7 +157,7 @@ public class FdfReader extends PdfReader {
      * with the field content.
      * @return all the fields
      */
-    public HashMap<String, PdfDictionary> getFields() {
+    public Map<String, PdfDictionary> getFields() {
         return fields;
     }
 

--- a/openpdf/src/main/java/com/lowagie/text/pdf/FdfWriter.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/FdfWriter.java
@@ -247,11 +247,10 @@ public class FdfWriter {
      * @param fdf the <CODE>FdfReader</CODE>
      */    
     public void setFields(FdfReader fdf) {
-        HashMap map = fdf.getFields();
-        for (Object o : map.entrySet()) {
-            Map.Entry entry = (Map.Entry) o;
-            String key = (String) entry.getKey();
-            PdfDictionary dic = (PdfDictionary) entry.getValue();
+        Map<String, PdfDictionary> map = fdf.getFields();
+        for (Map.Entry<String, PdfDictionary> entry : map.entrySet()) {
+            String key = entry.getKey();
+            PdfDictionary dic = entry.getValue();
             PdfObject v = dic.get(PdfName.V);
             if (v != null) {
                 setField(key, v);

--- a/openpdf/src/main/java/com/lowagie/text/pdf/FieldReader.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/FieldReader.java
@@ -1,14 +1,14 @@
 package com.lowagie.text.pdf;
 
-import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Represents the basic needs for reading fields.
  */
 public interface FieldReader {
 
-    HashMap<String, String> getFields();
+    Map<String, String> getFields();
 
     String getFieldValue(String fieldKey);
 

--- a/openpdf/src/main/java/com/lowagie/text/pdf/PdfAcroForm.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/PdfAcroForm.java
@@ -50,6 +50,7 @@
 package com.lowagie.text.pdf;
 
 import java.util.HashMap;
+import java.util.Map;
 
 
 import com.lowagie.text.Rectangle;
@@ -93,7 +94,7 @@ public class PdfAcroForm extends PdfDictionary {
      * @param ft
      */
 
-    public void addFieldTemplates(HashMap ft) {
+    public void addFieldTemplates(Map<PdfTemplate, Object> ft) {
         fieldTemplates.putAll(ft);
     }
 

--- a/openpdf/src/main/java/com/lowagie/text/pdf/PdfAnnotation.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/PdfAnnotation.java
@@ -52,6 +52,8 @@ package com.lowagie.text.pdf;
 import java.awt.Color;
 import java.io.IOException;
 import java.util.HashMap;
+import java.util.Map;
+
 import com.lowagie.text.error_messages.MessageLocalization;
 
 import com.lowagie.text.Rectangle;
@@ -198,7 +200,7 @@ public class PdfAnnotation extends PdfDictionary {
    * @since 2.1.6; was removed in 2.1.5, but restored in 2.1.6
    */
   protected PdfIndirectReference reference;
-  protected HashMap<PdfTemplate, Object> templates;
+  protected Map<PdfTemplate, Object> templates;
   protected boolean form = false;
   protected boolean annotation = true;
 
@@ -645,7 +647,7 @@ public class PdfAnnotation extends PdfDictionary {
     used = true;
   }
 
-  public HashMap<PdfTemplate, Object> getTemplates() {
+  public Map<PdfTemplate, Object> getTemplates() {
     return templates;
   }
 

--- a/openpdf/src/main/java/com/lowagie/text/pdf/PdfChunk.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/PdfChunk.java
@@ -76,10 +76,10 @@ public class PdfChunk {
     private static final PdfChunk[] thisChunk = new PdfChunk[1];
     private static final float ITALIC_ANGLE = 0.21256f;
 /** The allowed attributes in variable <CODE>attributes</CODE>. */
-    private static final HashMap keysAttributes = new HashMap();
+    private static final Map<String, Object> keysAttributes = new HashMap<>();
     
 /** The allowed attributes in variable <CODE>noStroke</CODE>. */
-    private static final HashMap keysNoStroke = new HashMap();
+    private static final Map<String, Object> keysNoStroke = new HashMap<>();
     
     static {
         keysAttributes.put(Chunk.ACTION, null);
@@ -124,7 +124,7 @@ public class PdfChunk {
  * This attributes require the measurement of characters widths when rendering
  * such as underline.
  */
-    protected HashMap attributes = new HashMap();
+    protected Map<String, Object> attributes = new HashMap<>();
     
 /**
  * Non metric attributes.
@@ -132,7 +132,7 @@ public class PdfChunk {
  * This attributes do not require the measurement of characters widths when rendering
  * such as Color.
  */
-    protected HashMap noStroke = new HashMap();
+    protected Map<String, Object> noStroke = new HashMap<>();
     
 /** <CODE>true</CODE> if the chunk split was cause by a newline. */
     protected boolean newlineSplit;
@@ -214,11 +214,10 @@ public class PdfChunk {
         }
         font = new PdfFont(baseFont, size);
         // other style possibilities
-        HashMap attr = chunk.getAttributes();
+        Map<String, Object> attr = chunk.getAttributes();
         if (attr != null) {
-            for (Object o : attr.entrySet()) {
-                Map.Entry entry = (Map.Entry) o;
-                Object name = entry.getKey();
+            for (Map.Entry<String, Object> entry : attr.entrySet()) {
+                String name = entry.getKey();
                 if (keysAttributes.containsKey(name)) {
                     attributes.put(name, entry.getValue());
                 } else if (keysNoStroke.containsKey(name)) {
@@ -302,7 +301,7 @@ public class PdfChunk {
             if (image.getScaledWidth() > width) {
                 PdfChunk pc = new PdfChunk(Chunk.OBJECT_REPLACEMENT_CHARACTER, this);
                 value = "";
-                attributes = new HashMap();
+                attributes = new HashMap<>();
                 image = null;
                 font = PdfFont.getDefaultFont();
                 return pc;
@@ -337,8 +336,7 @@ public class PdfChunk {
                     if (value.length() < 1) {
                         value = "\u0001";
                     }
-                    PdfChunk pc = new PdfChunk(returnValue, this);
-                    return pc;
+                    return new PdfChunk(returnValue, this);
                 }
                 currentWidth += getCharWidth(cidChar);
                 if (character == ' ') {
@@ -368,8 +366,7 @@ public class PdfChunk {
                     if (value.length() < 1) {
                         value = " ";
                     }
-                    PdfChunk pc = new PdfChunk(returnValue, this);
-                    return pc;
+                    return new PdfChunk(returnValue, this);
                 }
                 surrogate = Utilities.isSurrogatePair(valueArray, currentPosition);
                 if (surrogate)
@@ -399,8 +396,7 @@ public class PdfChunk {
         if (splitPosition < 0) {
             String returnValue = value;
             value = "";
-            PdfChunk pc = new PdfChunk(returnValue, this);
-            return pc;
+            return new PdfChunk(returnValue, this);
         }
         if (lastSpace > splitPosition && splitCharacter.isSplitCharacter(0, 0, 1, singleSpace, null))
             splitPosition = lastSpace;
@@ -412,15 +408,13 @@ public class PdfChunk {
                 if (pre.length() > 0) {
                     String returnValue = post + value.substring(wordIdx);
                     value = trim(value.substring(0, lastSpace) + pre);
-                    PdfChunk pc = new PdfChunk(returnValue, this);
-                    return pc;
+                    return new PdfChunk(returnValue, this);
                 }
             }
         }
         String returnValue = value.substring(splitPosition);
         value = trim(value.substring(0, splitPosition));
-        PdfChunk pc = new PdfChunk(returnValue, this);
-        return pc;
+        return new PdfChunk(returnValue, this);
     }
     
 /**
@@ -453,8 +447,7 @@ public class PdfChunk {
         if (width < font.width()) {
             String returnValue = value.substring(1);
             value = value.substring(0, 1);
-            PdfChunk pc = new PdfChunk(returnValue, this);
-            return pc;
+            return new PdfChunk(returnValue, this);
         }
         
         // loop over all the characters of a string
@@ -491,8 +484,7 @@ public class PdfChunk {
         }
         String returnValue = value.substring(currentPosition);
         value = value.substring(0, currentPosition);
-        PdfChunk pc = new PdfChunk(returnValue, this);
-        return pc;
+        return new PdfChunk(returnValue, this);
     }
     
     // methods to retrieve the membervariables

--- a/openpdf/src/main/java/com/lowagie/text/pdf/PdfCopy.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/PdfCopy.java
@@ -59,6 +59,7 @@ import com.lowagie.text.Rectangle;
 import com.lowagie.text.ExceptionConverter;
 
 import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -701,10 +702,10 @@ public class PdfCopy extends PdfWriter {
 
     private void expandFields(PdfFormField field, ArrayList allAnnots) {
       allAnnots.add(field);
-      ArrayList kids = field.getKids();
+      List<PdfFormField> kids = field.getKids();
       if (kids != null) {
-          for (Object kid : kids) {
-              expandFields((PdfFormField) kid, allAnnots);
+          for (PdfFormField kid : kids) {
+              expandFields(kid, allAnnots);
           }
       }
     }

--- a/openpdf/src/main/java/com/lowagie/text/pdf/PdfCopyFormsImp.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/PdfCopyFormsImp.java
@@ -51,7 +51,7 @@ package com.lowagie.text.pdf;
 
 import com.lowagie.text.DocumentException;
 import java.io.OutputStream;
-import java.util.HashMap;
+
 import com.lowagie.text.error_messages.MessageLocalization;
 
 /**
@@ -98,9 +98,8 @@ class PdfCopyFormsImp extends PdfCopyFieldsImp {
      * of PdfCopyFields.
      */
     void mergeFields() {
-        for (Object field : fields) {
-            HashMap fd = ((AcroFields) field).getFields();
-            mergeWithMaster(fd);
+        for (AcroFields field : fields) {
+            mergeWithMaster(field.getFields());
         }
     }
 

--- a/openpdf/src/main/java/com/lowagie/text/pdf/PdfEncryptor.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/PdfEncryptor.java
@@ -50,7 +50,7 @@ package com.lowagie.text.pdf;
 
 import java.io.IOException;
 import java.io.OutputStream;
-import java.util.HashMap;
+import java.util.Map;
 
 import com.lowagie.text.DocumentException;
 
@@ -103,7 +103,7 @@ public final class PdfEncryptor {
      * @throws DocumentException on error
      * @throws IOException on error
      */
-    public static void encrypt(PdfReader reader, OutputStream os, byte[] userPassword, byte[] ownerPassword, int permissions, boolean strength128Bits, HashMap newInfo) throws DocumentException, IOException {
+    public static void encrypt(PdfReader reader, OutputStream os, byte[] userPassword, byte[] ownerPassword, int permissions, boolean strength128Bits, Map<String, String> newInfo) throws DocumentException, IOException {
         PdfStamper stamper = new PdfStamper(reader, os);
         stamper.setEncryption(userPassword, ownerPassword, permissions, strength128Bits);
         stamper.setMoreInfo(newInfo);
@@ -150,7 +150,7 @@ public final class PdfEncryptor {
      * @throws DocumentException on error
      * @throws IOException on error
      */
-    public static void encrypt(PdfReader reader, OutputStream os, boolean strength, String userPassword, String ownerPassword, int permissions, HashMap newInfo) throws DocumentException, IOException {
+    public static void encrypt(PdfReader reader, OutputStream os, boolean strength, String userPassword, String ownerPassword, int permissions, Map<String, String> newInfo) throws DocumentException, IOException {
         PdfStamper stamper = new PdfStamper(reader, os);
         stamper.setEncryption(strength, userPassword, ownerPassword, permissions);
         stamper.setMoreInfo(newInfo);
@@ -178,7 +178,7 @@ public final class PdfEncryptor {
      * @throws DocumentException on error
      * @throws IOException on error
      */
-    public static void encrypt(PdfReader reader, OutputStream os, int type, String userPassword, String ownerPassword, int permissions, HashMap newInfo) throws DocumentException, IOException {
+    public static void encrypt(PdfReader reader, OutputStream os, int type, String userPassword, String ownerPassword, int permissions, Map<String, String> newInfo) throws DocumentException, IOException {
         PdfStamper stamper = new PdfStamper(reader, os);
         stamper.setEncryption(type, userPassword, ownerPassword, permissions);
         stamper.setMoreInfo(newInfo);

--- a/openpdf/src/main/java/com/lowagie/text/pdf/PdfFormField.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/PdfFormField.java
@@ -47,6 +47,7 @@
 
 package com.lowagie.text.pdf;
 import java.util.ArrayList;
+import java.util.List;
 
 import com.lowagie.text.Rectangle;
 
@@ -97,7 +98,7 @@ public class PdfFormField extends PdfAnnotation {
     /** Holds value of property parent. */
     protected PdfFormField parent;
     
-    protected ArrayList kids;
+    protected List<PdfFormField> kids;
     
 /**
  * Constructs a new <CODE>PdfAnnotation</CODE> of subtype link (Action).
@@ -226,11 +227,11 @@ public class PdfFormField extends PdfAnnotation {
     public void addKid(PdfFormField field) {
         field.parent = this;
         if (kids == null)
-            kids = new ArrayList();
+            kids = new ArrayList<>();
         kids.add(field);
     }
     
-    public ArrayList getKids() {
+    public List<PdfFormField> getKids() {
         return kids;
     }
     
@@ -312,7 +313,9 @@ public class PdfFormField extends PdfAnnotation {
             put(PdfName.PARENT, parent.getIndirectReference());
         if (kids != null) {
             PdfArray array = new PdfArray();
-            for (Object kid : kids) array.add(((PdfFormField) kid).getIndirectReference());
+            for (PdfFormField kid : kids) {
+                array.add(kid.getIndirectReference());
+            }
             put(PdfName.KIDS, array);
         }
         if (templates == null)

--- a/openpdf/src/main/java/com/lowagie/text/pdf/PdfPublicKeySecurityHandler.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/PdfPublicKeySecurityHandler.java
@@ -48,44 +48,44 @@
  * http://www.lowagie.com/iText/
  */
 
-/**
- *     The below 2 methods are from pdfbox.
- * 
- *     private DERObject createDERForRecipient(byte[] in, X509Certificate cert) ;
- *     private KeyTransRecipientInfo computeRecipientInfo(X509Certificate x509certificate, byte[] abyte0);
- *     
- *     2006-11-22 Aiken Sam.
+/*
+      The below 2 methods are from pdfbox.
+
+      private DERObject createDERForRecipient(byte[] in, X509Certificate cert) ;
+      private KeyTransRecipientInfo computeRecipientInfo(X509Certificate x509certificate, byte[] abyte0);
+
+      2006-11-22 Aiken Sam.
  */
 
-/**
- * Copyright (c) 2003-2006, www.pdfbox.org
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- * 3. Neither the name of pdfbox; nor the names of its
- *    contributors may be used to endorse or promote products derived from this
- *    software without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- * DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE FOR ANY
- * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
- * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
- * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
- * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- *
- * http://www.pdfbox.org
- *
+/*
+  Copyright (c) 2003-2006, www.pdfbox.org
+  All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are met:
+
+  1. Redistributions of source code must retain the above copyright notice,
+     this list of conditions and the following disclaimer.
+  2. Redistributions in binary form must reproduce the above copyright notice,
+     this list of conditions and the following disclaimer in the documentation
+     and/or other materials provided with the distribution.
+  3. Neither the name of pdfbox; nor the names of its
+     contributors may be used to endorse or promote products derived from this
+     software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE FOR ANY
+  DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+  http://www.pdfbox.org
+
  */
 
 package com.lowagie.text.pdf;
@@ -122,7 +122,7 @@ import org.bouncycastle.asn1.cms.RecipientIdentifier;
 import org.bouncycastle.asn1.cms.RecipientInfo;
 import org.bouncycastle.asn1.pkcs.PKCSObjectIdentifiers;
 import org.bouncycastle.asn1.x509.AlgorithmIdentifier;
-import org.bouncycastle.asn1.x509.TBSCertificateStructure;
+import org.bouncycastle.asn1.x509.TBSCertificate;
 
 /**
  * @author Aiken Sam (aikensam@ieee.org)
@@ -278,19 +278,14 @@ public class PdfPublicKeySecurityHandler {
       throws GeneralSecurityException, IOException {
     ASN1InputStream asn1inputstream = new ASN1InputStream(
         new ByteArrayInputStream(x509certificate.getTBSCertificate()));
-    TBSCertificateStructure tbscertificatestructure = TBSCertificateStructure
-        .getInstance(asn1inputstream.readObject());
-    AlgorithmIdentifier algorithmidentifier = tbscertificatestructure
-        .getSubjectPublicKeyInfo().getAlgorithmId();
+    TBSCertificate tbsCertificate = TBSCertificate.getInstance(asn1inputstream.readObject());
+    AlgorithmIdentifier algorithmidentifier = tbsCertificate.getSubjectPublicKeyInfo().getAlgorithm();
     IssuerAndSerialNumber issuerandserialnumber = new IssuerAndSerialNumber(
-        tbscertificatestructure.getIssuer(), tbscertificatestructure
-            .getSerialNumber().getValue());
-    Cipher cipher = Cipher.getInstance(algorithmidentifier.getAlgorithm()
-        .getId());
+            tbsCertificate.getIssuer(), tbsCertificate.getSerialNumber().getValue());
+    Cipher cipher = Cipher.getInstance(algorithmidentifier.getAlgorithm().getId());
     cipher.init(1, x509certificate);
     DEROctetString deroctetstring = new DEROctetString(cipher.doFinal(abyte0));
     RecipientIdentifier recipId = new RecipientIdentifier(issuerandserialnumber);
-    return new KeyTransRecipientInfo(recipId, algorithmidentifier,
-        deroctetstring);
+    return new KeyTransRecipientInfo(recipId, algorithmidentifier, deroctetstring);
   }
 }

--- a/openpdf/src/main/java/com/lowagie/text/pdf/PdfReader.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/PdfReader.java
@@ -3453,7 +3453,7 @@ public class PdfReader implements PdfViewerPreferences, Closeable {
      * ArrayList with the indirect references to every page. Element 0 = page 1;
      * 1 = page 2;... Not used for partial reading.
      */
-    private ArrayList refsn;
+    private List<PdfObject> refsn;
     /** The number of pages, updated only in case of partial reading. */
     private int sizep;
     /**
@@ -3486,9 +3486,9 @@ public class PdfReader implements PdfViewerPreferences, Closeable {
       this.reader = reader;
       this.sizep = other.sizep;
       if (other.refsn != null) {
-        refsn = new ArrayList(other.refsn);
+        refsn = new ArrayList<>(other.refsn);
         for (int k = 0; k < refsn.size(); ++k) {
-          refsn.set(k, duplicatePdfObject((PdfObject) refsn.get(k), reader));
+          refsn.set(k, duplicatePdfObject(refsn.get(k), reader));
         }
       } else
         this.refsp = (IntHashtable) other.refsp.clone();
@@ -3505,7 +3505,7 @@ public class PdfReader implements PdfViewerPreferences, Closeable {
       if (refsn != null)
         return;
       refsp = null;
-      refsn = new ArrayList();
+      refsn = new ArrayList<>();
       pageInh = new ArrayList();
       iteratePages((PRIndirectReference) reader.catalog.get(PdfName.PAGES));
       pageInh = null;
@@ -3765,7 +3765,7 @@ public class PdfReader implements PdfViewerPreferences, Closeable {
       PRIndirectReference parent = (PRIndirectReference) reader.catalog
           .get(PdfName.PAGES);
       PdfDictionary topPages = (PdfDictionary) PdfReader.getPdfObject(parent);
-      ArrayList newPageRefs = new ArrayList(finalPages.size());
+      List<PdfObject> newPageRefs = new ArrayList<>(finalPages.size());
       PdfArray kids = new PdfArray();
       for (Object finalPage : finalPages) {
         int p = (Integer) finalPage;

--- a/openpdf/src/main/java/com/lowagie/text/pdf/PdfStamper.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/PdfStamper.java
@@ -84,7 +84,7 @@ public class PdfStamper
      * The writer
      */    
     protected PdfStamperImp stamper;
-    private HashMap moreInfo;
+    private Map<String, String> moreInfo;
     private boolean hasSignature;
     private PdfSignatureAppearance sigApp;
 
@@ -134,7 +134,7 @@ public class PdfStamper
      * @return the map or <CODE>null</CODE>
      *
      */
-    public HashMap getMoreInfo() {
+    public Map<String, String> getMoreInfo() {
         return this.moreInfo;
     }
 
@@ -144,7 +144,7 @@ public class PdfStamper
      * @param moreInfo additional entries to the info dictionary
      *
      */
-    public void setMoreInfo(HashMap moreInfo) {
+    public void setMoreInfo(Map<String, String> moreInfo) {
         this.moreInfo = moreInfo;
     }
 

--- a/openpdf/src/main/java/com/lowagie/text/pdf/PdfWriter.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/PdfWriter.java
@@ -1284,8 +1284,7 @@ public class PdfWriter extends DocWriter implements
             }
         }
         // [F13] add the OCG layers
-        for (Object o : documentOCG) {
-            PdfOCG layer = (PdfOCG) o;
+        for (PdfOCG layer : documentOCG) {
             addToBody(layer.getPdfObject(), layer.getRef());
         }
     }
@@ -2402,9 +2401,9 @@ public class PdfWriter extends DocWriter implements
 
 //  [F13] Optional Content Groups
     /** A hashSet containing all the PdfLayer objects. */
-    protected HashSet documentOCG = new HashSet();
+    protected Set<PdfOCG> documentOCG = new HashSet<>();
     /** An array list used to define the order of an OCG tree. */
-    protected ArrayList documentOCGorder = new ArrayList();
+    protected List<PdfOCG> documentOCGorder = new ArrayList<>();
     /** The OCProperties in a catalog dictionary. */
     protected PdfOCProperties OCProperties;
     /** The RBGroups array in an OCG dictionary */
@@ -2478,7 +2477,7 @@ public class PdfWriter extends DocWriter implements
 
     private void addASEvent(PdfName event, PdfName category) {
         PdfArray arr = new PdfArray();
-        for (Object o : documentOCG) {
+        for (PdfOCG o : documentOCG) {
             PdfLayer layer = (PdfLayer) o;
             PdfDictionary usage = (PdfDictionary) layer.get(PdfName.USAGE);
             if (usage != null && usage.get(category) != null)
@@ -2511,7 +2510,7 @@ public class PdfWriter extends DocWriter implements
         }
         if (OCProperties.get(PdfName.OCGS) == null) {
             PdfArray gr = new PdfArray();
-            for (Object o : documentOCG) {
+            for (PdfOCG o : documentOCG) {
                 PdfLayer layer = (PdfLayer) o;
                 gr.add(layer.getRef());
             }
@@ -2519,14 +2518,14 @@ public class PdfWriter extends DocWriter implements
         }
         if (OCProperties.get(PdfName.D) != null)
             return;
-        ArrayList docOrder = new ArrayList(documentOCGorder);
-        for (Iterator it = docOrder.iterator(); it.hasNext();) {
+        List<PdfOCG> docOrder = new ArrayList<>(documentOCGorder);
+        for (Iterator<PdfOCG> it = docOrder.iterator(); it.hasNext();) {
             PdfLayer layer = (PdfLayer)it.next();
             if (layer.getParent() != null)
                 it.remove();
         }
         PdfArray order = new PdfArray();
-        for (Object o1 : docOrder) {
+        for (PdfOCG o1 : docOrder) {
             PdfLayer layer = (PdfLayer) o1;
             getOCGOrder(order, layer);
         }
@@ -2534,7 +2533,7 @@ public class PdfWriter extends DocWriter implements
         OCProperties.put(PdfName.D, d);
         d.put(PdfName.ORDER, order);
         PdfArray gr = new PdfArray();
-        for (Object o : documentOCG) {
+        for (PdfOCG o : documentOCG) {
             PdfLayer layer = (PdfLayer) o;
             if (!layer.isOn())
                 gr.add(layer.getRef());

--- a/openpdf/src/main/java/com/lowagie/text/pdf/SimpleBookmark.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/SimpleBookmark.java
@@ -110,17 +110,17 @@ import com.lowagie.text.xml.XMLUtil;
  */
 public final class SimpleBookmark implements SimpleXMLDocHandler {
     
-    private ArrayList topList;
-    private Stack attr = new Stack();
+    private List<Map<String, Object>> topList;
+    private Stack<Map<String, Object>> attr = new Stack<>();
     
     /** Creates a new instance of SimpleBookmark */
     private SimpleBookmark() {
     }
     
-    private static List bookmarkDepth(PdfReader reader, PdfDictionary outline, IntHashtable pages) {
-        ArrayList list = new ArrayList();
+    private static List<Map<String, Object>> bookmarkDepth(PdfReader reader, PdfDictionary outline, IntHashtable pages) {
+        List<Map<String, Object>> list = new ArrayList<>();
         while (outline != null) {
-            HashMap map = new HashMap();
+            Map<String, Object> map = new HashMap<>();
             PdfString title = (PdfString)PdfReader.getPdfObjectRelease(outline.get(PdfName.TITLE));
             map.put("Title", title.toUnicodeString());
             PdfArray color = (PdfArray)PdfReader.getPdfObjectRelease(outline.get(PdfName.C));
@@ -227,7 +227,7 @@ public final class SimpleBookmark implements SimpleXMLDocHandler {
         return list;
     }
     
-    private static void mapGotoBookmark(HashMap map, PdfObject dest, IntHashtable pages) 
+    private static void mapGotoBookmark(Map<String, Object> map, PdfObject dest, IntHashtable pages)
     {
         if (dest.isString())
             map.put("Named", dest.toString());
@@ -276,7 +276,7 @@ public final class SimpleBookmark implements SimpleXMLDocHandler {
      * @return a <CODE>List</CODE> with the bookmarks or <CODE>null</CODE> if the
      * document doesn't have any
      */    
-    public static List getBookmark(PdfReader reader) {
+    public static List<Map<String, Object>> getBookmark(PdfReader reader) {
         PdfDictionary catalog = reader.getCatalog();
         PdfObject obj = PdfReader.getPdfObjectRelease(catalog.get(PdfName.OUTLINES));
         if (obj == null || !obj.isDictionary())
@@ -353,11 +353,10 @@ public final class SimpleBookmark implements SimpleXMLDocHandler {
      * @param pageRange the page ranges, always in pairs. It can be <CODE>null</CODE>
      * to include all the pages
      */    
-    public static void shiftPageNumbers(List list, int pageShift, int[] pageRange) {
+    public static void shiftPageNumbers(List<Map<String, Object>> list, int pageShift, int[] pageRange) {
         if (list == null)
             return;
-        for (Object o : list) {
-            HashMap map = (HashMap) o;
+        for (Map<String, Object> map : list) {
             if ("GoTo".equals(map.get("Action"))) {
                 String page = (String) map.get("Page");
                 if (page != null) {
@@ -389,7 +388,7 @@ public final class SimpleBookmark implements SimpleXMLDocHandler {
                     map.put("Page", page);
                 }
             }
-            List kids = (List) map.get("Kids");
+            List<Map<String, Object>> kids = (List<Map<String, Object>>) map.get("Kids");
             if (kids != null)
                 shiftPageNumbers(kids, pageShift, pageRange);
         }
@@ -701,22 +700,22 @@ public final class SimpleBookmark implements SimpleXMLDocHandler {
         }
         if (!tag.equals("Title"))
             throw new RuntimeException(MessageLocalization.getComposedMessage("invalid.end.tag.1", tag));
-        HashMap attributes = (HashMap)attr.pop();
-        String title = (String)attributes.get("Title");
+        Map<String, Object> attributes = attr.pop();
+        String title = (String) attributes.get("Title");
         attributes.put("Title",  title.trim());
-        String named = (String)attributes.get("Named");
+        String named = (String) attributes.get("Named");
         if (named != null)
             attributes.put("Named", SimpleNamedDestination.unEscapeBinaryString(named));
-        named = (String)attributes.get("NamedN");
+        named = (String) attributes.get("NamedN");
         if (named != null)
             attributes.put("NamedN", SimpleNamedDestination.unEscapeBinaryString(named));
         if (attr.isEmpty())
             topList.add(attributes);
         else {
-            HashMap parent = (HashMap)attr.peek();
-            List kids = (List)parent.get("Kids");
+            Map<String, Object> parent = attr.peek();
+            List<Map<String, Object>> kids = (List<Map<String, Object>>) parent.get("Kids");
             if (kids == null) {
-                kids = new ArrayList();
+                kids = new ArrayList<>();
                 parent.put("Kids", kids);
             }
             kids.add(attributes);
@@ -726,10 +725,10 @@ public final class SimpleBookmark implements SimpleXMLDocHandler {
     public void startDocument() {
     }
 
-    public void startElement(String tag, HashMap h) {
+    public void startElement(String tag, Map<String, String> h) {
         if (topList == null) {
             if (tag.equals("Bookmark")) {
-                topList = new ArrayList();
+                topList = new ArrayList<>();
                 return;
             }
             else
@@ -737,7 +736,7 @@ public final class SimpleBookmark implements SimpleXMLDocHandler {
         }
         if (!tag.equals("Title"))
             throw new RuntimeException(MessageLocalization.getComposedMessage("tag.1.not.allowed", tag));
-        HashMap attributes = new HashMap(h);
+        Map<String, Object> attributes = new HashMap<>(h);
         attributes.put("Title", "");
         attributes.remove("Kids");
         attr.push(attributes);
@@ -746,8 +745,8 @@ public final class SimpleBookmark implements SimpleXMLDocHandler {
     public void text(String str) {
         if (attr.isEmpty())
             return;
-        HashMap attributes = (HashMap)attr.peek();
-        String title = (String)attributes.get("Title");
+        Map<String, Object> attributes = attr.peek();
+        String title = (String) attributes.get("Title");
         title += str;
         attributes.put("Title", title);
     }

--- a/openpdf/src/main/java/com/lowagie/text/pdf/SimpleNamedDestination.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/SimpleNamedDestination.java
@@ -71,7 +71,7 @@ import com.lowagie.text.xml.XMLUtil;
 public final class SimpleNamedDestination implements SimpleXMLDocHandler {
     
     private HashMap xmlNames;
-    private HashMap xmlLast;
+    private Map<String, String> xmlLast;
 
     private SimpleNamedDestination() {
     }
@@ -310,7 +310,7 @@ public final class SimpleNamedDestination implements SimpleXMLDocHandler {
     public void startDocument() {
     }
 
-    public void startElement(String tag, HashMap h) {
+    public void startElement(String tag, Map<String, String> h) {
         if (xmlNames == null) {
             if (tag.equals("Destination")) {
                 xmlNames = new HashMap();

--- a/openpdf/src/main/java/com/lowagie/text/pdf/TextField.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/TextField.java
@@ -50,6 +50,7 @@ package com.lowagie.text.pdf;
 import java.awt.Color;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.List;
 
 import com.lowagie.text.Chunk;
 import com.lowagie.text.DocumentException;
@@ -57,6 +58,8 @@ import com.lowagie.text.Element;
 import com.lowagie.text.Font;
 import com.lowagie.text.Phrase;
 import com.lowagie.text.Rectangle;
+
+import javax.annotation.Nullable;
 
 /**
  * Supports text, combo and list fields generating the correct appearances.
@@ -118,8 +121,8 @@ public class TextField extends BaseField {
             if (extensionFont != null)
                 fs.addFont(new Font(extensionFont, fontSize, 0, color));
             if (substitutionFonts != null) {
-                for (Object substitutionFont : substitutionFonts)
-                    fs.addFont(new Font((BaseFont) substitutionFont, fontSize, 0, color));
+                for (BaseFont substitutionFont : substitutionFonts)
+                    fs.addFont(new Font(substitutionFont, fontSize, 0, color));
             }
             phrase = fs.process(text);
         }
@@ -713,9 +716,9 @@ public class TextField extends BaseField {
      * list, all but the first element will be removed.
      * @param selections new selections.  If null, it clear()s the underlying ArrayList.
      */
-    public void setChoiceSelections( ArrayList selections ) {
+    public void setChoiceSelections(@Nullable List<Integer> selections ) {
         if (selections != null) {
-            choiceSelections = new ArrayList( selections );
+            choiceSelections = new ArrayList<>( selections );
             if (choiceSelections.size() > 1 && (options & BaseField.MULTISELECT) == 0 ) {
                 // can't have multiple selections in a single-select field
                 while (choiceSelections.size() > 1) {
@@ -745,14 +748,14 @@ public class TextField extends BaseField {
     /**
      * Holds value of property substitutionFonts.
      */
-    private ArrayList substitutionFonts;
+    private List<BaseFont> substitutionFonts;
 
     /**
      * Gets the list of substitution fonts. The list is composed of <CODE>BaseFont</CODE> and can be <CODE>null</CODE>. The fonts in this list will be used if the original
      * font doesn't contain the needed glyphs.
      * @return the list
      */
-    public ArrayList getSubstitutionFonts() {
+    public List<BaseFont> getSubstitutionFonts() {
         return this.substitutionFonts;
     }
 
@@ -761,7 +764,7 @@ public class TextField extends BaseField {
      * font doesn't contain the needed glyphs.
      * @param substitutionFonts the list
      */
-    public void setSubstitutionFonts(ArrayList substitutionFonts) {
+    public void setSubstitutionFonts(List<BaseFont> substitutionFonts) {
         this.substitutionFonts = substitutionFonts;
     }
 

--- a/openpdf/src/main/java/com/lowagie/text/pdf/hyphenation/SimplePatternParser.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/hyphenation/SimplePatternParser.java
@@ -59,6 +59,7 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
+import java.util.Map;
 import java.util.StringTokenizer;
 
 /** Parses the xml hyphenation pattern.
@@ -216,10 +217,10 @@ public class SimplePatternParser implements SimpleXMLDocHandler,
     public void startDocument() {
     }
 
-    public void startElement(String tag, java.util.HashMap h) {
+    public void startElement(String tag, Map<String, String> h) {
         switch (tag) {
             case "hyphen-char":
-                String hh = (String) h.get("value");
+                String hh = h.get("value");
                 if (hh != null && hh.length() == 1) {
                     hyphenChar = hh.charAt(0);
                 }
@@ -238,7 +239,7 @@ public class SimplePatternParser implements SimpleXMLDocHandler,
                 if (token.length() > 0) {
                     exception.add(token.toString());
                 }
-                exception.add(new Hyphen((String) h.get("pre"), (String) h.get("no"), (String) h.get("post")));
+                exception.add(new Hyphen(h.get("pre"), h.get("no"), h.get("post")));
                 currElement = ELEM_HYPHEN;
                 break;
         }

--- a/openpdf/src/main/java/com/lowagie/text/pdf/internal/PdfAnnotationsImp.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/internal/PdfAnnotationsImp.java
@@ -52,23 +52,14 @@ package com.lowagie.text.pdf.internal;
 import java.io.IOException;
 import java.net.URL;
 import java.util.ArrayList;
-import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 import com.lowagie.text.Annotation;
 
 import com.lowagie.text.Rectangle;
 import com.lowagie.text.ExceptionConverter;
-import com.lowagie.text.pdf.PdfAcroForm;
-import com.lowagie.text.pdf.PdfAction;
-import com.lowagie.text.pdf.PdfAnnotation;
-import com.lowagie.text.pdf.PdfArray;
-import com.lowagie.text.pdf.PdfFileSpecification;
-import com.lowagie.text.pdf.PdfFormField;
-import com.lowagie.text.pdf.PdfName;
-import com.lowagie.text.pdf.PdfObject;
-import com.lowagie.text.pdf.PdfRectangle;
-import com.lowagie.text.pdf.PdfString;
-import com.lowagie.text.pdf.PdfWriter;
+import com.lowagie.text.pdf.*;
 
 public class PdfAnnotationsImp {
 
@@ -81,13 +72,13 @@ public class PdfAnnotationsImp {
      * This is the array containing the references to annotations
      * that were added to the document.
      */
-    protected ArrayList annotations;
+    protected List<PdfAnnotation> annotations;
     
     /**
      * This is an array containing references to some delayed annotations
      * (that were added for a page that doesn't exist yet).
      */
-    protected ArrayList delayedAnnotations = new ArrayList();
+    protected List<PdfAnnotation> delayedAnnotations = new ArrayList<>();
     
     
     public PdfAnnotationsImp(PdfWriter writer) {
@@ -133,9 +124,11 @@ public class PdfAnnotationsImp {
     
     void addFormFieldRaw(PdfFormField field) {
         annotations.add(field);
-        ArrayList kids = field.getKids();
+        List<PdfFormField> kids = field.getKids();
         if (kids != null) {
-            for (Object kid : kids) addFormFieldRaw((PdfFormField) kid);
+            for (PdfFormField kid : kids) {
+                addFormFieldRaw(kid);
+            }
         }
     }
     
@@ -145,7 +138,7 @@ public class PdfAnnotationsImp {
 
     public void resetAnnotations() {
         annotations = delayedAnnotations;
-        delayedAnnotations = new ArrayList();
+        delayedAnnotations = new ArrayList<>();
     }
     
     public PdfArray rotateAnnotations(PdfWriter writer, Rectangle pageSize) {
@@ -161,7 +154,7 @@ public class PdfAnnotationsImp {
             }
             if (dic.isForm()) {
                 if (!dic.isUsed()) {
-                    HashMap templates = dic.getTemplates();
+                    Map<PdfTemplate, Object> templates = dic.getTemplates();
                     if (templates != null)
                         acroForm.addFieldTemplates(templates);
                 }
@@ -229,9 +222,8 @@ public class PdfAnnotationsImp {
                    fs = PdfFileSpecification.fileEmbedded(writer, fname, fname, null);
                else
                    fs = PdfFileSpecification.fileExtern(writer, fname);
-               PdfAnnotation ann = PdfAnnotation.createScreen(writer, new Rectangle(annot.llx(), annot.lly(), annot.urx(), annot.ury()),
+               return PdfAnnotation.createScreen(writer, new Rectangle(annot.llx(), annot.lly(), annot.urx(), annot.ury()),
                        fname, fs, mimetype, sparams[1]);
-               return ann;
            case Annotation.FILE_PAGE:
                return new PdfAnnotation(writer, annot.llx(), annot.lly(), annot.urx(), annot.ury(), new PdfAction((String) annot.attributes().get(Annotation.FILE), (Integer) annot.attributes().get(Annotation.PAGE)));
            case Annotation.NAMED_DEST:

--- a/openpdf/src/main/java/com/lowagie/text/xml/simpleparser/SimpleXMLDocHandler.java
+++ b/openpdf/src/main/java/com/lowagie/text/xml/simpleparser/SimpleXMLDocHandler.java
@@ -46,7 +46,7 @@
  */
 package com.lowagie.text.xml.simpleparser;
 
-import java.util.HashMap;
+import java.util.Map;
 
 /**
  * The handler for the events fired by <CODE>SimpleXMLParser</CODE>.
@@ -58,7 +58,7 @@ public interface SimpleXMLDocHandler {
      * @param tag the tag name
      * @param h the tag's attributes
      */
-    void startElement(String tag, HashMap h);
+    void startElement(String tag, Map<String, String> h);
     /**
      * Called when an end tag is found.
      * @param tag the tag name

--- a/openpdf/src/test/java/com/lowagie/text/pdf/AcroFieldsTest.java
+++ b/openpdf/src/test/java/com/lowagie/text/pdf/AcroFieldsTest.java
@@ -3,7 +3,7 @@ package com.lowagie.text.pdf;
 import java.io.ByteArrayOutputStream;
 import java.io.InputStream;
 import java.security.Security;
-import java.util.ArrayList;
+import java.util.List;
 
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.junit.jupiter.api.Assertions;
@@ -29,7 +29,7 @@ public class AcroFieldsTest {
         PdfWriter writer = PdfWriter.getInstance(document, out);
 
         AcroFields fields = new AcroFields(reader, writer);
-        ArrayList<String> names = fields.getSignatureNames();
+        List<String> names = fields.getSignatureNames();
         Assertions.assertEquals(1, names.size());
 
         for (String signName : names) {

--- a/pdf-html/src/main/java/com/lowagie/text/html/HtmlWriter.java
+++ b/pdf-html/src/main/java/com/lowagie/text/html/HtmlWriter.java
@@ -51,13 +51,8 @@ package com.lowagie.text.html;
 
 import java.io.IOException;
 import java.io.OutputStream;
-import java.util.Date;
-import java.util.EmptyStackException;
-import java.util.Enumeration;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.Properties;
-import java.util.Stack;
+import java.util.*;
+
 import com.lowagie.text.error_messages.MessageLocalization;
 
 import com.lowagie.text.Anchor;
@@ -133,7 +128,7 @@ public class HtmlWriter extends DocWriter {
     // membervariables
     
 /** This is the current font of the HTML. */
-    protected Stack currentfont = new Stack();
+    protected Stack<Font> currentfont = new Stack<>();
     
 /** This is the standard font of the HTML. */
     protected Font standardfont = new Font();
@@ -532,7 +527,7 @@ public class HtmlWriter extends DocWriter {
     
     public boolean isOtherFont(Font font) {
         try {
-            Font cFont = (Font) currentfont.peek();
+            Font cFont = currentfont.peek();
             return cFont.compareTo(font) != 0;
         }
         catch(EmptyStackException ese) {
@@ -635,7 +630,7 @@ public class HtmlWriter extends DocWriter {
                 }
                 
                 if (chunk.isEmpty()) return;
-                HashMap attributes = chunk.getAttributes();
+                Map<String, Object> attributes = chunk.getAttributes();
                 if (attributes != null && attributes.get(Chunk.NEWPAGE) != null) {
                     return;
                 }

--- a/pdf-html/src/main/java/com/lowagie/text/html/simpleparser/ChainedProperties.java
+++ b/pdf-html/src/main/java/com/lowagie/text/html/simpleparser/ChainedProperties.java
@@ -53,12 +53,14 @@ package com.lowagie.text.html.simpleparser;
 import com.lowagie.text.ElementTags;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 public class ChainedProperties {
 
     public final static int[] fontSizes = {8, 10, 12, 14, 18, 24, 36};
 
-    public ArrayList chain = new ArrayList();
+    public List<Object[]> chain = new ArrayList<>();
 
     /** Creates a new instance of ChainedProperties */
     public ChainedProperties() {
@@ -66,7 +68,7 @@ public class ChainedProperties {
 
     public String getProperty(String key) {
         for (int k = chain.size() - 1; k >= 0; --k) {
-            Object[] obj = (Object[]) chain.get(k);
+            Object[] obj = chain.get(k);
             HashMap prop = (HashMap) obj[1];
             String ret = (String) prop.get(key);
             if (ret != null)
@@ -77,7 +79,7 @@ public class ChainedProperties {
 
     public boolean hasProperty(String key) {
         for (int k = chain.size() - 1; k >= 0; --k) {
-            Object[] obj = (Object[]) chain.get(k);
+            Object[] obj = chain.get(k);
             HashMap prop = (HashMap) obj[1];
             if (prop.containsKey(key))
                 return true;
@@ -85,9 +87,9 @@ public class ChainedProperties {
         return false;
     }
 
-    public void addToChain(String key, HashMap prop) {
+    public void addToChain(String key, Map<String, String> prop) {
         // adjust the font size
-        String value = (String) prop.get(ElementTags.SIZE);
+        String value = prop.get(ElementTags.SIZE);
         if (value != null) {
             if (value.endsWith("pt")) {
                 prop.put(ElementTags.SIZE, value.substring(0,
@@ -128,7 +130,7 @@ public class ChainedProperties {
 
     public void removeChain(String key) {
         for (int k = chain.size() - 1; k >= 0; --k) {
-            if (key.equals(((Object[]) chain.get(k))[0])) {
+            if (key.equals(chain.get(k)[0])) {
                 chain.remove(k);
                 return;
             }

--- a/pdf-html/src/main/java/com/lowagie/text/html/simpleparser/FactoryProperties.java
+++ b/pdf-html/src/main/java/com/lowagie/text/html/simpleparser/FactoryProperties.java
@@ -338,8 +338,8 @@ public class FactoryProperties {
      * @param cprops
      * @since 2.1.3
      */
-    public static void insertStyle(final Map<String, String> h, final ChainedProperties cprops) {
-        final String style = h.get("style");
+    public static void insertStyle(Map<String, String> h, ChainedProperties cprops) {
+        String style = h.get("style");
         if (style == null)
             return;
         Properties prop = Markup.parseAttributes(style);

--- a/pdf-html/src/main/java/com/lowagie/text/html/simpleparser/HTMLWorker.java
+++ b/pdf-html/src/main/java/com/lowagie/text/html/simpleparser/HTMLWorker.java
@@ -53,10 +53,7 @@ package com.lowagie.text.html.simpleparser;
 import java.io.File;
 import java.io.IOException;
 import java.io.Reader;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.Stack;
-import java.util.StringTokenizer;
+import java.util.*;
 
 import com.lowagie.text.ExceptionConverter;
 import com.lowagie.text.html.HtmlTags;
@@ -172,19 +169,19 @@ public class HTMLWorker implements SimpleXMLDocHandler, DocListener {
     }
 
     public void startDocument() {
-        HashMap h = new HashMap();
+        Map<String, String> h = new HashMap<>();
         style.applyStyle("body", h);
         cprops.addToChain("body", h);
     }
 
-    public void startElement(String tag, HashMap h) {
+    public void startElement(String tag, Map<String, String> h) {
         if (!tagsSupported.containsKey(tag))
             return;
         try {
             style.applyStyle(tag, h);
             String follow = (String) FactoryProperties.followTags.get(tag);
             if (follow != null) {
-                HashMap prop = new HashMap();
+                Map<String, String> prop = new HashMap<>();
                 prop.put(follow, null);
                 cprops.addToChain(follow, prop);
                 return;
@@ -257,7 +254,7 @@ public class HTMLWorker implements SimpleXMLDocHandler, DocListener {
                 return;
             }
             if (tag.equals(HtmlTags.IMAGE)) {
-                String src = (String) h.get(ElementTags.SRC);
+                String src = h.get(ElementTags.SRC);
                 if (src == null)
                     return;
                 cprops.addToChain(tag, h);
@@ -295,9 +292,9 @@ public class HTMLWorker implements SimpleXMLDocHandler, DocListener {
                     }
                     img = Image.getInstance(src);
                 }
-                String align = (String) h.get("align");
-                String width = (String) h.get("width");
-                String height = (String) h.get("height");
+                String align = h.get("align");
+                String width = h.get("width");
+                String height = h.get("height");
                 String before = cprops.getProperty("before");
                 String after = cprops.getProperty("after");
                 if (before != null)
@@ -369,7 +366,7 @@ public class HTMLWorker implements SimpleXMLDocHandler, DocListener {
                 cprops.addToChain(tag, h);
                 com.lowagie.text.List list = new com.lowagie.text.List(false);
                 try{
-                    list.setIndentationLeft(new Float(cprops.getProperty("indent")));
+                    list.setIndentationLeft(Float.parseFloat(cprops.getProperty("indent")));
                 }catch (Exception e) {
                     list.setAutoindent(true);
                 }
@@ -384,7 +381,7 @@ public class HTMLWorker implements SimpleXMLDocHandler, DocListener {
                 cprops.addToChain(tag, h);
                 com.lowagie.text.List list = new com.lowagie.text.List(true);
                 try{
-                    list.setIndentationLeft(new Float(cprops.getProperty("indent")));
+                    list.setIndentationLeft(Float.parseFloat(cprops.getProperty("indent")));
                 }catch (Exception e) {
                     list.setAutoindent(true);
                 }

--- a/pdf-html/src/main/java/com/lowagie/text/html/simpleparser/ImageProvider.java
+++ b/pdf-html/src/main/java/com/lowagie/text/html/simpleparser/ImageProvider.java
@@ -50,8 +50,8 @@ package com.lowagie.text.html.simpleparser;
 
 import com.lowagie.text.DocListener;
 import com.lowagie.text.Image;
-import java.util.HashMap;
+import java.util.Map;
 
 public interface ImageProvider {
-    Image getImage(String src, HashMap h, ChainedProperties cprops, DocListener doc);
+    Image getImage(String src, Map<String, String> h, ChainedProperties cprops, DocListener doc);
 }

--- a/pdf-html/src/main/java/com/lowagie/text/html/simpleparser/Img.java
+++ b/pdf-html/src/main/java/com/lowagie/text/html/simpleparser/Img.java
@@ -47,7 +47,7 @@
 
 package com.lowagie.text.html.simpleparser;
 
-import java.util.HashMap;
+import java.util.Map;
 
 import com.lowagie.text.DocListener;
 import com.lowagie.text.Image;
@@ -57,5 +57,5 @@ import com.lowagie.text.Image;
  * @author  psoares
  */
 public interface Img {
-    boolean process(Image img, HashMap h, ChainedProperties cprops, DocListener doc);
+    boolean process(Image img, Map<String, String> h, ChainedProperties cprops, DocListener doc);
 }

--- a/pdf-html/src/main/java/com/lowagie/text/html/simpleparser/IncTable.java
+++ b/pdf-html/src/main/java/com/lowagie/text/html/simpleparser/IncTable.java
@@ -47,10 +47,9 @@
 
 package com.lowagie.text.html.simpleparser;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
+import java.util.*;
 
+import com.lowagie.text.pdf.PdfCell;
 import com.lowagie.text.pdf.PdfPCell;
 import com.lowagie.text.pdf.PdfPTable;
 
@@ -59,23 +58,23 @@ import com.lowagie.text.pdf.PdfPTable;
  * @author  psoares
  */
 public class IncTable {
-    private HashMap props = new HashMap();
-    private ArrayList rows = new ArrayList();
-    private ArrayList cols;
+    private Map<String, String> props = new HashMap<>();
+    private List<List<PdfPCell>> rows = new ArrayList<>();
+    private List<PdfPCell> cols;
     /** Creates a new instance of IncTable */
-    public IncTable(HashMap props) {
+    public IncTable(Map<String, String> props) {
         this.props.putAll(props);
     }
     
     public void addCol(PdfPCell cell) {
         if (cols == null)
-            cols = new ArrayList();
+            cols = new ArrayList<>();
         cols.add(cell);
     }
     
-    public void addCols(ArrayList ncols) {
+    public void addCols(List<PdfPCell> ncols) {
         if (cols == null)
-            cols = new ArrayList(ncols);
+            cols = new ArrayList<>(ncols);
         else
             cols.addAll(ncols);
     }
@@ -88,7 +87,7 @@ public class IncTable {
         }
     }
     
-    public ArrayList getRows() {
+    public List<List<PdfPCell>> getRows() {
         return rows;
     }
     
@@ -96,12 +95,11 @@ public class IncTable {
         if (rows.isEmpty())
             return new PdfPTable(1);
         int ncol = 0;
-        ArrayList c0 = (ArrayList)rows.get(0);
-        for (Object o1 : c0) {
-            ncol += ((PdfPCell) o1).getColspan();
+        for (PdfPCell pCell : rows.get(0)) {
+            ncol += pCell.getColspan();
         }
         PdfPTable table = new PdfPTable(ncol);
-        String width = (String)props.get("width");
+        String width = props.get("width");
         if (width == null)
             table.setWidthPercentage(100);
         else {
@@ -112,10 +110,9 @@ public class IncTable {
                 table.setLockedWidth(true);
             }
         }
-        for (Object row1 : rows) {
-            ArrayList col = (ArrayList) row1;
-            for (Object o : col) {
-                table.addCell((PdfPCell) o);
+        for (List<PdfPCell> col : rows) {
+            for (PdfPCell pdfPCell : col) {
+                table.addCell(pdfPCell);
             }
         }
         return table;

--- a/pdf-html/src/main/java/com/lowagie/text/html/simpleparser/StyleSheet.java
+++ b/pdf-html/src/main/java/com/lowagie/text/html/simpleparser/StyleSheet.java
@@ -52,61 +52,53 @@ package com.lowagie.text.html.simpleparser;
 
 import com.lowagie.text.html.Markup;
 import java.util.HashMap;
+import java.util.Map;
 
 public class StyleSheet {
 
-    public HashMap classMap = new HashMap();
-
-    public HashMap tagMap = new HashMap();
+    private Map<String, Map<String, String>> classMap = new HashMap<>();
+    private Map<String, Map<String, String>> tagMap = new HashMap<>();
 
     /** Creates a new instance of StyleSheet */
     public StyleSheet() {
     }
 
-    public void applyStyle(String tag, HashMap props) {
-        HashMap map = (HashMap) tagMap.get(tag.toLowerCase());
+    public void applyStyle(String tag, Map<String, String> props) {
+        Map<String, String> map = tagMap.get(tag.toLowerCase());
         if (map != null) {
-            HashMap temp = new HashMap(map);
+            Map<String, String> temp = new HashMap<>(map);
             temp.putAll(props);
             props.putAll(temp);
         }
-        String cm = (String) props.get(Markup.HTML_ATTR_CSS_CLASS);
+        String cm = props.get(Markup.HTML_ATTR_CSS_CLASS);
         if (cm == null)
             return;
-        map = (HashMap) classMap.get(cm.toLowerCase());
+        map = classMap.get(cm.toLowerCase());
         if (map == null)
             return;
         props.remove(Markup.HTML_ATTR_CSS_CLASS);
-        HashMap temp = new HashMap(map);
+        Map<String, String> temp = new HashMap<>(map);
         temp.putAll(props);
         props.putAll(temp);
     }
 
-    public void loadStyle(String style, HashMap props) {
+    public void loadStyle(String style, Map<String, String> props) {
         classMap.put(style.toLowerCase(), props);
     }
 
     public void loadStyle(String style, String key, String value) {
         style = style.toLowerCase();
-        HashMap props = (HashMap) classMap.get(style);
-        if (props == null) {
-            props = new HashMap();
-            classMap.put(style, props);
-        }
+        Map<String, String> props = classMap.computeIfAbsent(style, k -> new HashMap<>());
         props.put(key, value);
     }
 
-    public void loadTagStyle(String tag, HashMap props) {
+    public void loadTagStyle(String tag, Map<String, String> props) {
         tagMap.put(tag.toLowerCase(), props);
     }
 
     public void loadTagStyle(String tag, String key, String value) {
         tag = tag.toLowerCase();
-        HashMap props = (HashMap) tagMap.get(tag);
-        if (props == null) {
-            props = new HashMap();
-            tagMap.put(tag, props);
-        }
+        Map<String, String> props = tagMap.computeIfAbsent(tag, k -> new HashMap<>());
         props.put(key, value);
     }
 

--- a/pdf-toolbox/src/main/java/com/lowagie/toolbox/plugins/Bookmarks2XML.java
+++ b/pdf-toolbox/src/main/java/com/lowagie/toolbox/plugins/Bookmarks2XML.java
@@ -37,8 +37,8 @@ package com.lowagie.toolbox.plugins;
 
 import java.io.File;
 import java.io.FileOutputStream;
-import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import javax.swing.JInternalFrame;
 import javax.swing.JOptionPane;
@@ -87,7 +87,7 @@ public class Bookmarks2XML extends AbstractTool {
             if (getValue("pdffile") == null) throw new InstantiationException("You need to choose a source PDF file");
             PdfReader reader = new PdfReader(((File)getValue("pdffile")).getAbsolutePath());
             reader.consolidateNamedDestinations();
-            List<HashMap<String, Object>> bookmarks = SimpleBookmark.getBookmark( reader );
+            List<Map<String, Object>> bookmarks = SimpleBookmark.getBookmark( reader );
             // save them in XML format
             FileOutputStream bmWriter = new FileOutputStream( (File)getValue("xmlfile") );
             SimpleBookmark.exportToXML(bookmarks, bmWriter, "UTF-8", false);

--- a/pdf-toolbox/src/main/java/com/lowagie/toolbox/plugins/Concat.java
+++ b/pdf-toolbox/src/main/java/com/lowagie/toolbox/plugins/Concat.java
@@ -38,8 +38,8 @@ package com.lowagie.toolbox.plugins;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import javax.swing.JInternalFrame;
 
@@ -95,7 +95,7 @@ public class Concat extends AbstractTool {
             if (getValue("destfile") == null) throw new InstantiationException("You need to choose a destination file");
             File pdf_file = (File)getValue("destfile");
             int pageOffset = 0;
-            List<HashMap<String, Object>> master = new ArrayList<>();
+            List<Map<String, Object>> master = new ArrayList<>();
             Document document = null;
             PdfCopy  writer = null;
             for (int i = 0; i < 2; i++) {
@@ -104,7 +104,7 @@ public class Concat extends AbstractTool {
                 reader.consolidateNamedDestinations();
                 // we retrieve the total number of pages
                 int n = reader.getNumberOfPages();
-                List<HashMap<String, Object>> bookmarks = SimpleBookmark.getBookmark(reader);
+                List<Map<String, Object>> bookmarks = SimpleBookmark.getBookmark(reader);
                 if (bookmarks != null) {
                     if (pageOffset != 0)
                         SimpleBookmark.shiftPageNumbers(bookmarks, pageOffset, null);

--- a/pdf-toolbox/src/main/java/com/lowagie/toolbox/plugins/ConcatN.java
+++ b/pdf-toolbox/src/main/java/com/lowagie/toolbox/plugins/ConcatN.java
@@ -40,6 +40,7 @@ import java.io.FileOutputStream;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import javax.swing.JInternalFrame;
 
@@ -103,7 +104,7 @@ public class ConcatN extends AbstractTool {
             }
             File pdf_file = (File) getValue("destfile");
             int pageOffset = 0;
-            ArrayList<HashMap<String, Object>> master = new ArrayList<>();
+            List<Map<String, Object>> master = new ArrayList<>();
             Document document = null;
             PdfCopy writer = null;
             for (int i = 0; i < files.length; i++) {
@@ -112,7 +113,7 @@ public class ConcatN extends AbstractTool {
                 reader.consolidateNamedDestinations();
                 // we retrieve the total number of pages
                 int n = reader.getNumberOfPages();
-                List<HashMap<String, Object>> bookmarks = SimpleBookmark.getBookmark(reader);
+                List<Map<String, Object>> bookmarks = SimpleBookmark.getBookmark(reader);
                 if (bookmarks != null) {
                     if (pageOffset != 0) {
                         SimpleBookmark.shiftPageNumbers(bookmarks, pageOffset, null);

--- a/pdf-toolbox/src/main/java/com/lowagie/toolbox/plugins/HtmlBookmarks.java
+++ b/pdf-toolbox/src/main/java/com/lowagie/toolbox/plugins/HtmlBookmarks.java
@@ -52,6 +52,7 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.StringTokenizer;
 
 import javax.swing.JInternalFrame;
@@ -150,12 +151,12 @@ public class HtmlBookmarks extends AbstractTool {
                 Paragraph d = new Paragraph((String) description);
                 document.add(d);
             }
-            List<HashMap<String, Object>> list = SimpleBookmark.getBookmark(reader);
+            List<Map<String, Object>> list = SimpleBookmark.getBookmark(reader);
             if (list == null) {
                 document.add(new Paragraph("This document has no bookmarks."));
             }
             else {
-                for (HashMap<String, Object> c: list) {
+                for (Map<String, Object> c: list) {
                     Chapter chapter = (Chapter)createBookmark(src.getName(), null, c);
                     List<HashMap<String, Object>> kids = (List<HashMap<String, Object>>) c.get("Kids");
                     if (kids != null) {
@@ -201,7 +202,7 @@ public class HtmlBookmarks extends AbstractTool {
      * @param bookmark the bookmark that has the data for the line
      * @return a subsection of section
      */
-    private static Section createBookmark(String pdf, Section section, HashMap<String, Object> bookmark) {
+    private static Section createBookmark(String pdf, Section section, Map<String, Object> bookmark) {
         Section s;
         Paragraph title = new Paragraph((String)bookmark.get("Title"));
         System.out.println((String)bookmark.get("Title"));

--- a/pdf-toolbox/src/main/java/com/lowagie/tools/EncryptPdf.java
+++ b/pdf-toolbox/src/main/java/com/lowagie/tools/EncryptPdf.java
@@ -50,6 +50,7 @@ package com.lowagie.tools;
 
 import java.io.FileOutputStream;
 import java.util.HashMap;
+import java.util.Map;
 
 import com.lowagie.text.pdf.PdfEncryptor;
 import com.lowagie.text.pdf.PdfReader;
@@ -114,7 +115,7 @@ public class EncryptPdf {
             System.out.println("Reading " + args[INPUT_FILE]);
             PdfReader reader = new PdfReader(args[INPUT_FILE]);
             System.out.println("Writing " + args[OUTPUT_FILE]);
-            HashMap moreInfo = new HashMap();
+            Map<String, String> moreInfo = new HashMap<>();
             for (int k = MOREINFO; k < args.length - 1; k += 2)
                 moreInfo.put(args[k], args[k + 1]);
             PdfEncryptor.encrypt(reader, new FileOutputStream(args[OUTPUT_FILE]),

--- a/pdf-toolbox/src/test/java/com/lowagie/examples/general/copystamp/AddWatermarkPageNumbers.java
+++ b/pdf-toolbox/src/test/java/com/lowagie/examples/general/copystamp/AddWatermarkPageNumbers.java
@@ -15,6 +15,7 @@ package com.lowagie.examples.general.copystamp;
 
 import java.io.FileOutputStream;
 import java.util.HashMap;
+import java.util.Map;
 
 import com.lowagie.text.Element;
 import com.lowagie.text.Image;
@@ -41,7 +42,7 @@ public class AddWatermarkPageNumbers {
             // we create a stamper that will copy the document to a new file
             PdfStamper stamp = new PdfStamper(reader, new FileOutputStream("watermark_pagenumbers.pdf"));
             // adding some metadata
-            HashMap moreInfo = new HashMap();
+            Map<String, String> moreInfo = new HashMap<>();
             moreInfo.put("Author", "Bruno Lowagie");
             stamp.setMoreInfo(moreInfo);
             // adding content to each page

--- a/pdf-xml/src/main/java/com/lowagie/text/pdf/XfdfReader.java
+++ b/pdf-xml/src/main/java/com/lowagie/text/pdf/XfdfReader.java
@@ -51,10 +51,8 @@ package com.lowagie.text.pdf;
 import java.io.ByteArrayInputStream;
 import java.io.FileInputStream;
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Stack;
+import java.util.*;
+
 import com.lowagie.text.error_messages.MessageLocalization;
 
 import com.lowagie.text.xml.simpleparser.SimpleXMLDocHandler;
@@ -73,13 +71,13 @@ public class XfdfReader implements SimpleXMLDocHandler, FieldReader {
   private Stack<String> fieldValues = new Stack<>();
 
   // storage for the field list and their values
-  private HashMap<String, String> fields;
+  private Map<String, String> fields;
   /**
    * Storage for field values if there's more than one value for a field.
    *
    * @since 2.1.4
    */
-  private HashMap<String, List<String>> listFields;
+  private Map<String, List<String>> listFields;
 
   // storage for the path to referenced PDF, if any
   private String fileSpec;
@@ -112,7 +110,7 @@ public class XfdfReader implements SimpleXMLDocHandler, FieldReader {
    *
    * @return all the fields
    */
-  public HashMap<String, String> getFields() {
+  public Map<String, String> getFields() {
     return fields;
   }
 
@@ -133,12 +131,7 @@ public class XfdfReader implements SimpleXMLDocHandler, FieldReader {
    * @return the field value or <CODE>null</CODE>
    */
   public String getFieldValue(String name) {
-    String field = fields.get(name);
-    if (field == null) {
-      return null;
-    } else {
-      return field;
-    }
+    return fields.get(name);
   }
 
   /**
@@ -167,7 +160,7 @@ public class XfdfReader implements SimpleXMLDocHandler, FieldReader {
    * @param tag the tag name
    * @param h the tag's attributes
    */
-  public void startElement(String tag, HashMap h) {
+  public void startElement(String tag, Map<String, String> h) {
     if (!foundRoot) {
       if (!tag.equals("xfdf")) {
         throw new RuntimeException(MessageLocalization.getComposedMessage("root.element.is.not.xfdf.1", tag));
@@ -181,7 +174,7 @@ public class XfdfReader implements SimpleXMLDocHandler, FieldReader {
         // intentionally left blank
         break;
       case "f":
-        fileSpec = (String) h.get("href");
+        fileSpec = h.get("href");
         break;
       case "fields":
         fields = new HashMap<>();    // init it!
@@ -189,7 +182,7 @@ public class XfdfReader implements SimpleXMLDocHandler, FieldReader {
         listFields = new HashMap<>();
         break;
       case "field":
-        String fName = (String) h.get("name");
+        String fName = h.get("name");
         fieldNames.push(fName);
         break;
       case "value":

--- a/pdf-xml/src/main/java/com/lowagie/text/xml/TagMap.java
+++ b/pdf-xml/src/main/java/com/lowagie/text/xml/TagMap.java
@@ -61,12 +61,13 @@ import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.InputStream;
 import java.util.HashMap;
+import java.util.Map;
 
 /**
  * The <CODE>Tags</CODE>-class maps several XHTML-tags to iText-objects.
  */
 
-public class TagMap extends HashMap {
+public class TagMap extends HashMap<String, XmlPeer> {
 
     private static final long serialVersionUID = -6809383366554350820L;
 
@@ -91,7 +92,7 @@ public class TagMap extends HashMap {
         public static final String CONTENT = "content";
         
 /** This is the tagmap using the AttributeHandler */
-        private HashMap tagMap;
+        private Map<String, XmlPeer> tagMap;
         
 /** This is the current peer. */
         private XmlPeer currentPeer;
@@ -103,8 +104,7 @@ public class TagMap extends HashMap {
  * @param    tagMap  A Hashmap containing XmlPeer-objects
  */
         
-        public AttributeHandler(HashMap tagMap) {
-            super();
+        public AttributeHandler(Map<String, XmlPeer> tagMap) {
             this.tagMap = tagMap;
         }
         
@@ -183,7 +183,6 @@ public class TagMap extends HashMap {
      * @param tagfile the path to an XML file with the tagmap
      */
     public TagMap(String tagfile) {
-        super();
         try {
             init(TagMap.class.getClassLoader().getResourceAsStream(tagfile));
         }catch(Exception e) {
@@ -200,7 +199,6 @@ public class TagMap extends HashMap {
      * @param in    An InputStream with the tagmap xml
      */
     public TagMap(InputStream in) {
-        super();
         init(in);
     }
 


### PR DESCRIPTION
Replaced couple of bouncycastle deprecated  calls to their new API, replaced `new Float(String)` with `Float.parseFloat(String)`, moving lots of raw types to generics.