### PR TITLE
Allow to create indirect references from other projects

### DIFF
--- a/openpdf/src/main/java/com/lowagie/text/pdf/PRIndirectReference.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/PRIndirectReference.java
@@ -66,7 +66,7 @@ public class PRIndirectReference extends PdfIndirectReference {
  * @param        generation        the generation number.
  */
     
-    PRIndirectReference(PdfReader reader, int number, int generation) {
+    public PRIndirectReference(PdfReader reader, int number, int generation) {
         type = INDIRECT;
         this.number = number;
         this.generation = generation;
@@ -80,7 +80,7 @@ public class PRIndirectReference extends PdfIndirectReference {
  * @param        number            the object number.
  */
     
-    PRIndirectReference(PdfReader reader, int number) {
+    public PRIndirectReference(PdfReader reader, int number) {
         this(reader, number, 0);
     }
     


### PR DESCRIPTION
Hello,

We are currently working to make DSS compliant with Java Modules. 

To be able to extend signatures with the DSS/VRI dictionaries, we need to copy indirect references for streams (Certificates, CRLs, OCSP Responses,..). In DSS, we created this [class](https://github.com/esig/dss/blob/5.4.x/dss-pades-openpdf/src/main/java/com/lowagie/text/pdf/DSSIndirectReference.java) because the constructor wasn't accessible from external projects.

This causes a package conflict for DSS integrators. The same package shouldn't be present in multiple dependencies.

Can we ask you to make these constructors public ? 

Thanks in advance for your support,

Regards,

Pierrick