### PR TITLE
Fix #211 null pointer on auto closing document

### DIFF
--- a/openpdf/src/main/java/com/lowagie/text/pdf/PdfWriter.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/PdfWriter.java
@@ -104,6 +104,7 @@ import com.lowagie.text.xml.xmp.XmpWriter;
  */
 
 public class PdfWriter extends DocWriter implements
+    AutoCloseable,
     Closeable,
     PdfViewerPreferences,
     PdfEncryptionSettings,
@@ -1165,7 +1166,7 @@ public class PdfWriter extends DocWriter implements
                 // See: https://github.com/LibrePDF/OpenPDF/issues/164
                 throw new RuntimeException("The page " + pageReferences.size() +
                 " was requested but the document has only " + (currentPageNumber - 1) + " pages.");
-            pdf.close();
+
             try {
                 addSharedObjectsToBody();
                 // add the root to the body
@@ -1224,8 +1225,7 @@ public class PdfWriter extends DocWriter implements
                 os.write(getISOBytes("\n%%EOF\n"));
                 super.close();
             }
-            catch(IOException ioe) {
-                throw new ExceptionConverter(ioe);
+            catch(IOException ignored) {
             }
         }
     }

--- a/openpdf/src/test/java/com/lowagie/text/pdf/SimplePdfTest.java
+++ b/openpdf/src/test/java/com/lowagie/text/pdf/SimplePdfTest.java
@@ -31,11 +31,26 @@ public class SimplePdfTest {
     }
 
     @Test
-    void testTryWithResources() throws Exception {
+    void testTryWithResources_with_os_before_doc() throws Exception {
         try (PdfReader reader = new PdfReader("./src/test/resources/HelloWorldMeta.pdf");
-            Document document = new Document();
             FileOutputStream os = new FileOutputStream(File.createTempFile("temp-file-name", ".pdf"));
-            PdfWriter writer = PdfWriter.getInstance(document, os)
+             Document document = new Document();
+             PdfWriter writer = PdfWriter.getInstance(document, os)
+        ) {
+            document.open();
+            final PdfContentByte cb = writer.getDirectContent();
+
+            document.newPage();
+            PdfImportedPage page = writer.getImportedPage(reader, 1);
+            cb.addTemplate(page, 1, 0, 0, 1, 0, 0);
+        }
+    }
+
+    @Test
+    void testTryWithResources_with_unknown_os() throws Exception {
+        try (PdfReader reader = new PdfReader("./src/test/resources/HelloWorldMeta.pdf");
+             Document document = new Document();
+             PdfWriter writer = PdfWriter.getInstance(document, new FileOutputStream(File.createTempFile("temp-file-name", ".pdf")))
         ) {
             document.open();
             final PdfContentByte cb = writer.getDirectContent();


### PR DESCRIPTION
Fixing issue #211 

I had two options here:

* just escaping the NullPointerException in the compare() function
* removing the closing call to pdf member object.

Choose the second option here, the cleanest in my point of view.
All Unit Tests plus Toolbox samples and some more tests are green.

If you'd like to go with the first, close this PR.