### PR TITLE
Fix writing of large (>2GB) pdfs

### DIFF
--- a/openpdf/src/main/java/com/lowagie/text/pdf/OutputStreamCounter.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/OutputStreamCounter.java
@@ -55,7 +55,7 @@ import java.io.OutputStream;
 public class OutputStreamCounter extends OutputStream {
     
     protected OutputStream out;
-    protected int counter = 0;
+    protected long counter = 0;
     
     /** Creates a new instance of OutputStreamCounter */
     public OutputStreamCounter(OutputStream out) {
@@ -160,7 +160,7 @@ public class OutputStreamCounter extends OutputStream {
         out.write(b, off, len);
     }
     
-    public int getCounter() {
+    public long getCounter() {
         return counter;
     }
     

--- a/openpdf/src/main/java/com/lowagie/text/pdf/PdfLiteral.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/PdfLiteral.java
@@ -58,7 +58,7 @@ public class PdfLiteral extends PdfObject {
     /**
      * Holds value of property position.
      */
-    private int position;
+    private long position;
         
     public PdfLiteral(String text) {
         super(0, text);
@@ -92,7 +92,7 @@ public class PdfLiteral extends PdfObject {
      * Getter for property position.
      * @return Value of property position.
      */
-    public int getPosition() {
+    public long getPosition() {
         return this.position;
     }
     

--- a/openpdf/src/main/java/com/lowagie/text/pdf/PdfNumber.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/PdfNumber.java
@@ -102,6 +102,17 @@ public class PdfNumber extends PdfObject {
     }
     
     /**
+     * Constructs a new <CODE>PdfNumber</CODE>-object of type long.
+     *
+     * @param value    value of the new <CODE>PdfNumber</CODE>-object
+     */
+    public PdfNumber(long value) {
+        super(NUMBER);
+        this.value = value;
+        setContent(String.valueOf(value));
+    }
+
+    /**
      * Constructs a new <CODE>PdfNumber</CODE>-object of type real.
      *
      * @param value    value of the new <CODE>PdfNumber</CODE>-object

--- a/openpdf/src/main/java/com/lowagie/text/pdf/PdfSignatureAppearance.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/PdfSignatureAppearance.java
@@ -139,7 +139,7 @@ public class PdfSignatureAppearance {
   private PdfStamper stamper;
   private boolean preClosed = false;
   private PdfSigGenericPKCS sigStandard;
-  private int[] range;
+  private long[] range;
   private RandomAccessFile raf;
   private byte[] bout;
   private int boutLen;
@@ -1111,14 +1111,14 @@ public class PdfSignatureAppearance {
     }
     writer.close(stamper.getInfoDictionary());
 
-    range = new int[exclusionLocations.size() * 2];
-    int byteRangePosition = ((PdfLiteral) exclusionLocations
+    range = new long[exclusionLocations.size() * 2];
+    long byteRangePosition = ((PdfLiteral) exclusionLocations
         .get(PdfName.BYTERANGE)).getPosition();
     exclusionLocations.remove(PdfName.BYTERANGE);
     int idx = 1;
       for (Object o : exclusionLocations.values()) {
           PdfLiteral lit = (PdfLiteral) o;
-          int n = lit.getPosition();
+          long n = lit.getPosition();
           range[idx++] = n;
           range[idx++] = lit.getPosLength() + n;
       }
@@ -1132,17 +1132,17 @@ public class PdfSignatureAppearance {
       range[range.length - 1] = boutLen - range[range.length - 2];
       ByteBuffer bf = new ByteBuffer();
       bf.append('[');
-        for (int i : range) bf.append(i).append(' ');
+        for (long i : range) bf.append(i).append(' ');
       bf.append(']');
-      System.arraycopy(bf.getBuffer(), 0, bout, byteRangePosition, bf.size());
+      System.arraycopy(bf.getBuffer(), 0, bout, (int) byteRangePosition, bf.size());
     } else {
       try {
         raf = new RandomAccessFile(tempFile, "rw");
-        int boutL = (int) raf.length();
+        long boutL = raf.length();
         range[range.length - 1] = boutL - range[range.length - 2];
         ByteBuffer bf = new ByteBuffer();
         bf.append('[');
-          for (int i : range) bf.append(i).append(' ');
+          for (long i : range) bf.append(i).append(' ');
         bf.append(']');
         raf.seek(byteRangePosition);
         raf.write(bf.getBuffer(), 0, bf.size());
@@ -1197,7 +1197,7 @@ public class PdfSignatureAppearance {
                                 "the.key.1.is.too.big.is.2.reserved.3", key.toString(),
                                 String.valueOf(bf.size()), String.valueOf(lit.getPosLength())));
             if (tempFile == null)
-                System.arraycopy(bf.getBuffer(), 0, bout, lit.getPosition(),
+                System.arraycopy(bf.getBuffer(), 0, bout, (int) lit.getPosition(),
                         bf.size());
             else {
                 raf.seek(lit.getPosition());
@@ -1213,10 +1213,10 @@ public class PdfSignatureAppearance {
       } else {
         if (originalout != null) {
           raf.seek(0);
-          int length = (int) raf.length();
+          long length = raf.length();
           byte[] buf = new byte[8192];
           while (length > 0) {
-            int r = raf.read(buf, 0, Math.min(buf.length, length));
+            int r = raf.read(buf, 0, (int) Math.min(buf.length, length));
             if (r < 0)
               throw new EOFException(
                   MessageLocalization.getComposedMessage("unexpected.eof"));
@@ -1543,10 +1543,10 @@ public class PdfSignatureAppearance {
     private final byte[] b = new byte[1];
     private final RandomAccessFile raf;
     private final byte[] bout;
-    private final int[] range;
-    private int rangePosition = 0;
+    private final long[] range;
+    private long rangePosition = 0;
 
-    private RangeStream(RandomAccessFile raf, byte[] bout, int[] range) {
+    private RangeStream(RandomAccessFile raf, byte[] bout, long[] range) {
       this.raf = raf;
       this.bout = bout;
       this.range = range;
@@ -1580,14 +1580,14 @@ public class PdfSignatureAppearance {
         return -1;
       }
       for (int k = 0; k < range.length; k += 2) {
-        int start = range[k];
-        int end = start + range[k + 1];
+        long start = range[k];
+        long end = start + range[k + 1];
         if (rangePosition < start)
           rangePosition = start;
         if (rangePosition >= start && rangePosition < end) {
-          int lenf = Math.min(len, end - rangePosition);
+          int lenf = (int) Math.min(len, end - rangePosition);
           if (raf == null)
-            System.arraycopy(bout, rangePosition, b, off, lenf);
+            System.arraycopy(bout, (int) rangePosition, b, off, lenf);
           else {
             raf.seek(rangePosition);
             raf.readFully(b, off, lenf);

--- a/openpdf/src/main/java/com/lowagie/text/pdf/PdfStamperImp.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/PdfStamperImp.java
@@ -326,20 +326,9 @@ class PdfStamperImp extends PdfWriter {
         }
         // write the cross-reference table of the body
         body.writeCrossReferenceTable(os, root, info, encryption, fileID, prevxref);
-        if (fullCompression) {
-            os.write(getISOBytes("startxref\n"));
-            os.write(getISOBytes(String.valueOf(body.offset())));
-            os.write(getISOBytes("\n%%EOF\n"));
-        }
-        else {
-            PdfTrailer trailer = new PdfTrailer(body.size(),
-            body.offset(),
-            root,
-            info,
-            encryption,
-            fileID, prevxref);
-            trailer.toPdf(this, os);
-        }
+        os.write(getISOBytes("startxref\n"));
+        os.write(getISOBytes(String.valueOf(body.offset())));
+        os.write(getISOBytes("\n%%EOF\n"));
         os.flush();
         if (isCloseStream())
             os.close();

--- a/openpdf/src/main/java/com/lowagie/text/pdf/PdfStream.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/PdfStream.java
@@ -120,9 +120,9 @@ public class PdfStream extends PdfDictionary {
     protected ByteArrayOutputStream streamBytes = null;
     protected InputStream inputStream;
     protected PdfIndirectReference ref;
-    protected int inputStreamLength = -1;
+    protected long inputStreamLength = -1;
     protected PdfWriter writer;
-    protected int rawLength;
+    protected long rawLength;
 
     static final byte[] STARTSTREAM = DocWriter.getISOBytes("stream\n");
     static final byte[] ENDSTREAM = DocWriter.getISOBytes("\nendstream");
@@ -197,7 +197,7 @@ public class PdfStream extends PdfDictionary {
      * Gets the raw length of the stream.
      * @return the raw length of the stream
      */
-    public int getRawLength() {
+    public long getRawLength() {
         return rawLength;
     }
     

--- a/openpdf/src/main/java/com/lowagie/text/pdf/PdfWriter.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/PdfWriter.java
@@ -154,7 +154,7 @@ public class PdfWriter extends DocWriter implements
             private int type;
 
             /**    Byte offset in the PDF file. */
-            private int offset;
+            private long offset;
 
             private int refnum;
             /**    generation of the object. */
@@ -168,7 +168,7 @@ public class PdfWriter extends DocWriter implements
              * @param    generation    generation number of the object
              */
 
-            public PdfCrossReference(int refnum, int offset, int generation) {
+            public PdfCrossReference(int refnum, long offset, int generation) {
                 type = 0;
                 this.offset = offset;
                 this.refnum = refnum;
@@ -181,14 +181,14 @@ public class PdfWriter extends DocWriter implements
              * @param    offset        byte offset of the object
              */
 
-            public PdfCrossReference(int refnum, int offset) {
+            public PdfCrossReference(int refnum, long offset) {
                 type = 1;
                 this.offset = offset;
                 this.refnum = refnum;
                 this.generation = 0;
             }
 
-            public PdfCrossReference(int type, int refnum, int offset, int generation) {
+            public PdfCrossReference(int type, int refnum, long offset, int generation) {
                 this.type = type;
                 this.offset = offset;
                 this.refnum = refnum;
@@ -264,7 +264,7 @@ public class PdfWriter extends DocWriter implements
         private TreeSet<PdfCrossReference> xrefs;
         private int refnum;
         /** the current byte position in the body. */
-        private int position;
+        private long position;
         private PdfWriter writer;
         private ByteBuffer index;
         private ByteBuffer streamObjects;
@@ -421,7 +421,7 @@ public class PdfWriter extends DocWriter implements
          * @return        an offset
          */
 
-        int offset() {
+        long offset() {
             return position;
         }
 
@@ -448,7 +448,9 @@ public class PdfWriter extends DocWriter implements
 
         void writeCrossReferenceTable(OutputStream os, PdfIndirectReference root, PdfIndirectReference info, PdfIndirectReference encryption, PdfObject fileID, int prevxref) throws IOException {
             int refNumber = 0;
-            if (writer.isFullCompression()) {
+            // Old-style xref tables limit object offsets to 10 digits
+            boolean useNewXrefFormat = writer.isFullCompression() || position > 9_999_999_999L;
+            if (useNewXrefFormat) {
                 flushObjStm();
                 refNumber = getIndirectReferenceNumber();
                 xrefs.add(new PdfCrossReference(refNumber, position));
@@ -471,14 +473,8 @@ public class PdfWriter extends DocWriter implements
             sections.add(first);
             sections.add(len);
             PdfTrailer trailer = new PdfTrailer(size(), root, info, encryption, fileID, prevxref);
-            if (writer.isFullCompression()) {
-                int mid = 4;
-                int mask = 0xff000000;
-                for (; mid > 1; --mid) {
-                    if ((mask & position) != 0)
-                        break;
-                    mask >>>= 8;
-                }
+            if (useNewXrefFormat) {
+                int mid = 8 - (Long.numberOfLeadingZeros(position) >> 3);
                 ByteBuffer buf = new ByteBuffer();
 
                 for (PdfCrossReference xref : xrefs) {
@@ -2256,7 +2252,7 @@ public class PdfWriter extends DocWriter implements
      * the current size is needed.
      * @return the approximate size without fonts or templates
      */
-    public int getCurrentDocumentSize() {
+    public long getCurrentDocumentSize() {
         return body.offset() + body.size() * 20 + 0x48;
     }
 


### PR DESCRIPTION
OpenPDF lets you write PDFs larger than 2GB, but the resulting file has a broken xref table, so programs either won't open the PDF or will take forever trying to rebuild the xref. (https://github.com/LibrePDF/OpenPDF/issues/182) This PR fixes the issue, allowing writing PDFs of arbitrary size.

