### PR TITLE
Remove warnings 7

### DIFF
--- a/openpdf/src/main/java/com/lowagie/text/pdf/PdfArray.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/PdfArray.java
@@ -135,7 +135,7 @@ public class PdfArray extends PdfObject {
      *            added to the array
      * @since 2.1.3
      */
-    public PdfArray(List<PdfObject> pdfObjectList) {
+    public PdfArray(List<? extends PdfObject> pdfObjectList) {
         this();
         if (pdfObjectList != null) {
             arrayList.addAll(pdfObjectList);

--- a/openpdf/src/main/java/com/lowagie/text/pdf/PdfGraphics2D.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/PdfGraphics2D.java
@@ -141,13 +141,13 @@ public class PdfGraphics2D extends Graphics2D {
     private PdfContentByte cb;
     
     /** Storage for BaseFont objects created. */
-    private HashMap baseFonts;
+    private Map<String, BaseFont> baseFonts;
     
     private boolean disposeCalled = false;
     
     private FontMapper fontMapper;
     
-    private ArrayList kids;
+    private List<Object> kids;
     
     private boolean kid = false;
     
@@ -212,7 +212,7 @@ public class PdfGraphics2D extends Graphics2D {
         this.jpegQuality = quality;
         this.onlyShapes = onlyShapes;
         this.transform = new AffineTransform();
-        this.baseFonts = new HashMap();
+        this.baseFonts = new HashMap<>();
         if (!onlyShapes) {
             this.fontMapper = fontMapper;
             if (this.fontMapper == null)
@@ -271,7 +271,7 @@ public class PdfGraphics2D extends Graphics2D {
             int height = img.getHeight();
             WritableRaster raster = cm.createCompatibleWritableRaster(width, height);
             boolean isAlphaPremultiplied = cm.isAlphaPremultiplied();
-            Hashtable properties = new Hashtable();
+            Hashtable<String, Object> properties = new Hashtable<>();
             String[] keys = img.getPropertyNames();
             if (keys!=null) {
                 for (String key : keys) {
@@ -313,11 +313,11 @@ public class PdfGraphics2D extends Graphics2D {
      * before calling the actual string drawing routine
      * @param iter
      */
+    @SuppressWarnings("unchecked")
     protected void doAttributes(AttributedCharacterIterator iter) {
         underline = false;
-        Set set = iter.getAttributes().keySet();
-        for (Object o : set) {
-            AttributedCharacterIterator.Attribute attribute = (AttributedCharacterIterator.Attribute) o;
+        Set<AttributedCharacterIterator.Attribute> set = iter.getAttributes().keySet();
+        for (AttributedCharacterIterator.Attribute attribute : set) {
             if (!(attribute instanceof TextAttribute))
                 continue;
             TextAttribute textattribute = (TextAttribute) attribute;
@@ -340,17 +340,17 @@ public class PdfGraphics2D extends Graphics2D {
                 setColor((Color) iter.getAttributes().get(textattribute));
             } else if (textattribute.equals(TextAttribute.FAMILY)) {
                 Font font = getFont();
-                Map fontAttributes = font.getAttributes();
+                Map<TextAttribute, Object> fontAttributes = (Map<TextAttribute, Object>)font.getAttributes();
                 fontAttributes.put(TextAttribute.FAMILY, iter.getAttributes().get(textattribute));
                 setFont(font.deriveFont(fontAttributes));
             } else if (textattribute.equals(TextAttribute.POSTURE)) {
                 Font font = getFont();
-                Map fontAttributes = font.getAttributes();
+                Map<TextAttribute, Object> fontAttributes = (Map<TextAttribute, Object>)font.getAttributes();
                 fontAttributes.put(TextAttribute.POSTURE, iter.getAttributes().get(textattribute));
                 setFont(font.deriveFont(fontAttributes));
             } else if (textattribute.equals(TextAttribute.WEIGHT)) {
                 Font font = getFont();
-                Map fontAttributes = font.getAttributes();
+                Map<TextAttribute, Object> fontAttributes = (Map<TextAttribute, Object>)font.getAttributes();
                 fontAttributes.put(TextAttribute.WEIGHT, iter.getAttributes().get(textattribute));
                 setFont(font.deriveFont(fontAttributes));
             }
@@ -958,7 +958,7 @@ public class PdfGraphics2D extends Graphics2D {
             g2.followPath(g2.clip, CLIP);
         g2.kid = true;
         if (this.kids == null)
-            this.kids = new ArrayList();
+            this.kids = new ArrayList<>();
         this.kids.add(cb.getInternalBuffer().size());
         this.kids.add(g2);
         return g2;
@@ -1026,7 +1026,7 @@ public class PdfGraphics2D extends Graphics2D {
     
     private BaseFont getCachedBaseFont(Font f) {
         synchronized (baseFonts) {
-            BaseFont bf = (BaseFont)baseFonts.get(f.getFontName());
+            BaseFont bf = baseFonts.get(f.getFontName());
             if (bf == null) {
                 bf = fontMapper.awtToPdf(f);
                 baseFonts.put(f.getFontName(), bf);

--- a/openpdf/src/main/java/com/lowagie/text/pdf/PdfLine.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/PdfLine.java
@@ -66,7 +66,7 @@ public class PdfLine {
     // membervariables
     
     /** The arraylist containing the chunks. */
-    protected ArrayList line;
+    protected ArrayList<PdfChunk> line;
     
     /** The left indentation of the line. */
     protected float left;
@@ -111,7 +111,7 @@ public class PdfLine {
         this.originalWidth = this.width;
         this.alignment = alignment;
         this.height = height;
-        this.line = new ArrayList();
+        this.line = new ArrayList<>();
     }
     
     /**
@@ -124,7 +124,7 @@ public class PdfLine {
      * @param line                an array of PdfChunk objects
      * @param isRTL                do you have to read the line from Right to Left?
      */
-    PdfLine(float left, float originalWidth, float remainingWidth, int alignment, boolean newlineSplit, ArrayList line, boolean isRTL) {
+    PdfLine(float left, float originalWidth, float remainingWidth, int alignment, boolean newlineSplit, ArrayList<PdfChunk> line, boolean isRTL) {
         this.left = left;
         this.originalWidth = originalWidth;
         this.width = remainingWidth;
@@ -192,7 +192,7 @@ public class PdfLine {
             }
         }
         else {
-            width += ((PdfChunk)(line.get(line.size() - 1))).trimLastSpace();
+            width += line.get(line.size() - 1).trimLastSpace();
         }
         return overflow;
     }
@@ -397,7 +397,7 @@ public class PdfLine {
     public int getLastStrokeChunk() {
         int lastIdx = line.size() - 1;
         for (; lastIdx >= 0; --lastIdx) {
-            PdfChunk chunk = (PdfChunk)line.get(lastIdx);
+            PdfChunk chunk = line.get(lastIdx);
             if (chunk.isStroked())
                 break;
         }
@@ -412,7 +412,7 @@ public class PdfLine {
     public PdfChunk getChunk(int idx) {
         if (idx < 0 || idx >= line.size())
             return null;
-        return (PdfChunk)line.get(idx);
+        return line.get(idx);
     }
     
     /**
@@ -422,26 +422,7 @@ public class PdfLine {
     public float getOriginalWidth() {
         return originalWidth;
     }
-    
-    /*
-     * Gets the maximum size of all the fonts used in this line
-     * including images.
-     * @return maximum size of all the fonts used in this line
-     float getMaxSizeSimple() {
-        float maxSize = 0;
-        PdfChunk chunk;
-        for (int k = 0; k < line.size(); ++k) {
-            chunk = (PdfChunk)line.get(k);
-            if (!chunk.isImage()) {
-                maxSize = Math.max(chunk.font().size(), maxSize);
-            }
-            else {
-                maxSize = Math.max(chunk.getImage().getScaledHeight() + chunk.getImageOffsetY() , maxSize);
-            }
-        }
-        return maxSize;
-    }*/
-    
+
     /**
      * Gets the difference between the "normal" leading and the maximum
      * size (for instance when there are images in the chunk).

--- a/openpdf/src/main/java/com/lowagie/text/pdf/PdfNumberTree.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/PdfNumberTree.java
@@ -132,12 +132,12 @@ public class PdfNumberTree {
         }
     }
     
-    private static void iterateItems(PdfDictionary dic, HashMap items) {
+    private static void iterateItems(PdfDictionary dic, Map<PdfObject, PdfObject> items) {
         PdfArray nn = (PdfArray)PdfReader.getPdfObjectRelease(dic.get(PdfName.NUMS));
         if (nn != null) {
             for (int k = 0; k < nn.size(); ++k) {
                 PdfNumber s = (PdfNumber)PdfReader.getPdfObjectRelease(nn.getPdfObject(k++));
-                items.put(s.intValue(), nn.getPdfObject(k));
+                items.put(s, nn.getPdfObject(k));
             }
         }
         else if ((nn = (PdfArray)PdfReader.getPdfObjectRelease(dic.get(PdfName.KIDS))) != null) {
@@ -148,8 +148,8 @@ public class PdfNumberTree {
         }
     }
     
-    public static HashMap readTree(PdfDictionary dic) {
-        HashMap items = new HashMap();
+    public static HashMap<PdfObject, PdfObject> readTree(PdfDictionary dic) {
+        HashMap<PdfObject, PdfObject> items = new HashMap<>();
         if (dic != null)
             iterateItems(dic, items);
         return items;

--- a/openpdf/src/main/java/com/lowagie/text/pdf/PdfPKCS7.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/PdfPKCS7.java
@@ -306,12 +306,13 @@ public class PdfPKCS7 {
      * @param certsKey    the /Cert key
      * @param provider    the provider or <code>null</code> for the default provider
      */
+    @SuppressWarnings("unchecked")
     public PdfPKCS7(byte[] contentsKey, byte[] certsKey, String provider) {
         try {
             this.provider = provider;
             CertificateFactory certificateFactory = new CertificateFactory();
-            Collection certificates = certificateFactory.engineGenerateCertificates(new ByteArrayInputStream(certsKey));
-            certs = new ArrayList<>((Collection<Certificate>) certificates);
+            Collection<Certificate> certificates = certificateFactory.engineGenerateCertificates(new ByteArrayInputStream(certsKey));
+            certs = new ArrayList<>(certificates);
             signCerts = certs;
             signCert = (X509Certificate) certs.iterator().next();
             crls = new ArrayList<>();
@@ -380,6 +381,7 @@ public class PdfPKCS7 {
      * @param contentsKey the /Contents key
      * @param provider    the provider or <code>null</code> for the default provider
      */
+    @SuppressWarnings("unchecked")
     public PdfPKCS7(byte[] contentsKey, String provider) {
         try {
             this.provider = provider;
@@ -436,8 +438,8 @@ public class PdfPKCS7 {
 
             // the certificates and crls
             CertificateFactory certificateFactory = new CertificateFactory();
-            Collection certificates = certificateFactory.engineGenerateCertificates(new ByteArrayInputStream(contentsKey));
-            this.certs = new ArrayList<>((Collection<Certificate>) certificates);
+            Collection<Certificate> certificates = certificateFactory.engineGenerateCertificates(new ByteArrayInputStream(contentsKey));
+            this.certs = new ArrayList<>(certificates);
             X509CRLParser cl = new X509CRLParser();
             cl.engineInit(new ByteArrayInputStream(contentsKey));
             crls = (List<CRL>) cl.engineReadAll();
@@ -537,7 +539,7 @@ public class PdfPKCS7 {
                     ASN1Set attributeValues = ts.getAttrValues();
                     ASN1Sequence tokenSequence = ASN1Sequence.getInstance(attributeValues
                             .getObjectAt(0));
-                    ContentInfo contentInfo = new ContentInfo(tokenSequence);
+                    ContentInfo contentInfo = ContentInfo.getInstance(tokenSequence);
                     this.timeStampToken = new TimeStampToken(contentInfo);
                 }
             }

--- a/openpdf/src/main/java/com/lowagie/text/pdf/PdfPTable.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/PdfPTable.java
@@ -50,6 +50,7 @@
 package com.lowagie.text.pdf;
 
 import java.util.ArrayList;
+
 import com.lowagie.text.error_messages.MessageLocalization;
 
 import com.lowagie.text.DocumentException;
@@ -94,7 +95,7 @@ public class PdfPTable implements LargeElement{
      */    
     public static final int TEXTCANVAS = 3;
     
-    protected ArrayList rows = new ArrayList();
+    protected ArrayList<PdfPRow> rows = new ArrayList<>();
     protected float totalHeight = 0;
     protected PdfPCell[] currentRow;
     protected int currentRowIdx = 0;
@@ -243,7 +244,7 @@ public class PdfPTable implements LargeElement{
             currentRow[k] = new PdfPCell(table.currentRow[k]);
         }
         for (int k = 0; k < table.rows.size(); ++k) {
-            PdfPRow row = (PdfPRow)(table.rows.get(k));
+            PdfPRow row = table.rows.get(k);
             if (row != null)
                 row = new PdfPRow(row);
             rows.add(row);
@@ -514,7 +515,7 @@ public class PdfPTable implements LargeElement{
     }
     
     PdfPCell obtainCell(final int row, final int col) {
-        PdfPCell[] cells = ((PdfPRow)rows.get(row)).getCells();
+        PdfPCell[] cells = rows.get(row).getCells();
         for (int i = 0; i < cells.length; i++) {
             if (cells[i] != null) {
                 if (col >= i && col < (i + cells[i].getColspan())) {
@@ -539,12 +540,12 @@ public class PdfPTable implements LargeElement{
             return false;
         
         int row = currRow - 1;
-        PdfPRow aboveRow = (PdfPRow)rows.get(row);
+        PdfPRow aboveRow = rows.get(row);
         if (aboveRow == null)
             return false;
         PdfPCell aboveCell = obtainCell(row,currCol);
         while ((aboveCell == null) && (row > 0)) {
-            aboveRow  = (PdfPRow)rows.get(--row);
+            aboveRow  = rows.get(--row);
             if (aboveRow == null)
                 return false;
             aboveCell = obtainCell(row,currCol);
@@ -562,7 +563,7 @@ public class PdfPTable implements LargeElement{
         
         if ((aboveCell.getRowspan() == 1) && (distance > 1)) {
             int col = currCol - 1;
-            aboveRow = (PdfPRow)rows.get(row + 1);
+            aboveRow = rows.get(row + 1);
             distance--;
             aboveCell = aboveRow.getCells()[col];
             while ((aboveCell == null) && (col > 0))
@@ -680,7 +681,7 @@ public class PdfPTable implements LargeElement{
         
         float yPosStart = yPos;
         for (int k = rowStart; k < rowEnd; ++k) {
-            PdfPRow row = (PdfPRow)rows.get(k);
+            PdfPRow row = rows.get(k);
             if (row != null) {
                 row.writeCells(colStart, colEnd, xPos, yPos, canvases);
                 yPos -= row.getMaxHeights();
@@ -691,7 +692,7 @@ public class PdfPTable implements LargeElement{
             float[] heights = new float[rowEnd - rowStart + 1];
             heights[0] = yPosStart;
             for (int k = rowStart; k < rowEnd; ++k) {
-                PdfPRow row = (PdfPRow)rows.get(k);
+                PdfPRow row = rows.get(k);
                 float hr = 0;
                 if (row != null)
                     hr = row.getMaxHeights();
@@ -856,7 +857,7 @@ public class PdfPTable implements LargeElement{
     public float getRowHeight(int idx, boolean firsttime) {
         if (totalWidth <= 0 || idx < 0 || idx >= rows.size())
             return 0;
-        PdfPRow row = (PdfPRow)rows.get(idx);
+        PdfPRow row = rows.get(idx);
         if (row == null)
             return 0;
         if (firsttime)
@@ -871,7 +872,7 @@ public class PdfPTable implements LargeElement{
             while (rowSpanAbove(idx - rs, i)) {
                 rs++;
             }
-            tmprow = (PdfPRow)rows.get(idx - rs);
+            tmprow = rows.get(idx - rs);
             cell = tmprow.getCells()[i];
             float tmp = 0;
             if (cell != null && cell.getRowspan() == rs + 1) {
@@ -900,7 +901,7 @@ public class PdfPTable implements LargeElement{
     public float getRowspanHeight(int rowIndex, int cellIndex) {
         if (totalWidth <= 0 || rowIndex < 0 || rowIndex >= rows.size())
             return 0;
-        PdfPRow row = (PdfPRow)rows.get(rowIndex);
+        PdfPRow row = rows.get(rowIndex);
         if (row == null || cellIndex >= row.getCells().length)
             return 0;
         PdfPCell cell = row.getCells()[cellIndex];
@@ -923,7 +924,7 @@ public class PdfPTable implements LargeElement{
         float total = 0;
         int size = Math.min(rows.size(), headerRows);
         for (int k = 0; k < size; ++k) {
-            PdfPRow row = (PdfPRow)rows.get(k);
+            PdfPRow row = rows.get(k);
             if (row != null)
                 total += row.getMaxHeights();
         }
@@ -942,7 +943,7 @@ public class PdfPTable implements LargeElement{
         int start = Math.max(0, headerRows - footerRows);
         int size = Math.min(rows.size(), headerRows);
         for (int k = start; k < size; ++k) {
-            PdfPRow row = (PdfPRow)rows.get(k);
+            PdfPRow row = rows.get(k);
             if (row != null)
                 total += row.getMaxHeights();
         }
@@ -959,7 +960,7 @@ public class PdfPTable implements LargeElement{
         if (rowNumber < 0 || rowNumber >= rows.size())
             return false;
         if (totalWidth > 0) {
-            PdfPRow row = (PdfPRow)rows.get(rowNumber);
+            PdfPRow row = rows.get(rowNumber);
             if (row != null)
                 totalHeight -= row.getMaxHeights();
         }
@@ -985,7 +986,7 @@ public class PdfPTable implements LargeElement{
      * Removes all of the rows except headers
      */
     public void deleteBodyRows() {
-        ArrayList rows2 = new ArrayList();
+        ArrayList<PdfPRow> rows2 = new ArrayList<>();
         for (int k = 0; k < headerRows; ++k)
             rows2.add(rows.get(k));
         rows = rows2;
@@ -1031,8 +1032,8 @@ public class PdfPTable implements LargeElement{
      *
      * @return    an <CODE>ArrayList</CODE>
      */
-    public ArrayList getChunks() {
-        return new ArrayList();
+    public java.util.ArrayList<Element> getChunks() {
+        return new ArrayList<>();
     }
     
     /**
@@ -1122,7 +1123,7 @@ public class PdfPTable implements LargeElement{
      * @return the row at position idx
      */
     public PdfPRow getRow(int idx) {
-        return (PdfPRow)rows.get(idx);
+        return rows.get(idx);
     }
 
     /**
@@ -1130,7 +1131,7 @@ public class PdfPTable implements LargeElement{
      * 
      * @return an arraylist
      */
-    public ArrayList getRows() {
+    public ArrayList<PdfPRow> getRows() {
         return rows;
     }
     
@@ -1141,8 +1142,8 @@ public class PdfPTable implements LargeElement{
      * @return    a selection of rows
      * @since    2.1.6
      */
-    public ArrayList getRows(int start, int end) {
-        ArrayList list = new ArrayList();
+    public ArrayList<PdfPRow> getRows(int start, int end) {
+        ArrayList<PdfPRow> list = new ArrayList<>();
         if (start < 0 || end > size()) {
             return list;
         }
@@ -1253,7 +1254,7 @@ public class PdfPTable implements LargeElement{
             int n = 0;
             if (includeHeaders) {
                 for (int k = 0; k < headerRows; ++k) {
-                    PdfPRow row = (PdfPRow)rows.get(k);
+                    PdfPRow row = rows.get(k);
                     if (row == null)
                         ++n;
                     else
@@ -1261,7 +1262,7 @@ public class PdfPTable implements LargeElement{
                 }
             }
             for (; firstRow < lastRow; ++firstRow) {
-                    PdfPRow row = (PdfPRow)rows.get(firstRow);
+                    PdfPRow row = rows.get(firstRow);
                     if (row == null)
                         ++n;
                     else

--- a/openpdf/src/main/java/com/lowagie/text/pdf/PdfPageLabels.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/PdfPageLabels.java
@@ -35,6 +35,7 @@ import com.lowagie.text.factories.RomanNumberFactory;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.Map;
 
 /**
  * Page labels are used to identify each page visually on the screen or in print.
@@ -86,13 +87,13 @@ public class PdfPageLabels {
     /**
      * The sequence of logical pages. Will contain at least a value for page 1
      */
-    private HashMap map;
+    private HashMap<Integer, PdfDictionary> map;
 
     /**
      * Creates a new PdfPageLabel with a default logical page 1
      */
     public PdfPageLabels() {
-        map = new HashMap();
+        map = new HashMap<>();
         addPageLabel(1, PdfPageLabels.DECIMAL_ARABIC_NUMERALS, null, 1);
     }
 
@@ -205,7 +206,7 @@ public class PdfPageLabels {
 
         String[] labelstrings = new String[n];
 
-        HashMap numberTree = PdfNumberTree.readTree(labels);
+        Map<PdfObject, PdfObject> numberTree = PdfNumberTree.readTree(labels);
 
         int pagecount = 1;
         Integer current;
@@ -214,7 +215,7 @@ public class PdfPageLabels {
         for (int i = 0; i < n; i++ ) {
             current = i;
             if (numberTree.containsKey(current)) {
-                PdfDictionary d = (PdfDictionary) PdfReader.getPdfObjectRelease((PdfObject) numberTree.get(current));
+                PdfDictionary d = (PdfDictionary) PdfReader.getPdfObjectRelease(numberTree.get(current));
                 if (d.contains(PdfName.ST)) {
                     pagecount = ((PdfNumber) d.get(PdfName.ST)).intValue();
                 } else {
@@ -266,10 +267,9 @@ public class PdfPageLabels {
         if (labels == null) {
             return null;
         }
-        HashMap numberTree = PdfNumberTree.readTree(labels);
+        Map<PdfObject, PdfObject> numberTree = PdfNumberTree.readTree(labels);
         Integer[] numbers = new Integer[numberTree.size()];
-        numbers = (Integer[]) numberTree.keySet()
-                                        .toArray(numbers);
+        numbers = numberTree.keySet().toArray(numbers);
         Arrays.sort(numbers);
         PdfPageLabelFormat[] formats = new PdfPageLabelFormat[numberTree.size()];
         String prefix;
@@ -277,7 +277,7 @@ public class PdfPageLabels {
         int pagecount;
         for (int k = 0; k < numbers.length; ++k) {
             Integer key = numbers[k];
-            PdfDictionary d = (PdfDictionary) PdfReader.getPdfObjectRelease((PdfObject) numberTree.get(key));
+            PdfDictionary d = (PdfDictionary) PdfReader.getPdfObjectRelease(numberTree.get(key));
             if (d.contains(PdfName.ST)) {
                 pagecount = ((PdfNumber) d.get(PdfName.ST)).intValue();
             } else {
@@ -289,8 +289,7 @@ public class PdfPageLabels {
                 prefix = "";
             }
             if (d.contains(PdfName.S)) {
-                char type = d.get(PdfName.S).toString()
-                                                        .charAt(1);
+                char type = d.get(PdfName.S).toString().charAt(1);
                 switch (type) {
                     case 'R':
                         numberStyle = PdfPageLabels.UPPERCASE_ROMAN_NUMERALS;

--- a/openpdf/src/main/java/com/lowagie/text/pdf/PdfPages.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/PdfPages.java
@@ -71,8 +71,8 @@ import java.util.ArrayList;
 
 public class PdfPages {
     
-    private ArrayList pages = new ArrayList();
-    private ArrayList parents = new ArrayList();
+    private ArrayList<PdfIndirectReference> pages = new ArrayList<>();
+    private ArrayList<PdfIndirectReference> parents = new ArrayList<>();
     private int leafSize = 10;
     private PdfWriter writer;
     private PdfIndirectReference topParent;
@@ -91,7 +91,7 @@ public class PdfPages {
         try {
             if ((pages.size() % leafSize) == 0)
                 parents.add(writer.getPdfIndirectReference());
-            PdfIndirectReference parent = (PdfIndirectReference)parents.get(parents.size() - 1);
+            PdfIndirectReference parent = parents.get(parents.size() - 1);
             page.put(PdfName.PARENT, parent);
             PdfIndirectReference current = writer.getCurrentPage();
             writer.addToBody(page, current);
@@ -107,7 +107,7 @@ public class PdfPages {
             if ((pages.size() % leafSize) == 0)
                 parents.add(writer.getPdfIndirectReference());
             pages.add(pageRef);
-            return (PdfIndirectReference)parents.get(parents.size() - 1);
+            return parents.get(parents.size() - 1);
         }
         catch (Exception e) {
             throw new ExceptionConverter(e);
@@ -119,9 +119,9 @@ public class PdfPages {
         if (pages.isEmpty())
             throw new IOException(MessageLocalization.getComposedMessage("the.document.has.no.pages"));
         int leaf = 1;
-        ArrayList tParents = parents;
-        ArrayList tPages = pages;
-        ArrayList nextParents = new ArrayList();
+        ArrayList<PdfIndirectReference> tParents = parents;
+        ArrayList<PdfIndirectReference> tPages = pages;
+        ArrayList<PdfIndirectReference> nextParents = new ArrayList<>();
         while (true) {
             leaf *= leafSize;
             int stdCount = leafSize;
@@ -146,20 +146,20 @@ public class PdfPages {
                 if (tParents.size() > 1) {
                     if ((p % leafSize) == 0)
                         nextParents.add(writer.getPdfIndirectReference());
-                    top.put(PdfName.PARENT, (PdfIndirectReference)nextParents.get(p / leafSize));
+                    top.put(PdfName.PARENT, nextParents.get(p / leafSize));
                 }
                 else {
                     top.put(PdfName.ITXT, new PdfString(Document.getRelease()));
                 }
-                writer.addToBody(top, (PdfIndirectReference)tParents.get(p));
+                writer.addToBody(top, tParents.get(p));
             }
             if (tParents.size() == 1) {
-                topParent = (PdfIndirectReference)tParents.get(0);
+                topParent = tParents.get(0);
                 return topParent;
             }
             tPages = tParents;
             tParents = nextParents;
-            nextParents = new ArrayList();
+            nextParents = new ArrayList<>();
         }
     }
     
@@ -199,7 +199,7 @@ public class PdfPages {
                 throw new DocumentException(MessageLocalization.getComposedMessage("page.reordering.requires.no.page.repetition.page.1.is.repeated", p));
             temp[p - 1] = true;
         }
-        Object[] copy = pages.toArray();
+        PdfIndirectReference[] copy = pages.toArray(new PdfIndirectReference[0]);
         for (int k = 0; k < max; ++k) {
             pages.set(k, copy[order[k] - 1]);
         }


### PR DESCRIPTION
Specifying generic types.

In PdfPKCS7 on line 540, replacing deprecated bouncycastle `new ContentInfo(tokenSequence);` by `ContentInfo.getInstance(tokenSequence);` as suggested by their javadoc.

No breaking changes here, I think.
