### PR TITLE
Feat : clean Javadoc Warnings

### DIFF
--- a/openpdf/src/main/java/com/lowagie/text/MarkedSection.java
+++ b/openpdf/src/main/java/com/lowagie/text/MarkedSection.java
@@ -210,7 +210,7 @@ public class MarkedSection extends MarkedObject {
      * <P>
      * If the numberdepth is 0, the sections will not be numbered. If the numberdepth
      * is 1, the section will be numbered with their own number. If the numberdepth is
-     * higher (for instance x > 1), the numbers of x - 1 parents will be shown.
+     * higher (for instance {@literal x > 1}), the numbers of {@literal x - 1} parents will be shown.
      *
      * @param    numberDepth        the new numberDepth
      */

--- a/openpdf/src/main/java/com/lowagie/text/Section.java
+++ b/openpdf/src/main/java/com/lowagie/text/Section.java
@@ -496,7 +496,7 @@ public class Section extends ArrayList<Element> implements TextElementArray, Lar
      * <P>
      * If the numberdepth is 0, the sections will not be numbered. If the numberdepth
      * is 1, the section will be numbered with their own number. If the numberdepth is
-     * higher (for instance x > 1), the numbers of x - 1 parents will be shown.
+     * higher (for instance {@literal x > 1}), the numbers of {@literal x - 1} parents will be shown.
      *
      * @param    numberDepth        the new numberDepth
      */

--- a/openpdf/src/main/java/com/lowagie/text/SplitCharacter.java
+++ b/openpdf/src/main/java/com/lowagie/text/SplitCharacter.java
@@ -64,7 +64,7 @@ public interface SplitCharacter {
      * <p>
      * The default implementation is:
      * <p>
-     * <pre>
+     * <pre>{@code
      * public boolean isSplitCharacter(int start, int current, int end, char[] cc, PdfChunk[] ck) {
      *    char c;
      *    if (ck == null)
@@ -81,7 +81,7 @@ public interface SplitCharacter {
      *    || (c >= 0xfe30 && c < 0xfe50)
      *    || (c >= 0xff61 && c < 0xffa0));
      * }
-     * </pre>
+     * }</pre>
      * @param start the lower limit of <CODE>cc</CODE> inclusive
      * @param current the pointer to the character in <CODE>cc</CODE>
      * @param end the upper limit of <CODE>cc</CODE> exclusive

--- a/openpdf/src/main/java/com/lowagie/text/html/simpleparser/ChainedProperties.java
+++ b/openpdf/src/main/java/com/lowagie/text/html/simpleparser/ChainedProperties.java
@@ -123,7 +123,7 @@ public class ChainedProperties {
     }
 
     /**
-     * @deprecated use {@link ChainedProperties#addToChain(String, Map<String, String>)}
+     * @deprecated use {@link ChainedProperties#addToChain(String, HashMap)}
      */
     @Deprecated
     @SuppressWarnings("unchecked")

--- a/openpdf/src/main/java/com/lowagie/text/html/simpleparser/FactoryProperties.java
+++ b/openpdf/src/main/java/com/lowagie/text/html/simpleparser/FactoryProperties.java
@@ -231,7 +231,7 @@ public class FactoryProperties {
      * @param h a HashMap that should have at least a key named
      *          style. After this method is invoked, more keys could be added.
      *
-     * @deprecated use {@link FactoryProperties#insertStyle(Map<String, String>)} instead. (since 1.2.22)
+     * @deprecated use {@link FactoryProperties#insertStyle(Map)} instead. (since 1.2.22)
      */
     @SuppressWarnings("unchecked")
     @Deprecated

--- a/openpdf/src/main/java/com/lowagie/text/html/simpleparser/HTMLWorker.java
+++ b/openpdf/src/main/java/com/lowagie/text/html/simpleparser/HTMLWorker.java
@@ -164,7 +164,7 @@ public class HTMLWorker implements SimpleXMLDocHandler, DocListener {
 
     /**
      *
-     * @deprecated use {@link HTMLWorker#setInterfaceProps(Map<String, Object>)} since 1.2.22
+     * @deprecated use {@link HTMLWorker#setInterfaceProps(Map)} since 1.2.22
      */
     @SuppressWarnings("unchecked")
     @Deprecated
@@ -204,7 +204,7 @@ public class HTMLWorker implements SimpleXMLDocHandler, DocListener {
     }
 
     /**
-     * @deprecated use {@link HTMLWorker#startElement(String, Map<String, String>)}  } since 1.2.22
+     * @deprecated use {@link HTMLWorker#startElement(String, Map)}  } since 1.2.22
      */
     @Deprecated
     @SuppressWarnings("unchecked")

--- a/openpdf/src/main/java/com/lowagie/text/pdf/BidiLine.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/BidiLine.java
@@ -207,7 +207,7 @@ public class BidiLine {
     }
 
     /**
-     * Deprecated use {@link BidiLine#addChunks(List<PdfChunk>)}, since 1.2.22
+     * Deprecated use {@link BidiLine#addChunks(List)}, since 1.2.22
      */
     @Deprecated
     @SuppressWarnings("unchecked")

--- a/openpdf/src/main/java/com/lowagie/text/pdf/CFFFont.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/CFFFont.java
@@ -985,7 +985,7 @@ public class CFFFont {
     protected int[] gsubrOffsets;
     
     /**
-     * TODO Changed from private to protected by Ygal&Oren
+     * TODO Changed from private to protected by {@literal Ygal&Oren}
      */
     protected final class Font {
         public String    name;

--- a/openpdf/src/main/java/com/lowagie/text/pdf/CFFFontSubset.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/CFFFontSubset.java
@@ -429,7 +429,7 @@ public class CFFFontSubset extends CFFFont {
     }
     
     /**
-     * Function builds the new local & global subsrs indices. IF CID then All of 
+     * Function builds the new local and global subsrs indices. IF CID then All of
      * the FD Array lsubrs will be subsetted. 
      * @param Font the font
      * @throws IOException
@@ -519,8 +519,8 @@ public class CFFFontSubset extends CFFFont {
     }
 
     /**
-     * Function uses ReadAsubr on the glyph used to build the LSubr & Gsubr HashMap.
-     * The HashMap (of the lsubr only) is then scanned recursively for Lsubr & Gsubrs
+     * Function uses ReadAsubr on the glyph used to build the LSubr and Gsubr HashMap.
+     * The HashMap (of the lsubr only) is then scanned recursively for Lsubr and Gsubrs
      * calls.  
      * @param Font the font
      * @param FD FD array processed. 0 indicates function was called by non CID font
@@ -574,7 +574,7 @@ public class CFFFontSubset extends CFFFont {
     
     /**
      * Function scans the Glsubr used ArrayList to find recursive calls 
-     * to Gsubrs and adds to Hashmap & ArrayList
+     * to Gsubrs and adds to Hashmap and ArrayList
      * @param Font the font
      */
     protected void BuildGSubrsUsed(int Font)
@@ -737,7 +737,7 @@ public class CFFFontSubset extends CFFFont {
     
     /**
      * Function checks the key and return the change to the stack after the operator
-     * @return The change in the stack. 2-> flush the stack
+     * @return The change in the stack. {@literal 2->} flush the stack
      */
     protected int StackOpp()
     {

--- a/openpdf/src/main/java/com/lowagie/text/pdf/PdfDictionary.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/PdfDictionary.java
@@ -67,8 +67,8 @@ import java.util.Set;
  * A dictionary is generally used to collect and tie together the attributes
  * of a complex object, with each key-value pair specifying the name and value
  * of an attribute.<BR>
- * A dictionary is represented by two left angle brackets (<<), followed by a
- * sequence of key-value pairs, followed by two right angle brackets (>>).<BR>
+ * A dictionary is represented by two left angle brackets ({@literal <<}), followed by a
+ * sequence of key-value pairs, followed by two right angle brackets ({@literal >>}).<BR>
  * This object is described in the 'Portable Document Format Reference Manual
  * version 1.7' section 3.2.6 (page 59-60).
  * <P>

--- a/openpdf/src/main/java/com/lowagie/text/pdf/PdfObject.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/PdfObject.java
@@ -280,7 +280,7 @@ public abstract class PdfObject {
      * - <VAR>ARRAY</VAR>: A <CODE>PdfArray</CODE>
      * - <VAR>DICTIONARY</VAR>: A <CODE>PdfDictionary</CODE>
      * - <VAR>STREAM</VAR>: A <CODE>PdfStream</CODE>
-     * - <VAR>INDIRECT</VAR>: ><CODE>PdfIndirectObject</CODE>
+     * - <VAR>INDIRECT</VAR>: {@literal >} <CODE>PdfIndirectObject</CODE>
      *
      * @return The type
      */

--- a/openpdf/src/main/java/com/lowagie/text/pdf/PdfPTable.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/PdfPTable.java
@@ -891,7 +891,7 @@ public class PdfPTable implements LargeElement{
     
     /**
      * Gets the maximum height of a cell in a particular row (will only be different
-     * from getRowHeight is one of the cells in the row has a rowspan > 1).
+     * from getRowHeight is one of the cells in the row has a rowspan {@literal >} 1).
      * 
      * @param    rowIndex    the row index
      * @param    cellIndex    the cell index

--- a/openpdf/src/main/java/com/lowagie/text/pdf/PdfSignatureAppearance.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/PdfSignatureAppearance.java
@@ -1165,11 +1165,11 @@ public class PdfSignatureAppearance {
    * general sequence is: preClose(), getDocumentBytes() and close().
    * <p>
    * <CODE>update</CODE> is a <CODE>PdfDictionary</CODE> that must have exactly
-   * the same keys as the ones provided in {@link #preClose(HashMap)}.
+   * the same keys as the ones provided in {@link PdfSignatureAppearance#preClose(Map)}.
    * 
    * @param update
    *          a <CODE>PdfDictionary</CODE> with the key/value that will fill the
-   *          holes defined in {@link #preClose(HashMap)}
+   *          holes defined in {@link PdfSignatureAppearance#preClose(Map)}
    * @throws DocumentException
    *           on error
    * @throws IOException

--- a/openpdf/src/main/java/com/lowagie/text/pdf/SimpleBookmark.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/SimpleBookmark.java
@@ -756,7 +756,7 @@ public final class SimpleBookmark implements SimpleXMLDocHandler {
     }
 
     /**
-     * @deprecated user {@link SimpleBookmark#startElement(String, Map<String, String>)}
+     * @deprecated user {@link SimpleBookmark#startElement(String, Map)}
      */
     @Deprecated
     @SuppressWarnings("unchecked")

--- a/openpdf/src/main/java/com/lowagie/text/pdf/TextField.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/TextField.java
@@ -702,7 +702,7 @@ public class TextField extends BaseField {
     
     /**
      * adds another (or a first I suppose) selection to a MULTISELECT list.
-     * This doesn't do anything unless this.options & MUTLISELECT != 0 
+     * This doesn't do anything unless {@code this.options & MUTLISELECT != 0}
      * @param selection new selection
      */
     public void addChoiceSelection( int selection) {

--- a/openpdf/src/main/java/com/lowagie/text/pdf/hyphenation/ByteVector.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/hyphenation/ByteVector.java
@@ -22,7 +22,7 @@ import java.io.Serializable;
  * This class implements a simple byte vector with access to the
  * underlying array.
  *
- * @author Carlos Villegas <cav@uniscope.co.jp>
+ * @author <a href="cav@uniscope.co.jp">Carlos Villegas</a>
  */
 public class ByteVector implements Serializable {
 

--- a/openpdf/src/main/java/com/lowagie/text/pdf/hyphenation/CharVector.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/hyphenation/CharVector.java
@@ -22,7 +22,7 @@ import java.io.Serializable;
  * This class implements a simple char vector with access to the
  * underlying array.
  *
- * @author Carlos Villegas <cav@uniscope.co.jp>
+ * @author <a href="cav@uniscope.co.jp">Carlos Villegas</a>
  */
 public class CharVector implements Cloneable, Serializable {
 

--- a/openpdf/src/main/java/com/lowagie/text/pdf/hyphenation/Hyphen.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/hyphenation/Hyphen.java
@@ -28,7 +28,7 @@ import java.io.Serializable;
  * spelling if they're split across lines, like german's 'backen' which
  * hyphenates 'bak-ken'. BTW, this comes from TeX.
  *
- * @author Carlos Villegas <cav@uniscope.co.jp>
+ * @author <a href="cav@uniscope.co.jp">Carlos Villegas</a>
  */
 
 public class Hyphen implements Serializable {

--- a/openpdf/src/main/java/com/lowagie/text/pdf/hyphenation/Hyphenation.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/hyphenation/Hyphenation.java
@@ -19,7 +19,7 @@ package com.lowagie.text.pdf.hyphenation;
 /**
  * This class represents a hyphenated word.
  *
- * @author Carlos Villegas <cav@uniscope.co.jp>
+ * @author <a href="cav@uniscope.co.jp">Carlos Villegas</a>
  */
 public class Hyphenation {
     

--- a/openpdf/src/main/java/com/lowagie/text/pdf/hyphenation/HyphenationException.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/hyphenation/HyphenationException.java
@@ -17,7 +17,7 @@
 package com.lowagie.text.pdf.hyphenation;
 
 /**
- * @author Carlos Villegas <cav@uniscope.co.jp>
+ * @author <a href="cav@uniscope.co.jp">Carlos Villegas</a>
  */
 public class HyphenationException extends Exception {
 

--- a/openpdf/src/main/java/com/lowagie/text/pdf/hyphenation/HyphenationTree.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/hyphenation/HyphenationTree.java
@@ -29,7 +29,7 @@ import java.util.Map;
  * way for fast lookup. It provides the provides the method to
  * hyphenate a word.
  *
- * @author Carlos Villegas <cav@uniscope.co.jp>
+ * @author <a href="cav@uniscope.co.jp">Carlos Villegas</a>
  */
 public class HyphenationTree extends TernaryTree 
             implements PatternConsumer {
@@ -173,12 +173,14 @@ public class HyphenationTree extends TernaryTree
      * <p>Search for all possible partial matches of word starting
      * at index an update interletter values. In other words, it
      * does something like:</p>
-     * <code>
-     * for(i=0; i<patterns.length; i++) {
-     * if ( word.substring(index).startsWidth(patterns[i]) )
-     * update_interletter_values(patterns[i]);
-     * }
-     * </code>
+     * <pre>
+     * {@code
+     *  for(i=0; i<patterns.length; i++) {
+     *      if ( word.substring(index).startsWidth(patterns[i]) ) {
+     *          update_interletter_values(patterns[i]);
+     *      }
+     *  }
+     * }</pre>
      * <p>But it is done in an efficient way since the patterns are
      * stored in a ternary tree. In fact, this is the whole purpose
      * of having the tree: doing this search without having to test

--- a/openpdf/src/main/java/com/lowagie/text/pdf/hyphenation/Hyphenator.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/hyphenation/Hyphenator.java
@@ -28,7 +28,7 @@ import com.lowagie.text.pdf.BaseFont;
  * This class is the main entry point to the hyphenation package.
  * You can use only the static methods or create an instance.
  *
- * @author Carlos Villegas <cav@uniscope.co.jp>
+ * @author <a href="cav@uniscope.co.jp">Carlos Villegas</a>
  */
 public class Hyphenator {
     

--- a/openpdf/src/main/java/com/lowagie/text/pdf/hyphenation/PatternConsumer.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/hyphenation/PatternConsumer.java
@@ -22,7 +22,7 @@ import java.util.ArrayList;
  * This interface is used to connect the XML pattern file parser to
  * the hyphenation tree.
  *
- * @author Carlos Villegas <cav@uniscope.co.jp>
+ * @author <a href="cav@uniscope.co.jp">Carlos Villegas</a>
  */
 public interface PatternConsumer {
 

--- a/openpdf/src/main/java/com/lowagie/text/pdf/parser/MarkedUpTextAssembler.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/parser/MarkedUpTextAssembler.java
@@ -113,8 +113,7 @@ public class MarkedUpTextAssembler implements TextAssembler {
 
     /**
      * {@inheritDoc}
-     * @see com.lowagie.text.pdf.parser.TextAssembler#process(com.lowagie.text.pdf.parser.Word,
-     *      String)
+     * @see com.lowagie.text.pdf.parser.TextAssembler#process(Word, String)
      */
     @Override
     public void process(Word completed, String contextName) {
@@ -193,10 +192,8 @@ public class MarkedUpTextAssembler implements TextAssembler {
      * Captures text using a simplified algorithm for inserting hard returns and
      * spaces
      *
-     * @see com.lowagie.text.pdf.parser.AbstractRenderListener#renderText(java.lang.String,
-     *      com.lowagie.text.pdf.parser.GraphicsState,
-     *      com.lowagie.text.pdf.parser.Matrix,
-     *      com.lowagie.text.pdf.parser.Matrix)
+     * @see com.lowagie.text.pdf.parser.GraphicsState
+     * @see com.lowagie.text.pdf.parser.Matrix
      */
     @Override
     public void renderText(ParsedTextImpl partialWord) {
@@ -258,7 +255,6 @@ public class MarkedUpTextAssembler implements TextAssembler {
     /**
      * Getter.
      *
-     * @see SimpleTextExtractingPdfContentRenderListener#_reader
      * @return reader
      */
     protected PdfReader getReader() {

--- a/openpdf/src/main/java/com/lowagie/text/xml/simpleparser/EntitiesToUnicode.java
+++ b/openpdf/src/main/java/com/lowagie/text/xml/simpleparser/EntitiesToUnicode.java
@@ -401,7 +401,7 @@ public class EntitiesToUnicode {
     }
     
     /**
-     * Translates a String with entities (&...;) to a String without entities,
+     * Translates a String with entities {@literal (&...;)} to a String without entities,
      * replacing the entity with the right (unicode) character.
      */
     public static String decodeString(String s) {


### PR DESCRIPTION
Cleaning the Javadoc warnings.

* Wrapping special characters with {@code } or {@litteral }. 
* Replacing some '&' symbol by 'and' word.
* Rewriting some author email address

No breaking changes here.