### PR TITLE
Fix #250 - Remove Closable And AutoClosable From PdfWriter

### DIFF
--- a/openpdf/src/main/java/com/lowagie/text/pdf/PdfWriter.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/PdfWriter.java
@@ -52,7 +52,6 @@ package com.lowagie.text.pdf;
 import java.awt.Color;
 import java.awt.color.ICC_Profile;
 import java.io.ByteArrayOutputStream;
-import java.io.Closeable;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.security.cert.Certificate;
@@ -104,8 +103,6 @@ import com.lowagie.text.xml.xmp.XmpWriter;
  */
 
 public class PdfWriter extends DocWriter implements
-    AutoCloseable,
-    Closeable,
     PdfViewerPreferences,
     PdfEncryptionSettings,
     PdfVersion,
@@ -1158,8 +1155,7 @@ public class PdfWriter extends DocWriter implements
     @Override
     public void close() {
         if (open) {
-            if (this.document.isOpen()) this.document.close();
-            
+
             if ((currentPageNumber - 1) != pageReferences.size())
                 // 2019-04-26: If you get this error, it could be that you are using OpenPDF or
                 // another library such as flying-saucer's ITextRenderer in a non-threadsafe way.

--- a/openpdf/src/test/java/com/lowagie/text/pdf/SimplePdfTest.java
+++ b/openpdf/src/test/java/com/lowagie/text/pdf/SimplePdfTest.java
@@ -34,9 +34,9 @@ public class SimplePdfTest {
     void testTryWithResources_with_os_before_doc() throws Exception {
         try (PdfReader reader = new PdfReader("./src/test/resources/HelloWorldMeta.pdf");
             FileOutputStream os = new FileOutputStream(File.createTempFile("temp-file-name", ".pdf"));
-             Document document = new Document();
-             PdfWriter writer = PdfWriter.getInstance(document, os)
+             Document document = new Document()
         ) {
+            PdfWriter writer = PdfWriter.getInstance(document, os);
             document.open();
             final PdfContentByte cb = writer.getDirectContent();
 
@@ -49,9 +49,9 @@ public class SimplePdfTest {
     @Test
     void testTryWithResources_with_unknown_os() throws Exception {
         try (PdfReader reader = new PdfReader("./src/test/resources/HelloWorldMeta.pdf");
-             Document document = new Document();
-             PdfWriter writer = PdfWriter.getInstance(document, new FileOutputStream(File.createTempFile("temp-file-name", ".pdf")))
+             Document document = new Document()
         ) {
+            PdfWriter writer = PdfWriter.getInstance(document, new FileOutputStream(File.createTempFile("temp-file-name", ".pdf")));
             document.open();
             final PdfContentByte cb = writer.getDirectContent();
 


### PR DESCRIPTION
Fixing issue #250 and #211 

The PdfWriter should not be AutoClosable since it is the Document's responsibility to close its writer(s). 

A Document does not have to be closed from the Writer.