### PR TITLE
Fixes #271 - Make nested table visible when keepTogether is set for paragraph

### DIFF
--- a/openpdf/pom.xml
+++ b/openpdf/pom.xml
@@ -48,6 +48,13 @@
             <optional>true</optional>
         </dependency>
 
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-core</artifactId>
+            <version>${hamcrest.version}</version>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/openpdf/src/main/java/com/lowagie/text/pdf/PdfDocument.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/PdfDocument.java
@@ -528,13 +528,9 @@ public class PdfDocument extends Document {
                     // if a paragraph has to be kept together, we wrap it in a table object
                     if (paragraph.getKeepTogether()) {
                         carriageReturn();
-                        PdfPTable table = new PdfPTable(1);
-                        table.setWidthPercentage(100f);
-                        PdfPCell cell = new PdfPCell();
-                        cell.addElement(paragraph);
-                        cell.setBorder(Table.NO_BORDER);
-                        cell.setPadding(0);
-                        table.addCell(cell);
+                        // fixes bug with nested tables not shown
+                        // Paragraph#getChunks() doesn't contain the nested table element
+                        PdfPTable table = createInOneCell(paragraph.iterator());
                         indentation.indentLeft -= paragraph.getIndentationLeft();
                         indentation.indentRight -= paragraph.getIndentationRight();
                         this.add(table);
@@ -774,6 +770,20 @@ public class PdfDocument extends Document {
         catch(Exception e) {
             throw new DocumentException(e);
         }
+    }
+
+    static PdfPTable createInOneCell(Iterator<Element> elements) {
+        PdfPTable table = new PdfPTable(1);
+        table.setWidthPercentage(100f);
+
+        PdfPCell cell = new PdfPCell();
+        cell.setBorder(Table.NO_BORDER);
+        cell.setPadding(0);
+        while (elements.hasNext()) {
+            cell.addElement(elements.next());
+        }
+        table.addCell(cell);
+        return table;
     }
 
 //    [L1] DocListener interface

--- a/openpdf/src/test/java/com/lowagie/text/pdf/PdfDocumentTest.java
+++ b/openpdf/src/test/java/com/lowagie/text/pdf/PdfDocumentTest.java
@@ -1,0 +1,57 @@
+package com.lowagie.text.pdf;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import org.junit.jupiter.api.DynamicTest;
+import org.junit.jupiter.api.TestFactory;
+
+import com.lowagie.text.Element;
+import com.lowagie.text.Paragraph;
+
+class PdfDocumentTest {
+
+    private static final String PARAGRAPH_TEXT_1 = "Text above table";
+
+    private static final String PARAGRAPH_TEXT_2 = "Text below table";
+
+    @TestFactory
+    List<DynamicTest> testCreateWithAllElementsInOneCell() {
+        final PdfPTable table = new PdfPTable(2);
+        table.addCell("Lorem");
+        table.addCell("ipsum");
+        table.addCell("dolor");
+        table.addCell("sit");
+
+        final Paragraph mainParagraph = new Paragraph();
+        final Paragraph paragraph1 = new Paragraph(PARAGRAPH_TEXT_1);
+        final Paragraph paragraph2 = new Paragraph(PARAGRAPH_TEXT_2);
+
+        mainParagraph.add(paragraph1);
+        mainParagraph.add(table);
+        mainParagraph.add(paragraph2);
+
+        PdfPTable result = PdfDocument.createInOneCell(mainParagraph.iterator());
+        return Arrays.asList(
+                DynamicTest.dynamicTest("row size should be 1", () -> assertThat(result.getRows().size(), equalTo(1))),
+                DynamicTest.dynamicTest("cell size should be 1", () -> {
+                    final PdfPCell[] cells = result.getRows().get(0).getCells();
+                    assertThat(cells.length, equalTo(1));
+                }),
+                DynamicTest.dynamicTest("elements in cell should be 5", () -> assertThat(getCellElements(result).size(), equalTo(5))),
+                DynamicTest.dynamicTest("element text should be '" + PARAGRAPH_TEXT_1 + "'",
+                        () -> assertThat(getCellElements(result).get(0).getChunks().toString(), equalTo(paragraph1.toString()))),
+                DynamicTest.dynamicTest("element should be table", () -> assertThat(getCellElements(result).get(2), equalTo(table))),
+                DynamicTest.dynamicTest("element text should be '" + PARAGRAPH_TEXT_2 + "'",
+                        () -> assertThat(getCellElements(result).get(3).getChunks().toString(), equalTo(paragraph2.toString()))));
+    }
+
+    private List<Element> getCellElements(PdfPTable result) {
+        PdfPCell firstCell = result.getRows().get(0).getCells()[0];
+        return firstCell.getColumn().compositeElements;
+    }
+
+}


### PR DESCRIPTION
* nested tables are not working with pdftables
* iterate over elements in paragraph and add these as single cells
* iterator is necessary, paragraph.getChunks doesn't contain the nested table