### PR TITLE
Fix #211 : remove unneeded call to close() on PDFFile when closing PdfWriter

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,16 +38,17 @@ We want OpenPDF to consist of source code which is consistently licensed with th
 OpenPDF is open source software with a LGPL and MPL license. It is a fork of iText version 4, more specifically iText svn tag 4.2.0, which was hosted publicly on sourceforge with LGPL and MPL license headers in the source code, and lgpl and mpl license documents in the svn repository.
 Beginning with version 5.0 of iText, the developers have moved to the AGPL to improve their ability to sell commercial licenses. 
 
-## Contributing ##
-Release the hounds!  Please send all pull requests.
-Make sure that your contributions can be released with a dual LGPL and MPL license. In particular, pull requests to the OpenPDF project must only contain code that you have written yourself. GPL or AGPL licensed code will not be acceptable.
-
 ## Projects using OpenPDF ##
 - Spring Framework https://github.com/spring-projects/spring-framework
 - flyingsaucer https://github.com/flyingsaucerproject/flyingsaucer
 - Confluence PDF Export
+- Digital Signature Service - https://github.com/esig/dss
 - OpenCMS, Nuxeo Web Framework, QR Invoice Library and many closed source commercial applications as well.
 - Full list here: https://mvnrepository.com/artifact/com.github.librepdf/openpdf/usages
+
+## Contributing ##
+Release the hounds!  Please send all pull requests.
+Make sure that your contributions can be released with a dual LGPL and MPL license. In particular, pull requests to the OpenPDF project must only contain code that you have written yourself. GPL or AGPL licensed code will not be acceptable.
 
 ### Coding Style ###
 - Code indentation style is 4 spaces.

--- a/openpdf/src/main/java/com/lowagie/text/pdf/AcroFields.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/AcroFields.java
@@ -53,7 +53,6 @@ import java.util.ArrayList;
 import java.util.Base64;
 import java.util.Comparator;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
@@ -954,8 +953,8 @@ public class AcroFields {
     String[] options = getListOptionExport(name);
     PdfNumber n;
     int idx = 0;
-    for (Iterator i = values.listIterator(); i.hasNext(); ) {
-      n = (PdfNumber) i.next();
+    for (PdfObject pdfObject : values.getElements()) {
+      n = (PdfNumber) pdfObject;
       ret[idx++] = options[n.intValue()];
     }
     return ret;

--- a/openpdf/src/main/java/com/lowagie/text/pdf/PRAcroForm.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/PRAcroForm.java
@@ -53,7 +53,6 @@ package com.lowagie.text.pdf;
 
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.Iterator;
 
 /**
  * This class captures an AcroForm on input. Basically, it extends Dictionary
@@ -140,8 +139,8 @@ public class PRAcroForm extends PdfDictionary {
      * @param title the pathname of the field, up to this point or null
      */
     protected void iterateFields(PdfArray fieldlist, PRIndirectReference fieldDict, String title) {
-        for (Iterator it = fieldlist.listIterator(); it.hasNext();) {
-            PRIndirectReference ref = (PRIndirectReference)it.next();
+        for (PdfObject pdfObject : fieldlist.getElements()) {
+            PRIndirectReference ref = (PRIndirectReference)pdfObject;
             PdfDictionary dict = (PdfDictionary) PdfReader.getPdfObjectRelease(ref);
             
             // if we are not a field dictionary, pass our parent's values

--- a/openpdf/src/main/java/com/lowagie/text/pdf/PdfCopyFieldsImp.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/PdfCopyFieldsImp.java
@@ -51,7 +51,6 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.StringTokenizer;
@@ -213,8 +212,7 @@ class PdfCopyFieldsImp extends PdfWriter {
             }
             case PdfObject.ARRAY: {
                 //PdfArray arr = new PdfArray();
-                for (Iterator it = ((PdfArray)obj).listIterator(); it.hasNext();) {
-                    PdfObject ob = (PdfObject)it.next();
+                for (PdfObject ob : ((PdfArray)obj).getElements()) {
                     if (ob != null && ob.isIndirect()) {
                         PRIndirectReference ind = (PRIndirectReference)ob;
                         if (!isVisited(ind) && !isPage(ind)) {

--- a/openpdf/src/main/java/com/lowagie/text/pdf/PdfGraphics2D.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/PdfGraphics2D.java
@@ -361,7 +361,7 @@ public class PdfGraphics2D extends Graphics2D {
      * @see Graphics2D#drawString(String, float, float)
      */
     public void drawString(String s, float x, float y) {
-        if (s.length() == 0 || (!Float.isFinite(fontSize) || fontSize < PdfContentByte.MIN_FONT_SIZE)) {
+        if (s.length() == 0) {
             return;
         }
         setFillPaint();
@@ -370,6 +370,9 @@ public class PdfGraphics2D extends Graphics2D {
 //            Use the following line to compile in JDK 1.3    
 //            drawGlyphVector(this.font.createGlyphVector(getFontRenderContext(), s), x, y);
         } else {
+            if (!Float.isFinite(fontSize) || fontSize < PdfContentByte.MIN_FONT_SIZE) {
+                return;
+            }
             double width = 0;
             if (CompositeFontDrawer.isSupported() && compositeFontDrawer.isCompositeFont(font)) {
                 width = compositeFontDrawer.drawString(s, font, x, y, this::getCachedBaseFont, this::drawString);

--- a/openpdf/src/main/java/com/lowagie/text/pdf/PdfLister.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/PdfLister.java
@@ -53,7 +53,6 @@
 
 import java.io.IOException;
 import java.io.PrintStream;
-import java.util.Iterator;
 /**
  * List a PDF file in human-readable form (for debugging reasons mostly)
  * @author Mark Thompson
@@ -119,10 +118,7 @@ public class PdfLister {
     public void listArray(PdfArray array)
     {
         out.println('[');
-        for (Iterator i = array.listIterator(); i.hasNext(); ) {
-            PdfObject item = (PdfObject)i.next();
-            listAnyObject(item);
-        }
+        array.getElements().forEach(this::listAnyObject);
         out.println(']');
     }
     /**
@@ -178,8 +174,8 @@ public class PdfLister {
             listStream((PRStream)obj, readerInst);
             break;
         case PdfObject.ARRAY:
-            for (Iterator i = ((PdfArray)obj).listIterator(); i.hasNext();) {
-                PdfObject o = PdfReader.getPdfObject((PdfObject)i.next());
+            for (PdfObject pdfObject : ((PdfArray)obj).getElements()) {
+                PdfObject o = PdfReader.getPdfObject(pdfObject);
                 listStream((PRStream)o, readerInst);
                 out.println("-----------");
             }

--- a/openpdf/src/main/java/com/lowagie/text/pdf/PdfReader.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/PdfReader.java
@@ -3104,9 +3104,7 @@ public class PdfReader implements PdfViewerPreferences, Closeable {
     }
     case PdfObject.ARRAY: {
       PdfArray arr = new PdfArray();
-      for (Iterator it = ((PdfArray) original).listIterator(); it.hasNext();) {
-        arr.add(duplicatePdfObject((PdfObject) it.next(), newReader));
-      }
+      ((PdfArray) original).getElements().forEach(pdfObject -> arr.add(duplicatePdfObject(pdfObject, newReader)));
       return arr;
     }
     case PdfObject.INDIRECT: {
@@ -3719,10 +3717,9 @@ public class PdfReader implements PdfViewerPreferences, Closeable {
           if (obj != null)
             acc.put(pageInhCandidate, obj);
         }
-        PdfArray kids = (PdfArray) PdfReader.getPdfObjectRelease(top
-            .get(PdfName.KIDS));
-        for (Iterator it = kids.listIterator(); it.hasNext();) {
-          PRIndirectReference ref = (PRIndirectReference) it.next();
+        PdfArray kids = (PdfArray) PdfReader.getPdfObjectRelease(top.get(PdfName.KIDS));
+        for (PdfObject pdfObject : kids.getElements()) {
+          PRIndirectReference ref = (PRIndirectReference) pdfObject;
           PdfDictionary dic = (PdfDictionary) getPdfObject(ref);
           int last = reader.lastXrefPartial;
           PdfObject count = getPdfObjectRelease(dic.get(PdfName.COUNT));

--- a/openpdf/src/main/java/com/lowagie/text/pdf/PdfStamperImp.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/PdfStamperImp.java
@@ -52,7 +52,6 @@ import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -1567,8 +1566,8 @@ class PdfStamperImp extends PdfWriter {
         PdfIndirectReference ref;
         PdfLayer layer;
         Map<String, PdfLayer> ocgmap = new HashMap<>();
-        for (Iterator i = ocgs.listIterator(); i.hasNext(); ) {
-            ref = (PdfIndirectReference)i.next();
+        for (PdfObject pdfObject : ocgs.getElements()) {
+            ref = (PdfIndirectReference)pdfObject;
             layer = new PdfLayer(null);
             layer.setRef(ref);
             layer.setOnPanel(false);
@@ -1578,8 +1577,8 @@ class PdfStamperImp extends PdfWriter {
         PdfDictionary d = dict.getAsDict(PdfName.D);
         PdfArray off = d.getAsArray(PdfName.OFF);
         if (off != null) {
-            for (Iterator i = off.listIterator(); i.hasNext(); ) {
-                ref = (PdfIndirectReference)i.next();
+            for (PdfObject pdfObject : off.getElements() ) {
+                ref = (PdfIndirectReference)pdfObject;
                 layer = ocgmap.get(ref.toString());
                 layer.setOn(false);
             }
@@ -1631,9 +1630,7 @@ class PdfStamperImp extends PdfWriter {
                         parent.addChild(layer);
                     }
                     PdfArray array = new PdfArray();
-                    for (Iterator j = sub.listIterator(); j.hasNext(); ) {
-                        array.add((PdfObject)j.next());
-                    }
+                    sub.getElements().forEach(array::add);
                     addOrder(layer, array, ocgmap);
                 }
                 else {

--- a/openpdf/src/main/java/com/lowagie/text/pdf/PdfWriter.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/PdfWriter.java
@@ -68,6 +68,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.TreeSet;
+import java.util.stream.Collectors;
 
 import com.lowagie.text.DocListener;
 import com.lowagie.text.DocWriter;
@@ -532,7 +533,6 @@ public class PdfWriter extends DocWriter implements
          * Constructs a PDF-Trailer.
          *
          * @param        size        the number of entries in the <CODE>PdfCrossReferenceTable</CODE>
-         * @param        offset        offset of the <CODE>PdfCrossReferenceTable</CODE>
          * @param        root        an indirect reference to the root of the PDF document
          * @param        info        an indirect reference to the info object of the PDF document
          * @param encryption
@@ -2524,12 +2524,11 @@ public class PdfWriter extends DocWriter implements
         }
         if (OCProperties.get(PdfName.D) != null)
             return;
-        List<PdfOCG> docOrder = new ArrayList<>(documentOCGorder);
-        for (Iterator<PdfOCG> it = docOrder.iterator(); it.hasNext();) {
-            PdfLayer layer = (PdfLayer)it.next();
-            if (layer.getParent() != null)
-                it.remove();
-        }
+
+        List<PdfOCG> docOrder = documentOCGorder.stream()
+                .filter(pdfOCG -> ((PdfLayer)pdfOCG).getParent() == null)
+                .collect(Collectors.toList());
+
         PdfArray order = new PdfArray();
         for (PdfOCG o1 : docOrder) {
             PdfLayer layer = (PdfLayer) o1;

--- a/openpdf/src/main/java/com/lowagie/text/pdf/PdfWriter.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/PdfWriter.java
@@ -104,6 +104,7 @@ import com.lowagie.text.xml.xmp.XmpWriter;
  */
 
 public class PdfWriter extends DocWriter implements
+    AutoCloseable,
     Closeable,
     PdfViewerPreferences,
     PdfEncryptionSettings,
@@ -1165,7 +1166,7 @@ public class PdfWriter extends DocWriter implements
                 // See: https://github.com/LibrePDF/OpenPDF/issues/164
                 throw new RuntimeException("The page " + pageReferences.size() +
                 " was requested but the document has only " + (currentPageNumber - 1) + " pages.");
-            pdf.close();
+
             try {
                 addSharedObjectsToBody();
                 // add the root to the body
@@ -1224,8 +1225,7 @@ public class PdfWriter extends DocWriter implements
                 os.write(getISOBytes("\n%%EOF\n"));
                 super.close();
             }
-            catch(IOException ioe) {
-                throw new ExceptionConverter(ioe);
+            catch(IOException ignored) {
             }
         }
     }

--- a/openpdf/src/main/java/com/lowagie/text/pdf/parser/PdfContentStreamHandler.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/parser/PdfContentStreamHandler.java
@@ -65,9 +65,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.List;
-import java.util.ListIterator;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
@@ -337,8 +335,7 @@ public class PdfContentStreamHandler {
         @Override
         public void invoke(List<PdfObject> operands, PdfContentStreamHandler handler, PdfDictionary resources) {
             PdfArray array = (PdfArray) operands.get(0);
-            for (Iterator<?> i = array.listIterator(); i.hasNext(); ) {
-                Object entryObj = i.next();
+            for (PdfObject entryObj : array.getElements()) {
                 if (entryObj instanceof PdfString) {
                     handler.displayPdfString((PdfString) entryObj);
                 } else {
@@ -1011,9 +1008,7 @@ public class PdfContentStreamHandler {
                     return PdfReader.getStreamBytes((PRStream) PdfReader.getPdfObject(object));
                 case PdfObject.ARRAY:
                     ByteArrayOutputStream baos = new ByteArrayOutputStream();
-                    ListIterator<PdfObject> iter = ((PdfArray) object).listIterator();
-                    while (iter.hasNext()) {
-                        PdfObject element = iter.next();
+                    for (PdfObject element : ((PdfArray) object).getElements()) {
                         baos.write(getContentBytesFromPdfObject(element));
                     }
                     return baos.toByteArray();

--- a/openpdf/src/main/java/com/lowagie/text/pdf/parser/PdfTextExtractor.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/parser/PdfTextExtractor.java
@@ -67,7 +67,6 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.ListIterator;
 
 /**
  * Extracts text from a PDF file.
@@ -163,10 +162,8 @@ public class PdfTextExtractor {
                 // processContent() resets state.
                 ByteArrayOutputStream allBytes = new ByteArrayOutputStream();
                 PdfArray contentArray = (PdfArray) contentObject;
-                ListIterator<PdfObject> iter = contentArray.listIterator();
-                while (iter.hasNext()) {
-                    PdfObject element = iter.next();
-                    allBytes.write(getContentBytesFromContentObject(element));
+                for (PdfObject pdfObject : contentArray.getElements()) {
+                    allBytes.write(getContentBytesFromContentObject(pdfObject));
                 }
                 result = allBytes.toByteArray();
                 break;

--- a/openpdf/src/test/java/com/lowagie/text/pdf/SimplePdfTest.java
+++ b/openpdf/src/test/java/com/lowagie/text/pdf/SimplePdfTest.java
@@ -31,11 +31,26 @@ public class SimplePdfTest {
     }
 
     @Test
-    void testTryWithResources() throws Exception {
+    void testTryWithResources_with_os_before_doc() throws Exception {
         try (PdfReader reader = new PdfReader("./src/test/resources/HelloWorldMeta.pdf");
-            Document document = new Document();
             FileOutputStream os = new FileOutputStream(File.createTempFile("temp-file-name", ".pdf"));
-            PdfWriter writer = PdfWriter.getInstance(document, os)
+             Document document = new Document();
+             PdfWriter writer = PdfWriter.getInstance(document, os)
+        ) {
+            document.open();
+            final PdfContentByte cb = writer.getDirectContent();
+
+            document.newPage();
+            PdfImportedPage page = writer.getImportedPage(reader, 1);
+            cb.addTemplate(page, 1, 0, 0, 1, 0, 0);
+        }
+    }
+
+    @Test
+    void testTryWithResources_with_unknown_os() throws Exception {
+        try (PdfReader reader = new PdfReader("./src/test/resources/HelloWorldMeta.pdf");
+             Document document = new Document();
+             PdfWriter writer = PdfWriter.getInstance(document, new FileOutputStream(File.createTempFile("temp-file-name", ".pdf")))
         ) {
             document.open();
             final PdfContentByte cb = writer.getDirectContent();

--- a/openpdf/src/test/java/com/lowagie/text/pdf/metadata/CleanMetaDataTest.java
+++ b/openpdf/src/test/java/com/lowagie/text/pdf/metadata/CleanMetaDataTest.java
@@ -168,6 +168,7 @@ public class CleanMetaDataTest {
       String metadataString = new String(metadata);
       Assertions.assertFalse(metadataString.contains("Bruno Lowagie"));
       Assertions.assertFalse(metadataString.contains(" 1.2.12.SNAPSHOT"));
+      Assertions.assertTrue(metadataString.contains("<pdf:Producer></pdf:Producer>"));
     }  
   }
 	

--- a/pdf-swing/src/main/java/com/lowagie/rups/model/TreeNodeFactory.java
+++ b/pdf-swing/src/main/java/com/lowagie/rups/model/TreeNodeFactory.java
@@ -22,7 +22,6 @@ package com.lowagie.rups.model;
 
 import java.util.ArrayList;
 import java.util.Enumeration;
-import java.util.Iterator;
 
 import com.lowagie.rups.view.itext.treenodes.PdfObjectTreeNode;
 import com.lowagie.rups.view.itext.treenodes.PdfPagesTreeNode;
@@ -91,8 +90,8 @@ public class TreeNodeFactory {
             return;
         case PdfObject.ARRAY:
             PdfArray array = (PdfArray)object;
-            for (Iterator it = array.listIterator(); it.hasNext(); ) {
-                leaf = PdfObjectTreeNode.getInstance((PdfObject)it.next());
+            for (PdfObject pdfObject : array.getElements()) {
+                leaf = PdfObjectTreeNode.getInstance(pdfObject);
                 addNodes(node, leaf);
                 expandNode(leaf);
             }

--- a/pdf-toolbox/src/main/java/com/lowagie/toolbox/plugins/ExtractAttachments.java
+++ b/pdf-toolbox/src/main/java/com/lowagie/toolbox/plugins/ExtractAttachments.java
@@ -39,7 +39,6 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.util.HashMap;
-import java.util.Iterator;
 
 import javax.swing.JInternalFrame;
 
@@ -124,9 +123,8 @@ public class ExtractAttachments extends AbstractTool {
                 PdfArray annots = reader.getPageN(k).getAsArray(PdfName.ANNOTS);
                 if (annots == null)
                     continue;
-                for (Iterator<PdfObject> i = annots.listIterator(); i.hasNext();) {
-                    PdfDictionary annot = (PdfDictionary) PdfReader
-                            .getPdfObject(i.next());
+                for (PdfObject pdfObject : annots.getElements()) {
+                    PdfDictionary annot = (PdfDictionary) PdfReader.getPdfObject(pdfObject);
                     PdfName subType = annot.getAsName(PdfName.SUBTYPE);
                     if (!PdfName.FILEATTACHMENT.equals(subType))
                         continue;


### PR DESCRIPTION
I had two options here:

* just escaping the NullPointerException in the compare() function
* removing the closing call to pdf member object.

Choose the second option, the cleanest in my point of view.
All my tests are green.

If you'd like to go with the first, close this PR.