### PR TITLE
Remove warnings 10

### DIFF
--- a/openpdf/src/main/java/com/lowagie/text/pdf/TSAClientBouncyCastle.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/TSAClientBouncyCastle.java
@@ -178,8 +178,7 @@ public class TSAClientBouncyCastle implements TSAClient {
       tsqGenerator.setCertReq(true);
       // tsqGenerator.setReqPolicy("1.3.6.1.4.1.601.10.3.1");
       BigInteger nonce = BigInteger.valueOf(System.currentTimeMillis());
-      TimeStampRequest request = tsqGenerator.generate(
-          X509ObjectIdentifiers.id_SHA1.getId(), imprint, nonce);
+      TimeStampRequest request = tsqGenerator.generate(X509ObjectIdentifiers.id_SHA1, imprint, nonce);
       byte[] requestBytes = request.getEncoded();
 
       // Call the communications layer

--- a/openpdf/src/main/java/com/lowagie/text/pdf/Type1Font.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/Type1Font.java
@@ -53,6 +53,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.HashMap;
+import java.util.Map;
 import java.util.StringTokenizer;
 import com.lowagie.text.error_messages.MessageLocalization;
 
@@ -142,14 +143,14 @@ class Type1Font extends BaseFont
  *  Integer, Integer, String and int[]. This is the code, width, name and char bbox.
  *  The key is the name of the char and also an Integer with the char number.
  */
-    private HashMap CharMetrics = new HashMap();
+    private Map<Object, Object[]> CharMetrics = new HashMap<>();
 /** Represents the section KernPairs in the AFM file. The key is
  *  the name of the first character and the value is a <CODE>Object[]</CODE>
  *  with 2 elements for each kern pair. Position 0 is the name of
  *  the second character and position 1 is the kerning distance. This is
  *  repeated for all the pairs.
  */
-    private HashMap KernPairs = new HashMap();
+    private Map<String, Object[]> KernPairs = new HashMap<>();
 /** The file in use.
  */
     private String fileName;
@@ -295,12 +296,12 @@ class Type1Font extends BaseFont
     int getRawWidth(int c, String name) {
         Object[] metrics;
         if (name == null) { // font specific
-            metrics = (Object[])CharMetrics.get(c);
+            metrics = CharMetrics.get(c);
         }
         else {
             if (name.equals(".notdef"))
                 return 0;
-            metrics = (Object[])CharMetrics.get(name);
+            metrics = CharMetrics.get(name);
         }
         if (metrics != null)
             return (Integer) (metrics[1]);
@@ -459,7 +460,7 @@ class Type1Font extends BaseFont
         if (isMetrics)
             throw new DocumentException(MessageLocalization.getComposedMessage("missing.endcharmetrics.in.1", fileName));
         if (!CharMetrics.containsKey("nonbreakingspace")) {
-            Object[] space = (Object[])CharMetrics.get("space");
+            Object[] space = CharMetrics.get("space");
             if (space != null)
                 CharMetrics.put("nonbreakingspace", space);
         }
@@ -490,7 +491,7 @@ class Type1Font extends BaseFont
                 String first = tok.nextToken();
                 String second = tok.nextToken();
                 Integer width = (int) Float.parseFloat(tok.nextToken());
-                Object[] relates = (Object[]) KernPairs.get(first);
+                Object[] relates = KernPairs.get(first);
                 if (relates == null)
                     KernPairs.put(first, new Object[]{second, width});
                 else
@@ -811,7 +812,7 @@ class Type1Font extends BaseFont
         String second = GlyphList.unicodeToName(char2);
         if (second == null)
             return false;
-        Object[] obj = (Object[]) KernPairs.get(first);
+        Object[] obj = KernPairs.get(first);
         if (obj == null) {
             obj = new Object[]{second, kern};
             KernPairs.put(first, obj);
@@ -835,12 +836,12 @@ class Type1Font extends BaseFont
     protected int[] getRawCharBBox(int c, String name) {
         Object[] metrics;
         if (name == null) { // font specific
-            metrics = (Object[])CharMetrics.get(c);
+            metrics = CharMetrics.get(c);
         }
         else {
             if (name.equals(".notdef"))
                 return null;
-            metrics = (Object[])CharMetrics.get(name);
+            metrics = CharMetrics.get(name);
         }
         if (metrics != null)
             return ((int[])(metrics[3]));

--- a/openpdf/src/main/java/com/lowagie/text/pdf/Type3Font.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/Type3Font.java
@@ -48,6 +48,8 @@
 package com.lowagie.text.pdf;
 
 import java.util.HashMap;
+import java.util.Map;
+
 import com.lowagie.text.error_messages.MessageLocalization;
 
 import com.lowagie.text.DocumentException;
@@ -59,7 +61,7 @@ public class Type3Font extends BaseFont {
     
     private boolean[] usedSlot;
     private IntHashtable widths3 = new IntHashtable();
-    private HashMap char2glyph = new HashMap();
+    private Map<Integer, Type3Glyph> char2glyph = new HashMap<>();
     private PdfWriter writer;
     private float llx = Float.NaN, lly, urx, ury;
     private PageResources pageResources = new PageResources();
@@ -129,7 +131,7 @@ public class Type3Font extends BaseFont {
             throw new IllegalArgumentException(MessageLocalization.getComposedMessage("the.char.1.doesn.t.belong.in.this.type3.font", (int)c));
         usedSlot[c] = true;
         Integer ck = (int) c;
-        Type3Glyph glyph = (Type3Glyph)char2glyph.get(ck);
+        Type3Glyph glyph = char2glyph.get(ck);
         if (glyph != null)
             return glyph;
         widths3.put(c, (int)wx);
@@ -238,7 +240,7 @@ public class Type3Font extends BaseFont {
                 s = "a" + c2;
             PdfName n = new PdfName(s);
             diffs.add(n);
-            Type3Glyph glyph = (Type3Glyph)char2glyph.get(c2);
+            Type3Glyph glyph = char2glyph.get(c2);
             PdfStream stream = new PdfStream(glyph.toPdf(null));
             stream.flateCompress(compressionLevel);
             PdfIndirectReference refp = writer.addToBody(stream).getIndirectReference();

--- a/openpdf/src/main/java/com/lowagie/text/pdf/VerticalText.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/VerticalText.java
@@ -49,6 +49,7 @@ package com.lowagie.text.pdf;
 import java.awt.Color;
 import java.util.ArrayList;
 import java.util.Iterator;
+
 import com.lowagie.text.error_messages.MessageLocalization;
 
 import com.lowagie.text.Chunk;
@@ -69,7 +70,7 @@ public class VerticalText {
     public static final int NO_MORE_COLUMN = 2;
 
 /** The chunks that form the text. */    
-    protected ArrayList chunks = new ArrayList();
+    protected ArrayList<PdfChunk> chunks = new ArrayList<>();
 
     /** The <CODE>PdfContent</CODE> where the text will be written to. */    
     protected PdfContentByte text;
@@ -174,7 +175,7 @@ public class VerticalText {
         PdfLine line = new PdfLine(0, width, alignment, 0);
         String total;
         for (currentChunkMarker = 0; currentChunkMarker < chunks.size(); ++currentChunkMarker) {
-            PdfChunk original = (PdfChunk)(chunks.get(currentChunkMarker));
+            PdfChunk original = chunks.get(currentChunkMarker);
             total = original.toString();
             currentStandbyChunk = line.add(original);
             if (currentStandbyChunk != null) {
@@ -196,7 +197,7 @@ public class VerticalText {
             chunks.clear();
             return;
         }
-        PdfChunk split = (PdfChunk)(chunks.get(currentChunkMarker));
+        PdfChunk split = chunks.get(currentChunkMarker);
         split.setValue(splittedChunkText);
         chunks.set(currentChunkMarker, currentStandbyChunk);
         if (currentChunkMarker > 0) {

--- a/openpdf/src/main/java/com/lowagie/text/pdf/XfaForm.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/XfaForm.java
@@ -621,6 +621,7 @@ public class XfaForm {
          * @deprecated use {@link #addSomNameToSearchNodeChain(Map, Stack2, String)}
          */
         @Deprecated
+        @SuppressWarnings("unchecked")
         public static void inverseSearchAdd(HashMap inverseSearch, Stack2 stack, String unstack) {
             addSomNameToSearchNodeChain(inverseSearch, stack, unstack);
         }
@@ -662,6 +663,7 @@ public class XfaForm {
          * @return the full name or <CODE>null</CODE> if not found
          */
         @Deprecated
+        @SuppressWarnings("unchecked")
         public String inverseSearchGlobal(ArrayList parts) {
             return inverseSearch(parts);
         }
@@ -752,6 +754,7 @@ public class XfaForm {
          * @param order the order the names appear in the XML, depth first
          */
         @Deprecated
+        @SuppressWarnings("unchecked")
         public void setOrder(ArrayList order) {
             this.order = order;
         }
@@ -788,6 +791,7 @@ public class XfaForm {
          * @param name2Node the mapping of full names to nodes
          */
         @Deprecated
+        @SuppressWarnings("unchecked")
         public void setName2Node(HashMap name2Node) {
             this.name2Node = name2Node;
         }
@@ -985,6 +989,7 @@ public class XfaForm {
          * @param acroShort2LongName the mapping from short names to long names
          */
         @Deprecated
+        @SuppressWarnings("unchecked")
         public void setAcroShort2LongName(HashMap acroShort2LongName) {
             this.acroShort2LongName = acroShort2LongName;
         }

--- a/openpdf/src/main/java/com/lowagie/text/pdf/XfdfReader.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/XfdfReader.java
@@ -176,6 +176,7 @@ public class XfdfReader implements SimpleXMLDocHandler, FieldReader {
      */
     @Deprecated
     @Override
+    @SuppressWarnings("unchecked")
     public void startElement(String tag, HashMap h) {
         startElement(tag, (Map<String, String>) h);
     }

--- a/openpdf/src/main/java/com/lowagie/text/xml/simpleparser/EntitiesToSymbol.java
+++ b/openpdf/src/main/java/com/lowagie/text/xml/simpleparser/EntitiesToSymbol.java
@@ -53,21 +53,30 @@ import com.lowagie.text.Chunk;
 import com.lowagie.text.Font;
 
 import java.util.HashMap;
+import java.util.Map;
 
 /**
  * This class contains entities that can be used in an entity tag.
  */
 
+@SuppressWarnings("deprecated")
 public class EntitiesToSymbol {
-    
+
+    public static Map<String, Character> getMap() {
+        return map;
+    }
+
     /**
      * This is a map that contains all possible id values of the entity tag
      * that can be translated to a character in font Symbol.
+     *
+     * @deprecated use the getter ({@link EntitiesToSymbol#getMap()}) instead of accessing this field directly
      */
-    public static final HashMap map;
-    
+    @Deprecated
+    public static final HashMap<String, Character> map;
+
     static {
-        map = new HashMap();
+        map = new HashMap<>(300);
         map.put("169", (char) 227);
         map.put("172", (char) 216);
         map.put("174", (char) 210);
@@ -343,7 +352,7 @@ public class EntitiesToSymbol {
         map.put("xi", (char) 120);
         map.put("zeta", (char) 122);
     }
-    
+
     /**
      * Gets a chunk with a symbol character.
      * @param e a symbol value (see Entities class: alfa is greek alfa,...)
@@ -363,7 +372,7 @@ public class EntitiesToSymbol {
         Font symbol = new Font(Font.SYMBOL, font.getSize(), font.getStyle(), font.getColor());
         return new Chunk(String.valueOf(s), symbol);
     }
-    
+
     /**
      * Looks for the corresponding symbol in the font Symbol.
      *
@@ -371,7 +380,7 @@ public class EntitiesToSymbol {
      * @return    the corresponding character in font Symbol
      */
     public static char getCorrespondingSymbol(String name) {
-        Character symbol = (Character) map.get(name);
+        Character symbol = map.get(name);
         if (symbol == null) {
             return (char)0;
         }

--- a/openpdf/src/main/java/com/lowagie/text/xml/simpleparser/EntitiesToUnicode.java
+++ b/openpdf/src/main/java/com/lowagie/text/xml/simpleparser/EntitiesToUnicode.java
@@ -50,17 +50,27 @@
 package com.lowagie.text.xml.simpleparser;
 
 import java.util.HashMap;
+import java.util.Map;
 
 /**
  * This class contains entities that can be used in an entity tag.
  */
 
+@SuppressWarnings("deprecated")
 public class EntitiesToUnicode {
-    
+
+    public static Map<String, Character> getMap() {
+        return map;
+    }
+
     /**
      * This is a map that contains the names of entities and their unicode value.
+     *
+     * @deprecated use the getter ({@link EntitiesToUnicode#getMap()}) instead of accessing this field directly
      */
-    public static final HashMap map = new HashMap();
+    @Deprecated
+    public static final HashMap<String, Character> map = new HashMap<>();
+
     static {
         map.put("nbsp", '\u00a0'); // no-break space = non-breaking space, U+00A0 ISOnum
         map.put("iexcl", '\u00a1'); // inverted exclamation mark, U+00A1 ISOnum
@@ -383,7 +393,7 @@ public class EntitiesToUnicode {
                 return '\0';
             }
         }
-        Character c = (Character)map.get(name);
+        Character c = map.get(name);
         if (c == null)
             return '\0';
         else


### PR DESCRIPTION
Specifying generic types.

In TSAClientBouncyCastle on line 181, replacing deprecated bouncycastle `TimeStampRequest request = tsqGenerator.generate(X509ObjectIdentifiers.id_SHA1.getId(), imprint, nonce);` by `TimeStampRequest request = tsqGenerator.generate(X509ObjectIdentifiers.id_SHA1, imprint, nonce);`as suggested by their javadoc.

No breaking changes here, I think.