### PR TITLE
Fix NullPointerException for OTF Fonts

### DIFF
--- a/openpdf/src/main/java/com/lowagie/text/pdf/CFFFont.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/CFFFont.java
@@ -1112,10 +1112,6 @@ public class CFFFont {
                     fonts[j].charsetOffset = (Integer) args[0];
                     
                 }
-                else if (Objects.equals(key, "Encoding")){
-                    fonts[j].encodingOffset = (Integer) args[0];
-                    ReadEncoding(fonts[j].encodingOffset);
-                }
                 else if (Objects.equals(key, "CharStrings")) {
                     fonts[j].charstringsOffset = (Integer) args[0];
                     //System.err.println("charstrings "+fonts[j].charstringsOffset);
@@ -1167,12 +1163,4 @@ public class CFFFont {
         }
         //System.err.println("CFF: done");
     }
-    
-    // ADDED BY Oren & Ygal
-    
-    void ReadEncoding(int nextIndexOffset){
-        int format;
-        seek(nextIndexOffset);
-        format = getCard8();
-    }    
 }


### PR DESCRIPTION
I've encountered a bug creating a PDF out of HTML when using OTF fonts as a `@font-face` CSS directive via flying-saucer.

I'm not yet sure why this happens with some OTF fonts, but I could reproduce and fix the bug.

Steps to reproduce:

Fetch the "D-DIN" font from https://fontlibrary.org/de/font/d-din. Download ZIP, choose D-DIN.otf. I could reproduce it with a variety of other OTF fonts, but this should serve as an example.

Convert the following HTML:

```html
<!DOCTYPE html>
<html lang="de">
<head>
  <meta charset="utf-8" />
  <style>
    @font-face {
      font-family: "D-DIN";
      src: url('file:/path/to/D-DIN.otf');
      -fs-pdf-font-embed: embed;
      -fs-pdf-font-encoding: Identity-H;
      font-weight: normal;
      font-style: normal;
    }
    body {
      font-family: "D-DIN";
    }
  </style>
</head>
<body>
  <h1>Test</h1>
</body>
</html>
```

to a PDF. I've been using flying-saucer (https://github.com/flyingsaucerproject/flyingsaucer) which uses OpenPDF as one of its backends.

The code to create the PDF with flyingsaucer:

```java
package test;

import org.xhtmlrenderer.pdf.ITextRenderer;

import java.io.File;
import java.io.FileNotFoundException;
import java.io.FileOutputStream;
import java.io.IOException;
import java.nio.charset.StandardCharsets;
import java.nio.file.Files;
import java.nio.file.Paths;
import java.util.stream.Stream;

public class Fixture {
    private static String readLines(String filePath)
    {
        StringBuilder contentBuilder = new StringBuilder();
        try (Stream<String> stream = Files.lines( Paths.get(filePath), StandardCharsets.UTF_8))
        {
            stream.forEach(s -> contentBuilder.append(s).append("\n"));
        }
        catch (IOException e)
        {
            e.printStackTrace();
        }
        return contentBuilder.toString();
    }

    private static void buildPDF(String htmlContent) {
        try {
            ITextRenderer renderer = new ITextRenderer();
            renderer.setDocumentFromString(htmlContent);
            renderer.layout();
            renderer.createPDF(new FileOutputStream(new File("/path/to/output.pdf")));
            renderer.finishPDF();
        } catch (FileNotFoundException e) {
            e.printStackTrace();
        }
    }

    public static void main(String[] args) {
         String content = readLines("/path/to/fixture.html");
         buildPDF(content);
    }
}
```

Currently, OpenPDF gives me a NullPointerException:

```
java.lang.NullPointerException
        at com.lowagie.text.pdf.CFFFont.<init>(CFFFont.java:1103)
        at com.lowagie.text.pdf.CFFFontSubset.<init>(CFFFontSubset.java:174)
        at com.lowagie.text.pdf.TrueTypeFontUnicode.writeFont(TrueTypeFontUnicode.java:419)
        at com.lowagie.text.pdf.FontDetails.writeFont(FontDetails.java:317)
        at com.lowagie.text.pdf.PdfWriter.addSharedObjectsToBody(PdfWriter.java:1236)
        at com.lowagie.text.pdf.PdfWriter.close(PdfWriter.java:1170)
        at com.lowagie.text.pdf.PdfDocument.close(PdfDocument.java:833)
        at com.lowagie.text.Document.close(Document.java:452)
        at org.xhtmlrenderer.pdf.ITextRenderer.createPDF(ITextRenderer.java:337)
        at org.xhtmlrenderer.pdf.ITextRenderer.createPDF(ITextRenderer.java:265)
[...]
```

After applying the patch in this PR, it works again with all the fonts that caused issues. I also tested with a variety of TTF fonts.

