### PR TITLE
Allow overriding File ID

### DIFF
--- a/openpdf/src/main/java/com/lowagie/text/pdf/PdfName.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/PdfName.java
@@ -584,6 +584,8 @@ public class PdfName extends PdfObject implements Comparable{
     /** A name */
     public static final PdfName FILEATTACHMENT = new PdfName("FileAttachment");
     /** A name */
+    public static final PdfName FILEID = new PdfName("FileId");
+    /** A name */
     public static final PdfName FILESPEC = new PdfName("Filespec");
     /** A name */
     public static final PdfName FILTER = new PdfName("Filter");

--- a/openpdf/src/main/java/com/lowagie/text/pdf/PdfWriter.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/PdfWriter.java
@@ -1222,9 +1222,11 @@ public class PdfWriter extends DocWriter implements
                     PdfIndirectObject encryptionObject = addToBody(crypto.getEncryptionDictionary(), false);
                     encryption = encryptionObject.getIndirectReference();
                     fileID = crypto.getFileID();
-                }
-                else
+                } else if (getInfo().contains(PdfName.FILEID)) {
+                    fileID = getInfo().get(PdfName.FILEID);
+                } else {
                     fileID = PdfEncryption.createInfoId(PdfEncryption.createDocumentId());
+                }
 
                 // write the cross-reference table of the body
                 body.writeCrossReferenceTable(os, indirectCatalog.getIndirectReference(),


### PR DESCRIPTION
This change adds new PdfName - FILEID that can be used to override generated File ID (if encryption is not used). Overridden File ID allows deterministic creation of PDFs that is especially useful during tests.

**Note:** this change works and generates deterministic PDFs but I'm not sure if this is a right approach. If yes then I could add unit tests that utilize this property (if you think it's a good idea).