### PR TITLE
Fix bug concerning stroke colors when simulating bold fonts.

### DIFF
--- a/openpdf/src/main/java/com/lowagie/text/pdf/PdfGraphics2D.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/PdfGraphics2D.java
@@ -444,7 +444,7 @@ public class PdfGraphics2D extends Graphics2D {
                                 }
                                 cb.setGState(gs);
                             }
-                            cb.setColorStroke(color);
+                            setStrokePaint();
                             restoreTextRenderingMode = true;
                         }
                     }


### PR DESCRIPTION
I've encountered a bug in PdfGraphics2D#drawString() when simulating a bold font. It is quite hard to find an easily reproducible example, but I hope static code analysis is clear enough in this case.

Until now, when simulating a bold font, the stroke color is changed by using PdfContentByte#setColorStroke(). Unfortunately, this means that the value of paintStroke is not updated in PdfGraphics2D. This incorrect state of paintStroke only will have an effect if the next time the stroke color is used it is expected to have the same color as it had before cb.setColorStroke() was called. OpenPDF then assumes the desired color has already been set and doesn't change it again, leading to elements painted in an unexpected color.

Using setStrokePaint() instead fixes this bug because it takes care of maintaining the correct state.