### PR TITLE
Bugfix check font size before drawing string

### DIFF
--- a/openpdf/src/main/java/com/lowagie/text/pdf/PdfContentByte.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/PdfContentByte.java
@@ -167,6 +167,8 @@ public class PdfContentByte {
     public static final int TEXT_RENDER_MODE_FILL_STROKE_CLIP = 6;
     /** A possible text rendering value */
     public static final int TEXT_RENDER_MODE_CLIP = 7;
+    
+    static final float MIN_FONT_SIZE = 0.0001f;
 
     private static final float[] unitRect = {0, 0, 0, 1, 1, 0, 1, 1};
     // membervariables
@@ -1384,8 +1386,9 @@ public class PdfContentByte {
      */
     public void setFontAndSize(BaseFont bf, float size) {
         checkWriter();
-        if (size < 0.0001f && size > -0.0001f)
+        if (size < MIN_FONT_SIZE && size > -MIN_FONT_SIZE) {
             throw new IllegalArgumentException(MessageLocalization.getComposedMessage("font.size.too.small.1", String.valueOf(size)));
+        }
         state.size = size;
         state.fontDetails = writer.addSimple(bf);
         PageResources prs = getPageResources();

--- a/openpdf/src/main/java/com/lowagie/text/pdf/PdfGraphics2D.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/PdfGraphics2D.java
@@ -355,8 +355,9 @@ public class PdfGraphics2D extends Graphics2D {
      * @see Graphics2D#drawString(String, float, float)
      */
     public void drawString(String s, float x, float y) {
-        if (s.length() == 0)
+        if (s.length() == 0 || (!Float.isFinite(fontSize) || fontSize < PdfContentByte.MIN_FONT_SIZE)) {
             return;
+        }
         setFillPaint();
         if (onlyShapes) {
             drawGlyphVector(this.font.layoutGlyphVector(getFontRenderContext(), s.toCharArray(), 0, s.length(), java.awt.Font.LAYOUT_LEFT_TO_RIGHT), x, y);


### PR DESCRIPTION
MOD PdfContentByte: added minimal font size constant.
MOD PdfGraphics2D: fixed avoiding drawing text whose font size is less than the minimum allowed value. This allows to create pdf document if there is some text with font size 0 without IllegalArgumentException form the method  PdfContentByte::setFontAndSize and additional checks by calling of Graphics2D::drawString since there is no poblem with the font size 0 in SunGraphics2D.