### PR TITLE
Doesn't clean metadata by default in Stamper.

### DIFF
--- a/openpdf/src/main/java/com/lowagie/text/pdf/PdfStamper.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/PdfStamper.java
@@ -160,6 +160,23 @@ public class PdfStamper
     public void setMoreInfo(HashMap moreInfo) {
         this.moreInfo = moreInfo;
     }
+    
+    /**
+     * An option to make this stamper to clean metadata in the generated file. You must call this method before closing the stamper.
+     */
+    
+    public void cleanMetadata() {
+      Map<String, String> meta = new HashMap<>();
+      meta.put("Title", null);
+      meta.put("Author", null);
+      meta.put("Subject", null);
+      meta.put("Producer", null);
+      meta.put("Keywords", null);
+      meta.put("Creator", null);
+      meta.put("CreationDate", null);
+      meta.put("ModDate",null);
+      setInfoDictionary(meta);
+    }
 
     /** An optional <CODE>String</CODE> map to add or change values in
      * the info dictionary. Entries with <CODE>null</CODE>

--- a/openpdf/src/main/java/com/lowagie/text/pdf/PdfStamperImp.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/PdfStamperImp.java
@@ -57,20 +57,20 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import com.lowagie.text.error_messages.MessageLocalization;
-
-import com.lowagie.text.ExceptionConverter;
-import com.lowagie.text.pdf.AcroFields.Item;
+import org.xml.sax.SAXException;
 
 import com.lowagie.text.Document;
 import com.lowagie.text.DocumentException;
-
+import com.lowagie.text.ExceptionConverter;
 import com.lowagie.text.Image;
 import com.lowagie.text.Rectangle;
+import com.lowagie.text.error_messages.MessageLocalization;
 import com.lowagie.text.exceptions.BadPasswordException;
+import com.lowagie.text.pdf.AcroFields.Item;
 import com.lowagie.text.pdf.collection.PdfCollection;
 import com.lowagie.text.pdf.interfaces.PdfViewerPreferences;
 import com.lowagie.text.pdf.internal.PdfViewerPreferencesImp;
+import com.lowagie.text.xml.xmp.XmpReader;
 
 class PdfStamperImp extends PdfWriter {
     HashMap<PdfReader, IntHashtable> readers2intrefs = new HashMap<>();
@@ -220,14 +220,60 @@ class PdfStamperImp extends PdfWriter {
         int skipInfo = -1;
         PRIndirectReference iInfo = (PRIndirectReference)reader.getTrailer().get(PdfName.INFO);
       
-
+        PdfDictionary oldInfo = (PdfDictionary)PdfReader.getPdfObject(iInfo);
+        String producer = null;
+        if (iInfo != null) {
+          skipInfo = iInfo.getNumber();
+        }
+        if (oldInfo != null && oldInfo.get(PdfName.PRODUCER) != null) {
+          producer = oldInfo.getAsString(PdfName.PRODUCER).toString();
+        }
+        if (producer == null) {
+          producer = Document.getVersion();
+        }
+        else if (!producer.contains(Document.getProduct())) {
+          StringBuffer buf = new StringBuffer(producer);
+          buf.append("; modified using ");
+          buf.append(Document.getVersion());
+          producer = buf.toString();
+        }
+          
         // XMP
-        byte[] altMetadata = xmpMetadata;
+        byte[] altMetadata = null;
+        PdfObject xmpo = PdfReader.getPdfObject(catalog.get(PdfName.METADATA));
+        if (xmpo != null && xmpo.isStream()) {
+          altMetadata = PdfReader.getStreamBytesRaw((PRStream)xmpo);
+          PdfReader.killIndirect(catalog.get(PdfName.METADATA));
+        }
+        if (xmpMetadata != null) {
+          altMetadata = xmpMetadata;
+        }
+        PdfDate date = null;
+        if (modificationDate == null) {
+          date = new PdfDate();
+        }
+        else {
+          date = new PdfDate(modificationDate);
+        }
 
         // if there is XMP data to add: add it
         
         if (altMetadata != null) {
-            PdfStream xmp = new PdfStream(altMetadata);
+            PdfStream xmp = null;
+            try {
+              XmpReader xmpr = new XmpReader(altMetadata);
+              if (!xmpr.replace("http://ns.adobe.com/pdf/1.3/", "Producer", producer)) {
+                xmpr.add("rdf:Description", "http://ns.adobe.com/pdf/1.3/", "pdf:Producer", producer);
+              }
+              if (!xmpr.replace("http://ns.adobe.com/xap/1.0/", "ModifyDate", date.getW3CDate())) {
+                xmpr.add("rdf:Description", "http://ns.adobe.com/xap/1.0/", "xmp:ModifyDate", date.getW3CDate());
+              }
+              xmpr.replace("http://ns.adobe.com/xap/1.0/", "MetadataDate", date.getW3CDate());
+              xmp = new PdfStream(xmpr.serializeDoc());              
+            }
+            catch (SAXException | IOException e) {
+              xmp = new PdfStream(altMetadata);
+            }
             xmp.put(PdfName.TYPE, PdfName.METADATA);
             xmp.put(PdfName.SUBTYPE, PdfName.XML);
             if (crypto != null && !crypto.isMetadataEncrypted()) {
@@ -235,8 +281,13 @@ class PdfStamperImp extends PdfWriter {
                 ar.add(PdfName.CRYPT);
                 xmp.put(PdfName.FILTER, ar);
             }
-            catalog.put(PdfName.METADATA, body.add(xmp).getIndirectReference());
-            markUsed(catalog);            
+            if (append && xmpo != null) {
+              body.add(xmp, xmpo.getIndRef());
+            }
+            else {
+              catalog.put(PdfName.METADATA, body.add(xmp).getIndirectReference());
+              markUsed(catalog);
+            }        
         }
         try {
             file.reOpen();
@@ -298,16 +349,27 @@ class PdfStamperImp extends PdfWriter {
         PdfIndirectReference root = new PdfIndirectReference(0, getNewObjectNumber(reader, iRoot.getNumber(), 0));
         PdfIndirectReference info = null;
         PdfDictionary newInfo = new PdfDictionary();
-
+        if (oldInfo != null) {
+          for (PdfName key : oldInfo.getKeys()) {
+            PdfObject value = PdfReader.getPdfObject(oldInfo.get(key));
+            newInfo.put(key, value);
+          }
+        }
+        
+        newInfo.put(PdfName.MODDATE, date);
+        newInfo.put(PdfName.PRODUCER, new PdfString(producer));
+        
         if (moreInfo != null) {
             for (Map.Entry<String, String> entry : moreInfo.entrySet()) {
                 String key = entry.getKey();
                 PdfName keyName = new PdfName(key);
                 String value = entry.getValue();
-                if (value == null)
+                if (value == null) {
                     newInfo.remove(keyName);
-                else
+                }
+                else {
                     newInfo.put(keyName, new PdfString(value, PdfObject.TEXT_UNICODE));
+                }
             }
         }
 

--- a/openpdf/src/test/java/com/lowagie/text/pdf/metadata/CleanMetaDataTest.java
+++ b/openpdf/src/test/java/com/lowagie/text/pdf/metadata/CleanMetaDataTest.java
@@ -17,6 +17,22 @@ import com.lowagie.text.pdf.PdfStamper;
 import com.lowagie.text.pdf.PdfWriter;
 
 public class CleanMetaDataTest {
+  
+  public CleanMetaDataTest() {
+    super();
+  }
+  
+  private HashMap<String, String> createCleanerMoreInfo() {
+    HashMap<String, String> moreInfo = new HashMap<String, String>();
+    moreInfo.put("Title", null);
+    moreInfo.put("Author", null);
+    moreInfo.put("Subject", null);
+    moreInfo.put("Producer", null);
+    moreInfo.put("Keywords", null);
+    moreInfo.put("Creator", null);
+    moreInfo.put("ModDate",null);
+    return moreInfo;
+  }
 
 	@Test
 	public void testProducer() throws Exception {
@@ -65,18 +81,20 @@ public class CleanMetaDataTest {
 
 	@Test
 	public void testStamperMetadata() throws Exception {
-		byte[] data = addWatermark(new File("src/test/resources/HelloWorldMeta.pdf"), false, null);
+		byte[] data = addWatermark(new File("src/test/resources/HelloWorldMeta.pdf"), false, createCleanerMoreInfo());
 		PdfReader r = new PdfReader(data);
 		Assertions.assertNull(r.getInfo().get("Producer"));
 		Assertions.assertNull(r.getInfo().get("Author"));
 		Assertions.assertNull(r.getInfo().get("Title"));
 		Assertions.assertNull(r.getInfo().get("Subject"));	
 		r.close();
+		String dataString = new String(data);
+		Assertions.assertFalse(dataString.contains("This example explains how to add metadata."));
 	}
 	
 	@Test
 	public void testStamperEncryptMetadata() throws Exception {
-		byte[] data = addWatermark(new File("src/test/resources/HelloWorldMeta.pdf"), true, null);
+		byte[] data = addWatermark(new File("src/test/resources/HelloWorldMeta.pdf"), true, createCleanerMoreInfo());
 		PdfReader r = new PdfReader(data);
 		Assertions.assertNull(r.getInfo().get("Producer"));
 		Assertions.assertNull(r.getInfo().get("Author"));
@@ -100,6 +118,28 @@ public class CleanMetaDataTest {
 		Assertions.assertEquals("Title2", r.getInfo().get("Title"));
 		Assertions.assertEquals("Subject3", r.getInfo().get("Subject"));	
 		r.close();
+	}
+	
+	@Test
+	public void testCleanMetadataMethodInStamper() throws Exception {
+	  byte[] data = cleanMetadata(new File("src/test/resources/HelloWorldMeta.pdf"));
+	  PdfReader r = new PdfReader(data);
+    Assertions.assertNull(r.getInfo().get("Producer"));
+    Assertions.assertNull(r.getInfo().get("Author"));
+    Assertions.assertNull(r.getInfo().get("Title"));
+    Assertions.assertNull(r.getInfo().get("Subject"));  
+    r.close();
+    String dataString = new String(data);
+    Assertions.assertFalse(dataString.contains("This example explains how to add metadata."));
+	}
+	
+	private byte[] cleanMetadata(File origin) throws Exception {
+	  ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    PdfReader reader = new PdfReader(origin.getAbsolutePath());
+    PdfStamper stamp = new PdfStamper(reader, baos);
+    stamp.cleanMetadata();
+    stamp.close();
+    return baos.toByteArray();
 	}
 	
 


### PR DESCRIPTION
It reverts previous pull request (#179) and provide a utility method in stamper to clean metadata.
Metadata is preserved by default and only removed via new method or via setInfoDictionary

Fixes LibrePDF/OpenPDF#216

