### PR TITLE
Fix using Document in try-with-resources

### DIFF
--- a/openpdf/src/main/java/com/lowagie/text/DocWriter.java
+++ b/openpdf/src/main/java/com/lowagie/text/DocWriter.java
@@ -281,6 +281,9 @@ public abstract class DocWriter implements DocListener {
  */
 
     public void close() {
+        if (!open) {
+            return;
+        }
         open = false;
         try {
             os.flush();

--- a/openpdf/src/test/java/com/lowagie/text/pdf/SimplePdfTest.java
+++ b/openpdf/src/test/java/com/lowagie/text/pdf/SimplePdfTest.java
@@ -1,5 +1,8 @@
 package com.lowagie.text.pdf;
 
+import java.io.File;
+import java.io.FileOutputStream;
+
 import com.lowagie.text.Annotation;
 import com.lowagie.text.Document;
 import com.lowagie.text.Rectangle;
@@ -27,4 +30,19 @@ public class SimplePdfTest {
 
     }
 
+    @Test
+    void testTryWithResources() throws Exception {
+        try (PdfReader reader = new PdfReader("./src/test/resources/HelloWorldMeta.pdf");
+            Document document = new Document();
+            FileOutputStream os = new FileOutputStream(File.createTempFile("temp-file-name", ".pdf"));
+            PdfWriter writer = PdfWriter.getInstance(document, os);
+            ) {
+            document.open();
+            final PdfContentByte cb = writer.getDirectContent();
+
+            document.newPage();
+            PdfImportedPage page = writer.getImportedPage(reader, 1);
+            cb.addTemplate(page, 1, 0, 0, 1, 0, 0);
+        }
+    }
 }


### PR DESCRIPTION
If the Document object has already been closed or was not opened do nothing in `close` method. If it's already closed it would trigger `Stream Closed` exception.

Fixes #197.