### PR TITLE
Fix warnings

### DIFF
--- a/openpdf/src/main/java/com/lowagie/text/pdf/codec/wmf/MetaState.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/codec/wmf/MetaState.java
@@ -52,6 +52,7 @@ package com.lowagie.text.pdf.codec.wmf;
 import java.awt.Color;
 import java.awt.Point;
 import java.util.ArrayList;
+import java.util.List;
 import java.util.Stack;
 
 import com.lowagie.text.pdf.PdfContentByte;
@@ -73,8 +74,8 @@ public class MetaState {
     public static final int ALTERNATE = 1;
     public static final int WINDING = 2;
 
-    public Stack savedStates;
-    public ArrayList MetaObjects;
+    public Stack<MetaState> savedStates;
+    public List<Object> MetaObjects;
     public Point currentPoint;
     public MetaPen currentPen;
     public MetaBrush currentBrush;
@@ -95,8 +96,8 @@ public class MetaState {
 
     /** Creates new MetaState */
     public MetaState() {
-        savedStates = new Stack();
-        MetaObjects = new ArrayList();
+        savedStates = new Stack<>();
+        MetaObjects = new ArrayList<>();
         currentPoint = new Point(0, 0);
         currentPen = new MetaPen();
         currentBrush = new MetaBrush();

--- a/openpdf/src/main/java/com/lowagie/text/pdf/crypto/AESCipher.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/crypto/AESCipher.java
@@ -49,7 +49,7 @@
 package com.lowagie.text.pdf.crypto;
 
 import org.bouncycastle.crypto.BlockCipher;
-import org.bouncycastle.crypto.engines.AESFastEngine;
+import org.bouncycastle.crypto.engines.AESEngine;
 import org.bouncycastle.crypto.modes.CBCBlockCipher;
 import org.bouncycastle.crypto.paddings.PaddedBufferedBlockCipher;
 import org.bouncycastle.crypto.params.KeyParameter;
@@ -65,7 +65,7 @@ public class AESCipher {
 
   /** Creates a new instance of AESCipher */
   public AESCipher(boolean forEncryption, byte[] key, byte[] iv) {
-    BlockCipher aes = new AESFastEngine();
+    BlockCipher aes = new AESEngine();
     BlockCipher cbc = new CBCBlockCipher(aes);
     bp = new PaddedBufferedBlockCipher(cbc);
     KeyParameter kp = new KeyParameter(key);

--- a/openpdf/src/main/java/com/lowagie/text/pdf/events/FieldPositioningEvents.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/events/FieldPositioningEvents.java
@@ -48,6 +48,8 @@ package com.lowagie.text.pdf.events;
 
 import java.io.IOException;
 import java.util.HashMap;
+import java.util.Map;
+
 import com.lowagie.text.error_messages.MessageLocalization;
 
 import com.lowagie.text.Document;
@@ -73,7 +75,7 @@ public class FieldPositioningEvents extends PdfPageEventHelper implements PdfPCe
     /**
      * Keeps a map with fields that are to be positioned in inGenericTag.
      */
-    protected HashMap genericChunkFields = new HashMap();
+    protected Map<String, PdfFormField> genericChunkFields = new HashMap<>();
 
     /**
      * Keeps the form field that is to be positioned in a cellLayout event.
@@ -153,7 +155,7 @@ public class FieldPositioningEvents extends PdfPageEventHelper implements PdfPCe
     public void onGenericTag(PdfWriter writer, Document document,
             Rectangle rect, String text) {
         rect.setBottom(rect.getBottom() - 3);
-        PdfFormField field = (PdfFormField) genericChunkFields.get(text);
+        PdfFormField field = genericChunkFields.get(text);
         if (field == null) {
             TextField tf = new TextField(writer, new Rectangle(rect.getLeft(padding), rect.getBottom(padding), rect.getRight(padding), rect.getTop(padding)), text);
             tf.setFontSize(14);

--- a/openpdf/src/main/java/com/lowagie/text/pdf/events/IndexEvents.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/events/IndexEvents.java
@@ -69,7 +69,7 @@ public class IndexEvents extends PdfPageEventHelper {
     /**
      * keeps the indextag with the pagenumber
      */
-    private Map indextag = new TreeMap();
+    private Map<String, Integer> indextag = new TreeMap<>();
 
     /**
      * All the text that is passed to this event, gets registered in the indexentry.
@@ -92,7 +92,7 @@ public class IndexEvents extends PdfPageEventHelper {
     /**
      * the list for the index entry
      */
-    private List indexentry = new ArrayList();
+    private List<Entry> indexentry = new ArrayList<>();
 
     /**
      * Create an index entry.
@@ -180,9 +180,7 @@ public class IndexEvents extends PdfPageEventHelper {
     /**
      * Comparator for sorting the index
      */
-    private Comparator comparator = (arg0, arg1) -> {
-        Entry en1 = (Entry) arg0;
-        Entry en2 = (Entry) arg1;
+    private Comparator<Entry> comparator = (en1, en2) -> {
 
         int rt = 0;
         if (en1.getIn1() != null && en2.getIn1() != null) {
@@ -207,7 +205,7 @@ public class IndexEvents extends PdfPageEventHelper {
      * Set the comparator.
      * @param aComparator The comparator to set.
      */
-    public void setComparator(Comparator aComparator) {
+    public void setComparator(Comparator<Entry> aComparator) {
         comparator = aComparator;
     }
 
@@ -215,15 +213,14 @@ public class IndexEvents extends PdfPageEventHelper {
      * Returns the sorted list with the entries and the collected page numbers.
      * @return Returns the sorted list with the entries and the collected page numbers.
      */
-    public List getSortedEntries() {
+    public List<Entry> getSortedEntries() {
 
-        Map grouped = new HashMap();
+        Map<String, Entry> grouped = new HashMap<>();
 
-        for (Object o : indexentry) {
-            Entry e = (Entry) o;
+        for (Entry e : indexentry) {
             String key = e.getKey();
 
-            Entry master = (Entry) grouped.get(key);
+            Entry master = grouped.get(key);
             if (master != null) {
                 master.addPageNumberAndTag(e.getPageNumber(), e.getTag());
             } else {
@@ -233,7 +230,7 @@ public class IndexEvents extends PdfPageEventHelper {
         }
 
         // copy to a list and sort it
-        List sorted = new ArrayList(grouped.values());
+        List<Entry> sorted = new ArrayList<>(grouped.values());
         sorted.sort(comparator);
         return sorted;
     }
@@ -271,12 +268,12 @@ public class IndexEvents extends PdfPageEventHelper {
         /**
          * the list of all page numbers.
          */
-        private List pagenumbers = new ArrayList();
+        private List<Integer> pagenumbers = new ArrayList<>();
 
         /**
          * the list of all tags.
          */
-        private List tags = new ArrayList();
+        private List<String> tags = new ArrayList<>();
 
         /**
          * Create a new object.

--- a/openpdf/src/main/java/com/lowagie/text/pdf/events/PdfPCellEventForwarder.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/events/PdfPCellEventForwarder.java
@@ -50,6 +50,7 @@
 package com.lowagie.text.pdf.events;
 
 import java.util.ArrayList;
+import java.util.List;
 
 import com.lowagie.text.Rectangle;
 import com.lowagie.text.pdf.PdfContentByte;
@@ -66,7 +67,7 @@ import com.lowagie.text.pdf.PdfPCellEvent;
 public class PdfPCellEventForwarder implements PdfPCellEvent {
 
     /** ArrayList containing all the PageEvents that have to be executed. */
-    protected ArrayList events = new ArrayList();
+    protected List<PdfPCellEvent> events = new ArrayList<>();
     
     /** 
      * Add a page event to the forwarder.

--- a/openpdf/src/main/java/com/lowagie/text/pdf/events/PdfPTableEventForwarder.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/events/PdfPTableEventForwarder.java
@@ -50,6 +50,7 @@
 package com.lowagie.text.pdf.events;
 
 import java.util.ArrayList;
+import java.util.List;
 
 import com.lowagie.text.pdf.PdfContentByte;
 import com.lowagie.text.pdf.PdfPTable;
@@ -65,7 +66,7 @@ import com.lowagie.text.pdf.PdfPTableEvent;
 public class PdfPTableEventForwarder implements PdfPTableEvent {
 
     /** ArrayList containing all the PageEvents that have to be executed. */
-    protected ArrayList events = new ArrayList();
+    protected List<PdfPTableEvent> events = new ArrayList<>();
     
     /** 
      * Add a page event to the forwarder.

--- a/openpdf/src/main/java/com/lowagie/text/pdf/events/PdfPageEventForwarder.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/events/PdfPageEventForwarder.java
@@ -50,6 +50,7 @@
 package com.lowagie.text.pdf.events;
 
 import java.util.ArrayList;
+import java.util.List;
 
 import com.lowagie.text.Document;
 import com.lowagie.text.Paragraph;
@@ -67,7 +68,7 @@ import com.lowagie.text.pdf.PdfWriter;
 public class PdfPageEventForwarder implements PdfPageEvent {
 
     /** ArrayList containing all the PageEvents that have to be executed. */
-    protected ArrayList events = new ArrayList();
+    protected List<PdfPageEvent> events = new ArrayList<>();
     
     /** 
      * Add a page event to the forwarder.


### PR DESCRIPTION
In the AESCipher.java class, I've replaced the AESFastEngine by AESEngine as the first one is deprecated. I used the AESEngine as replacement as it is the one suggested by the JavaDoc.

In the other classes, I've replace the use of raw Map to the parametrised type. 

I've also replaced raw ArrayList by the parametrised interface List<>. These changes may be broking ones as some fields are protected. 