### PR TITLE
:bug: Fix bug #231 : Text is not rendered with specific font

### DIFF
--- a/openpdf/src/main/java/com/lowagie/text/pdf/TrueTypeFont.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/TrueTypeFont.java
@@ -879,6 +879,7 @@ class TrueTypeFont extends BaseFont {
     HashMap<Integer, int[]> readFormat12() throws IOException {
         HashMap<Integer, int[]> h = new HashMap<>();
         rf.skipBytes(2);
+        rf.readInt();
         rf.skipBytes(4);
         int nGroups = rf.readInt();
         for (int k = 0; k < nGroups; k++) {


### PR DESCRIPTION
Originally was :

```
       rf.skipBytes(2);
        int table_lenght = rf.readInt();
        rf.skipBytes(4);
``` 

But as the table_length variable was not used, I removed it but without reading the buffer... :grimacing: 

