### PR TITLE
Fixes PageNumbersWatermark example

### DIFF
--- a/pdf-toolbox/src/test/java/com/lowagie/examples/directcontent/pageevents/PageNumbersWatermark.java
+++ b/pdf-toolbox/src/test/java/com/lowagie/examples/directcontent/pageevents/PageNumbersWatermark.java
@@ -161,8 +161,8 @@ public class PageNumbersWatermark extends PdfPageEventHelper {
             catch(Exception e) {
                 throw new ExceptionConverter(e);
             }
-            cb.restoreState();
         }
+        cb.restoreState();
         cb.sanityCheck();
     }
     


### PR DESCRIPTION
Fixes #242 #196

The "restoreState" should be called outside the if