### PR TITLE
Fix Warnings

### DIFF
--- a/openpdf/src/main/java/com/lowagie/text/error_messages/MessageLocalization.java
+++ b/openpdf/src/main/java/com/lowagie/text/error_messages/MessageLocalization.java
@@ -56,6 +56,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
+import java.util.Map;
 
 /**
  * Localizes error messages. The messages are located in the package
@@ -65,8 +66,8 @@ import java.util.HashMap;
  * @author Paulo Soares (psoares@glintt.com)
  */
 public final class MessageLocalization {
-    private static HashMap defaultLanguage = new HashMap();
-    private static HashMap currentLanguage;
+    private static Map<String, String> defaultLanguage = new HashMap<>();
+    private static Map<String, String> currentLanguage;
     private static final String BASE_PATH = "com/lowagie/text/error_messages/";
 
     private MessageLocalization() {
@@ -79,7 +80,7 @@ public final class MessageLocalization {
             // do nothing
         }
         if (defaultLanguage == null)
-            defaultLanguage = new HashMap();
+            defaultLanguage = new HashMap<>();
     }
 
     /**
@@ -88,15 +89,15 @@ public final class MessageLocalization {
      * @return the message
      */
     public static String getMessage(String key) {
-        HashMap cl = currentLanguage;
+        Map<String, String> cl = currentLanguage;
         String val;
         if (cl != null) {
-            val = (String)cl.get(key);
+            val = cl.get(key);
             if (val != null)
                 return val;
         }
         cl = defaultLanguage;
-        val = (String)cl.get(key);
+        val = cl.get(key);
         if (val != null)
             return val;
         return "No message found for " + key;
@@ -195,7 +196,7 @@ public final class MessageLocalization {
      * @throws IOException on error
      */
     public static boolean setLanguage(String language, String country) throws IOException {
-        HashMap lang = getLanguageMessages(language, country);
+        Map<String, String> lang = getLanguageMessages(language, country);
         if (lang == null)
             return false;
         currentLanguage = lang;
@@ -211,7 +212,7 @@ public final class MessageLocalization {
         currentLanguage = readLanguageStream(r);
     }
 
-    private static HashMap getLanguageMessages(String language, String country) throws IOException {
+    private static Map<String, String> getLanguageMessages(String language, String country) throws IOException {
         if (language == null)
             throw new IllegalArgumentException("The language cannot be null.");
         InputStream is = null;
@@ -242,12 +243,12 @@ public final class MessageLocalization {
         }
     }
 
-    private static HashMap readLanguageStream(InputStream is) throws IOException {
+    private static Map<String, String> readLanguageStream(InputStream is) throws IOException {
         return readLanguageStream(new InputStreamReader(is, StandardCharsets.UTF_8));
     }
 
-    private static HashMap readLanguageStream(Reader r) throws IOException {
-        HashMap lang = new HashMap();
+    private static Map<String, String> readLanguageStream(Reader r) throws IOException {
+        Map<String, String> lang = new HashMap<>();
         BufferedReader br = new BufferedReader(r);
         String line;
         while ((line = br.readLine()) != null) {

--- a/openpdf/src/main/java/com/lowagie/text/factories/ElementFactory.java
+++ b/openpdf/src/main/java/com/lowagie/text/factories/ElementFactory.java
@@ -57,6 +57,9 @@ import java.net.MalformedURLException;
 import java.util.ArrayList;
 import java.util.Properties;
 import java.util.StringTokenizer;
+
+import com.lowagie.text.alignment.HorizontalAlignment;
+import com.lowagie.text.alignment.VerticalAlignment;
 import com.lowagie.text.error_messages.MessageLocalization;
 
 import com.lowagie.text.Anchor;
@@ -288,10 +291,26 @@ public class ElementFactory {
         Cell cell = new Cell();
         String value;
 
-        cell.setHorizontalAlignment(attributes
-                .getProperty(ElementTags.HORIZONTALALIGN));
-        cell.setVerticalAlignment(attributes
-                .getProperty(ElementTags.VERTICALALIGN));
+        try {
+            if (attributes.getProperty(ElementTags.HORIZONTALALIGN) != null) {
+                final HorizontalAlignment horizontalAlignment = HorizontalAlignment.valueOf(attributes.getProperty(ElementTags.HORIZONTALALIGN));
+                cell.setHorizontalAlignment(horizontalAlignment);
+            } else {
+                cell.setHorizontalAlignment(HorizontalAlignment.UNDEFINED);
+            }
+        } catch (IllegalArgumentException exc) {
+            cell.setHorizontalAlignment(HorizontalAlignment.UNDEFINED);
+        }
+        try {
+            if (attributes.getProperty(ElementTags.VERTICALALIGN) != null) {
+                final VerticalAlignment verticalAlignment = VerticalAlignment.valueOf(attributes.getProperty(ElementTags.VERTICALALIGN));
+                cell.setVerticalAlignment(verticalAlignment);
+            } else {
+                cell.setVerticalAlignment(VerticalAlignment.UNDEFINED);
+            }
+        } catch (IllegalArgumentException exc) {
+            cell.setVerticalAlignment(VerticalAlignment.UNDEFINED);
+        }
 
         value = attributes.getProperty(ElementTags.WIDTH);
         if (value != null) {
@@ -331,14 +350,14 @@ public class ElementFactory {
             value = attributes.getProperty(ElementTags.WIDTHS);
             if (value != null) {
                 StringTokenizer widthTokens = new StringTokenizer(value, ";");
-                ArrayList values = new ArrayList();
+                java.util.List<String> values = new ArrayList<>();
                 while (widthTokens.hasMoreTokens()) {
                     values.add(widthTokens.nextToken());
                 }
                 table = new Table(values.size());
                 float[] widths = new float[table.getColumns()];
                 for (int i = 0; i < values.size(); i++) {
-                    value = (String) values.get(i);
+                    value = values.get(i);
                     widths[i] = Float.parseFloat(value + "f");
                 }
                 table.setWidths(widths);
@@ -361,7 +380,12 @@ public class ElementFactory {
             }
             value = attributes.getProperty(ElementTags.ALIGN);
             if (value != null) {
-                table.setAlignment(value);
+                try {
+                    final HorizontalAlignment horizontalAlignment = HorizontalAlignment.valueOf(value);
+                    table.setHorizontalAlignment(horizontalAlignment);
+                } catch (IllegalArgumentException exc) {
+                    table.setHorizontalAlignment(HorizontalAlignment.UNDEFINED);
+                }
             }
             value = attributes.getProperty(ElementTags.CELLSPACING);
             if (value != null) {

--- a/openpdf/src/main/java/com/lowagie/text/pdf/fonts/cmaps/CMap.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/fonts/cmaps/CMap.java
@@ -46,9 +46,9 @@ import java.util.Map;
  */
 public class CMap
 {
-    private List codeSpaceRanges = new ArrayList();
-    private Map singleByteMappings = new HashMap();
-    private Map doubleByteMappings = new HashMap();
+    private List<CodespaceRange> codeSpaceRanges = new ArrayList<>();
+    private Map<Integer, String> singleByteMappings = new HashMap<>();
+    private Map<Integer, String> doubleByteMappings = new HashMap<>();
 
     /**
      * Creates a new instance of CMap.
@@ -90,10 +90,10 @@ public class CMap
     {
         String result = null;
         if (hasTwoByteMappings()) {
-            result = (String) doubleByteMappings.get((int) code);
+            result = doubleByteMappings.get((int) code);
         }
         if (result == null && code <= 0xff && hasOneByteMappings()) {
-            result = (String) singleByteMappings.get(code & 0xff);
+            result = singleByteMappings.get(code & 0xff);
         }
         return result;
     }
@@ -116,7 +116,7 @@ public class CMap
         {
             
             key = code[offset] & 0xff;
-            result = (String)singleByteMappings.get( key );
+            result = singleByteMappings.get( key );
         }
         else if( length == 2 )
         {
@@ -125,7 +125,7 @@ public class CMap
             intKey += code[offset+1] & 0xff;
             key = intKey;
 
-            result = (String)doubleByteMappings.get( key );
+            result = doubleByteMappings.get( key );
         }
 
         return result;

--- a/openpdf/src/main/java/com/lowagie/text/pdf/fonts/cmaps/CMapParser.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/fonts/cmaps/CMapParser.java
@@ -217,7 +217,7 @@ public class CMapParser
             }
             case '[':
             {
-                List list = new ArrayList();
+                List<Object> list = new ArrayList<>();
                 
                 Object nextToken = parseNextToken( is ); 
                 while( nextToken != MARK_END_OF_ARRAY )
@@ -233,7 +233,7 @@ public class CMapParser
                 int theNextByte = is.read();
                 if( theNextByte == '<' )
                 {
-                    Map result = new HashMap();
+                    Map<String, Object> result = new HashMap<>();
                     //we are reading a dictionary
                     Object key = parseNextToken( is ); 
                     while( key instanceof LiteralName && key != MARK_END_OF_DICTIONARY )

--- a/openpdf/src/main/java/com/lowagie/text/pdf/hyphenation/HyphenationTree.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/hyphenation/HyphenationTree.java
@@ -21,6 +21,8 @@ package com.lowagie.text.pdf.hyphenation;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 /**
  * This tree structure stores the hyphenation patterns in an efficient
@@ -42,7 +44,7 @@ public class HyphenationTree extends TernaryTree
     /**
      * This map stores hyphenation exceptions
      */
-    protected HashMap stoplist;
+    protected Map<String, List> stoplist;
 
     /**
      * This map stores the character classes
@@ -55,7 +57,7 @@ public class HyphenationTree extends TernaryTree
     private transient TernaryTree ivalues;
 
     public HyphenationTree() {
-        stoplist = new HashMap(23);    // usually a small table
+        stoplist = new HashMap<>(23);    // usually a small table
         classmap = new TernaryTree();
         vspace = new ByteVector();
         vspace.alloc(1);    // this reserves index 0, which we don't use

--- a/openpdf/src/main/java/com/lowagie/text/pdf/hyphenation/Hyphenator.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/hyphenation/Hyphenator.java
@@ -20,6 +20,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.InputStream;
 import java.util.Hashtable;
+import java.util.Map;
 
 import com.lowagie.text.pdf.BaseFont;
 
@@ -32,7 +33,7 @@ import com.lowagie.text.pdf.BaseFont;
 public class Hyphenator {
     
     /** TODO: Don't use statics */
-    private static Hashtable hyphenTrees = new Hashtable();
+    private static Map<String, HyphenationTree> hyphenTrees = new Hashtable<>();
 
     private HyphenationTree hyphenTree = null;
     private int remainCharCount = 2;

--- a/openpdf/src/main/java/com/lowagie/text/pdf/hyphenation/SimplePatternParser.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/hyphenation/SimplePatternParser.java
@@ -60,6 +60,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.StringTokenizer;
 
@@ -75,7 +76,7 @@ public class SimplePatternParser implements SimpleXMLDocHandler,
 
     StringBuffer token;
 
-    ArrayList exception;
+    List<Object> exception;
 
     char hyphenChar;
 
@@ -120,8 +121,8 @@ public class SimplePatternParser implements SimpleXMLDocHandler,
         return pat.toString();
     }
 
-    protected ArrayList normalizeException(ArrayList ex) {
-        ArrayList res = new ArrayList();
+    protected List<Object> normalizeException(List<Object> ex) {
+        List<Object> res = new ArrayList<>();
         for (Object item : ex) {
             if (item instanceof String) {
                 String str = (String) item;
@@ -150,7 +151,7 @@ public class SimplePatternParser implements SimpleXMLDocHandler,
         return res;
     }
 
-    protected String getExceptionWord(ArrayList ex) {
+    protected String getExceptionWord(List<Object> ex) {
         StringBuilder res = new StringBuilder();
         for (Object item : ex) {
             if (item instanceof String) {
@@ -194,7 +195,7 @@ public class SimplePatternParser implements SimpleXMLDocHandler,
                 exception.add(word);
                 exception = normalizeException(exception);
                 consumer.addException(getExceptionWord(exception),
-                        (ArrayList) exception.clone());
+                        (ArrayList) ((ArrayList) exception).clone());
                 break;
             case ELEM_PATTERNS:
                 consumer.addPattern(getPattern(word),
@@ -224,6 +225,7 @@ public class SimplePatternParser implements SimpleXMLDocHandler,
      */
     @Override
     @Deprecated
+    @SuppressWarnings("unchecked")
     public void startElement(String tag, HashMap h) {
         startElement(tag, ((Map<String, String>) h));
     }
@@ -245,7 +247,7 @@ public class SimplePatternParser implements SimpleXMLDocHandler,
                 break;
             case "exceptions":
                 currElement = ELEM_EXCEPTIONS;
-                exception = new ArrayList();
+                exception = new ArrayList<>();
                 break;
             case "hyphen":
                 if (token.length() > 0) {
@@ -271,7 +273,7 @@ public class SimplePatternParser implements SimpleXMLDocHandler,
                 exception.add(word);
                 exception = normalizeException(exception);
                 consumer.addException(getExceptionWord(exception),
-                        (ArrayList) exception.clone());
+                        (ArrayList)((ArrayList) exception).clone());
                 exception.clear();
                 break;
             case ELEM_PATTERNS:

--- a/openpdf/src/main/java/com/lowagie/text/pdf/hyphenation/TernaryTree.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/hyphenation/TernaryTree.java
@@ -492,7 +492,7 @@ public class TernaryTree implements Cloneable, Serializable {
         /**
          * Node stack
          */
-        Stack ns;
+        Stack<Item> ns;
 
         /**
          * key stack implemented with a StringBuffer
@@ -501,7 +501,7 @@ public class TernaryTree implements Cloneable, Serializable {
 
         public Iterator() {
             cur = -1;
-            ns = new Stack();
+            ns = new Stack<>();
             ks = new StringBuffer();
             rewind();
         }
@@ -549,17 +549,17 @@ public class TernaryTree implements Cloneable, Serializable {
             boolean climb = true;
 
             while (climb) {
-                i = (Item)ns.pop();
+                i = ns.pop();
                 i.child++;
                 switch (i.child) {
                 case 1:
                     if (sc[i.parent] != 0) {
                         res = eq[i.parent];
-                        ns.push(i.clone());
+                        ns.push((Item)i.clone());
                         ks.append(sc[i.parent]);
                     } else {
                         i.child++;
-                        ns.push(i.clone());
+                        ns.push((Item)i.clone());
                         res = hi[i.parent];
                     }
                     climb = false;
@@ -567,7 +567,7 @@ public class TernaryTree implements Cloneable, Serializable {
 
                 case 2:
                     res = hi[i.parent];
-                    ns.push(i.clone());
+                    ns.push((Item)i.clone());
                     if (ks.length() > 0) {
                         ks.setLength(ks.length() - 1);    // pop
                     }


### PR DESCRIPTION
I've replaced some calls to deprecated setHorizontalAlignment(int), setVerticalAlignment(int), setAlignment(int) by their corresponding functions using the HorizontalAlignment or VerticalAlignment Enum as parameter. In the cases where no values are found in the Enum (when IllegalArgumentException is thrown) I set the value to the UNDEFINED one.

I've replace the use of raw HashMap to the parametrised Map type. 

I've also replaced raw ArrayList by the parametrised interface List<>. These changes may be breaking ones as members are package private (TernaryTree.ns or SimplePatternParser. exception) or protected function (for exemple SimplePatternParser.normalizeException() ). 