### PR TITLE
fix NPE in PdfWriter#getNewObjectNumber

### DIFF
--- a/openpdf/src/main/java/com/lowagie/text/pdf/PdfWriter.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/PdfWriter.java
@@ -2283,7 +2283,13 @@ public class PdfWriter extends DocWriter implements
     protected PdfReaderInstance currentPdfReaderInstance;
 
     protected int getNewObjectNumber(PdfReader reader, int number, int generation) {
-        return currentPdfReaderInstance.getNewObjectNumber(number, generation);
+        if (currentPdfReaderInstance == null && importedPages.get(reader) == null) {
+            importedPages.put(reader, reader.getPdfReaderInstance(this));
+        }
+        currentPdfReaderInstance = importedPages.get(reader);
+        int n = currentPdfReaderInstance.getNewObjectNumber(number, generation);
+        currentPdfReaderInstance = null;
+        return n;
     }
 
     RandomAccessFileOrArray getReaderFile(PdfReader reader) {


### PR DESCRIPTION
When trying to add an indirect reference with `PdfWriter`, an NPE occurs because `currentPdfReaderInstance` is null. This fix ensures that it is using the correct `PdfReaderInstance` via the `importedPages` field.

I'm not entirely sure why `currentPdfReaderInstance` exists at all, since it is immediately reset to `null` after any methods that use it, but I used it in this fix for consistency's sake.