### PR TITLE
Remove warnings 11

### DIFF
--- a/openpdf/src/main/java/com/lowagie/text/Anchor.java
+++ b/openpdf/src/main/java/com/lowagie/text/Anchor.java
@@ -218,8 +218,8 @@ public class Anchor extends Phrase {
      *
      * @return    an <CODE>ArrayList</CODE>
      */
-    public java.util.ArrayList<Element> getChunks() {
-        java.util.ArrayList<Element> tmp = new ArrayList<>();
+    public ArrayList<Element> getChunks() {
+        ArrayList<Element> tmp = new ArrayList<>();
         Chunk chunk;
         Iterator<Element> i = iterator();
         boolean localDestination = (reference != null && reference.startsWith("#"));

--- a/openpdf/src/main/java/com/lowagie/text/Cell.java
+++ b/openpdf/src/main/java/com/lowagie/text/Cell.java
@@ -253,8 +253,8 @@ public class Cell extends TableRectangle implements TextElementArray, WithHorizo
      *
      * @return    an <CODE>ArrayList</CODE>
      */
-    public java.util.ArrayList<Element> getChunks() {
-        java.util.ArrayList<Element> tmp = new ArrayList<>();
+    public ArrayList<Element> getChunks() {
+        ArrayList<Element> tmp = new ArrayList<>();
         for (Element o : arrayList) {
             tmp.addAll(o.getChunks());
         }

--- a/openpdf/src/main/java/com/lowagie/text/Chunk.java
+++ b/openpdf/src/main/java/com/lowagie/text/Chunk.java
@@ -320,8 +320,8 @@ public class Chunk implements Element {
      * 
      * @return an <CODE>ArrayList</CODE>
      */
-    public ArrayList getChunks() {
-        ArrayList tmp = new ArrayList();
+    public ArrayList<Element> getChunks() {
+        ArrayList<Element> tmp = new ArrayList<>();
         tmp.add(this);
         return tmp;
     }
@@ -447,6 +447,7 @@ public class Chunk implements Element {
      * @deprecated use {@link #setChunkAttributes(Map)}
      */
     @Deprecated
+    @SuppressWarnings("unchecked")
     public void setAttributes(HashMap attributes) {
         this.attributes = attributes;
     }

--- a/openpdf/src/main/java/com/lowagie/text/Element.java
+++ b/openpdf/src/main/java/com/lowagie/text/Element.java
@@ -49,6 +49,8 @@
 
 package com.lowagie.text;
 
+import java.util.ArrayList;
+
 /**
  * Interface for a text element.
  * <P>
@@ -344,7 +346,7 @@ public interface Element {
      * @return an <CODE>ArrayList</CODE>
      */
 
-    java.util.ArrayList<Element> getChunks();
+    ArrayList<Element> getChunks();
 
     /**
      * Gets the content of the text element.

--- a/openpdf/src/main/java/com/lowagie/text/List.java
+++ b/openpdf/src/main/java/com/lowagie/text/List.java
@@ -250,8 +250,8 @@ public class List implements TextElementArray {
      *
      * @return    an <CODE>ArrayList</CODE>
      */
-    public java.util.ArrayList<Element> getChunks() {
-        java.util.ArrayList<Element> tmp = new ArrayList<>();
+    public ArrayList<Element> getChunks() {
+        ArrayList<Element> tmp = new ArrayList<>();
         for (Element o : list) {
             tmp.addAll(o.getChunks());
         }

--- a/openpdf/src/main/java/com/lowagie/text/MarkedObject.java
+++ b/openpdf/src/main/java/com/lowagie/text/MarkedObject.java
@@ -49,6 +49,7 @@
 
 package com.lowagie.text;
 
+import java.util.ArrayList;
 import java.util.Properties;
 
 /**
@@ -86,7 +87,7 @@ public class MarkedObject implements Element {
      *
      * @return  an <CODE>ArrayList</CODE>
      */
-    public java.util.ArrayList<Element> getChunks() {
+    public ArrayList<Element> getChunks() {
         return element.getChunks();
     }
 

--- a/openpdf/src/main/java/com/lowagie/text/Meta.java
+++ b/openpdf/src/main/java/com/lowagie/text/Meta.java
@@ -130,8 +130,8 @@ public class Meta implements Element {
      *
      * @return    an <CODE>ArrayList</CODE>
      */
-    public ArrayList getChunks() {
-        return new ArrayList();
+    public ArrayList<Element> getChunks() {
+        return new ArrayList<>();
     }
     
     /**

--- a/openpdf/src/main/java/com/lowagie/text/Phrase.java
+++ b/openpdf/src/main/java/com/lowagie/text/Phrase.java
@@ -83,7 +83,7 @@ import com.lowagie.text.pdf.HyphenationEvent;
  * @see        Anchor
  */
 
-public class Phrase extends java.util.ArrayList<Element> implements TextElementArray {
+public class Phrase extends ArrayList<Element> implements TextElementArray {
 
     // constants
     private static final long serialVersionUID = 2643594602455068231L;
@@ -236,8 +236,8 @@ public class Phrase extends java.util.ArrayList<Element> implements TextElementA
      *
      * @return    an <CODE>ArrayList</CODE>
      */
-    public java.util.ArrayList<Element> getChunks() {
-        java.util.ArrayList<Element> tmp = new ArrayList<>();
+    public ArrayList<Element> getChunks() {
+        ArrayList<Element> tmp = new ArrayList<>();
         for (Element element : this) {
             tmp.addAll(element.getChunks());
         }

--- a/openpdf/src/main/java/com/lowagie/text/Rectangle.java
+++ b/openpdf/src/main/java/com/lowagie/text/Rectangle.java
@@ -283,7 +283,7 @@ public class Rectangle implements Element {
    * @return an <CODE>ArrayList</CODE>
    */
   @Override
-  public java.util.ArrayList<Element> getChunks() {
+  public ArrayList<Element> getChunks() {
     return new ArrayList<>();
   }
 

--- a/openpdf/src/main/java/com/lowagie/text/Row.java
+++ b/openpdf/src/main/java/com/lowagie/text/Row.java
@@ -146,7 +146,7 @@ public class Row implements Element, WithHorizontalAlignment {
      *
      * @return  an <CODE>ArrayList</CODE>
      */
-    public java.util.ArrayList<Element> getChunks() {
+    public ArrayList<Element> getChunks() {
         return new ArrayList<>();
     }
     

--- a/openpdf/src/main/java/com/lowagie/text/Section.java
+++ b/openpdf/src/main/java/com/lowagie/text/Section.java
@@ -81,7 +81,7 @@ import com.lowagie.text.error_messages.MessageLocalization;
  * </PRE></BLOCKQUOTE>
  */
 
-public class Section extends java.util.ArrayList<Element> implements TextElementArray, LargeElement {
+public class Section extends ArrayList<Element> implements TextElementArray, LargeElement {
     // constant
     /**
      * A possible number style. The default number style: "1.2.3."
@@ -231,8 +231,8 @@ public class Section extends java.util.ArrayList<Element> implements TextElement
      *
      * @return    an <CODE>ArrayList</CODE>
      */
-    public java.util.ArrayList<Element> getChunks() {
-        java.util.ArrayList<Element> tmp = new ArrayList<>();
+    public ArrayList<Element> getChunks() {
+        ArrayList<Element> tmp = new ArrayList<>();
         for (Element o : this) {
             tmp.addAll(o.getChunks());
         }

--- a/openpdf/src/main/java/com/lowagie/text/Table.java
+++ b/openpdf/src/main/java/com/lowagie/text/Table.java
@@ -330,7 +330,7 @@ public class Table extends TableRectangle implements LargeElement, WithHorizonta
      * @return  an <CODE>ArrayList</CODE>
      */
     
-    public java.util.ArrayList<Element> getChunks() {
+    public ArrayList<Element> getChunks() {
         return new ArrayList<>();
     }
 


### PR DESCRIPTION
Specifying generic types.
Import ArrayList instead of using the full Class package + name
No breaking changes here, I think.