### PR TITLE
fix PdfPCell background color ignoring alpha channel of an rgba

### DIFF
--- a/openpdf/src/main/java/com/lowagie/text/pdf/CMYKColor.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/CMYKColor.java
@@ -69,7 +69,19 @@ public class CMYKColor extends ExtendedColor {
      * @param intBlack
      */
     public CMYKColor(int intCyan, int intMagenta, int intYellow, int intBlack) {
-        this(intCyan / 255f, intMagenta / 255f, intYellow / 255f, intBlack / 255f);
+        this(normalize(intCyan) / MAX_INT_COLOR_VALUE, normalize(intMagenta) / MAX_INT_COLOR_VALUE, normalize(intYellow) / MAX_INT_COLOR_VALUE, normalize(intBlack) / MAX_INT_COLOR_VALUE);
+    }
+
+    /**
+     * Constructs a CMYK Color based on 4 color values (values are integers from 0 to 255).
+     * @param intCyan
+     * @param intMagenta
+     * @param intYellow
+     * @param intBlack
+     * @param intAlpha
+     */
+    public CMYKColor(int intCyan, int intMagenta, int intYellow, int intBlack, int intAlpha) {
+        this(normalize(intCyan) / MAX_INT_COLOR_VALUE, normalize(intMagenta) / MAX_INT_COLOR_VALUE, normalize(intYellow) / MAX_INT_COLOR_VALUE, normalize(intBlack) / MAX_INT_COLOR_VALUE, normalize(intAlpha) / MAX_INT_COLOR_VALUE);
     }
 
     /**
@@ -80,13 +92,25 @@ public class CMYKColor extends ExtendedColor {
      * @param floatBlack
      */
     public CMYKColor(float floatCyan, float floatMagenta, float floatYellow, float floatBlack) {
-        super(TYPE_CMYK, 1f - floatCyan - floatBlack, 1f - floatMagenta - floatBlack, 1f - floatYellow - floatBlack);
+        this(floatCyan, floatMagenta, floatYellow, floatBlack, MAX_FLOAT_COLOR_VALUE);
+    }
+
+    /**
+     * Construct a CMYK Color.
+     * @param floatCyan
+     * @param floatMagenta
+     * @param floatYellow
+     * @param floatBlack
+     * @param floatAlpha
+     */
+    public CMYKColor(float floatCyan, float floatMagenta, float floatYellow, float floatBlack, float floatAlpha) {
+        super(TYPE_CMYK, MAX_FLOAT_COLOR_VALUE - normalize(floatCyan) - normalize(floatBlack), MAX_FLOAT_COLOR_VALUE - normalize(floatMagenta) - normalize(floatBlack), MAX_FLOAT_COLOR_VALUE - normalize(floatYellow) - normalize(floatBlack), normalize(floatAlpha));
         cyan = normalize(floatCyan);
         magenta = normalize(floatMagenta);
         yellow = normalize(floatYellow);
         black = normalize(floatBlack);
     }
-    
+
     /**
      * @return the cyan value
      */
@@ -119,11 +143,16 @@ public class CMYKColor extends ExtendedColor {
         if (!(obj instanceof CMYKColor))
             return false;
         CMYKColor c2 = (CMYKColor)obj;
-        return (cyan == c2.cyan && magenta == c2.magenta && yellow == c2.yellow && black == c2.black);
+        return (cyan == c2.cyan && magenta == c2.magenta && yellow == c2.yellow && black == c2.black && getAlpha() == c2.getAlpha());
     }
     
     public int hashCode() {
-        return Float.floatToIntBits(cyan) ^ Float.floatToIntBits(magenta) ^ Float.floatToIntBits(yellow) ^ Float.floatToIntBits(black); 
+        return Float.floatToIntBits(cyan)
+                ^ Float.floatToIntBits(magenta)
+                ^ Float.floatToIntBits(yellow)
+                ^ Float.floatToIntBits(black)
+                ^ Float.floatToIntBits(getAlpha())
+                ;
     }
     
 }

--- a/openpdf/src/main/java/com/lowagie/text/pdf/ExtendedColor.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/ExtendedColor.java
@@ -69,7 +69,13 @@ public abstract class ExtendedColor extends Color{
     public static final int TYPE_PATTERN = 4;
     /** a type of extended color. */
     public static final int TYPE_SHADING = 5;
-    
+    /** the max int color value (255) expressed in int */
+    public static final int MAX_COLOR_VALUE = 0xFF;
+    /** the max int color value (255) expressed in float */
+    public static final float MAX_INT_COLOR_VALUE = 0xFF;
+    /** the max float color value (1) expressed in float */
+    public static final float MAX_FLOAT_COLOR_VALUE = 0x1;
+
     protected int type;
 
     /**
@@ -89,10 +95,21 @@ public abstract class ExtendedColor extends Color{
      * @param blue
      */
     public ExtendedColor(int type, float red, float green, float blue) {
-        super(normalize(red), normalize(green), normalize(blue));
+        this(type, normalize(red), normalize(green), normalize(blue), MAX_FLOAT_COLOR_VALUE);
+    }
+
+    /**
+     * Constructs an extended color of a certain type and a certain color.
+     * @param type
+     * @param red
+     * @param green
+     * @param blue
+     */
+    public ExtendedColor(int type, float red, float green, float blue, float alpha) {
+        super(normalize(red), normalize(green), normalize(blue), normalize(alpha));
         this.type = type;
     }
-    
+
     /**
      * Gets the type of this color.
      * @return one of the types (see constants)
@@ -113,10 +130,18 @@ public abstract class ExtendedColor extends Color{
     }
 
     static final float normalize(float value) {
+        if (value < 0f)
+            return 0f;
+        if (value > MAX_FLOAT_COLOR_VALUE)
+            return MAX_FLOAT_COLOR_VALUE;
+        return value;
+    }
+
+    static final int normalize(int value) {
         if (value < 0)
             return 0;
-        if (value > 1)
-            return 1;
+        if (value > (int)MAX_INT_COLOR_VALUE)
+            return (int)MAX_INT_COLOR_VALUE;
         return value;
     }
 }

--- a/openpdf/src/main/java/com/lowagie/text/pdf/GrayColor.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/GrayColor.java
@@ -59,18 +59,26 @@ public class GrayColor extends ExtendedColor {
 
     private float gray;
     
-    public static final GrayColor GRAYBLACK = new GrayColor(0f);
-    public static final GrayColor GRAYWHITE = new GrayColor(1f);
+    public static final GrayColor GRAYBLACK = new GrayColor(0);
+    public static final GrayColor GRAYWHITE = new GrayColor(MAX_FLOAT_COLOR_VALUE);
 
     public GrayColor(int intGray) {
-        this(intGray / 255f);
+        this(normalize(intGray) / MAX_INT_COLOR_VALUE);
     }
 
     public GrayColor(float floatGray) {
-        super(TYPE_GRAY, floatGray, floatGray, floatGray);
+        this(floatGray, MAX_FLOAT_COLOR_VALUE);
+    }
+
+    public GrayColor(int intGray, int alpha) {
+        this(normalize(intGray) / MAX_INT_COLOR_VALUE, normalize(alpha) / MAX_INT_COLOR_VALUE);
+    }
+
+    public GrayColor(float floatGray, float alpha) {
+        super(TYPE_GRAY, normalize(floatGray), normalize(floatGray), normalize(floatGray), normalize(alpha));
         gray = normalize(floatGray);
     }
-    
+
     public float getGray() {
         return gray;
     }

--- a/openpdf/src/main/java/com/lowagie/text/pdf/PdfContentByte.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/PdfContentByte.java
@@ -72,6 +72,10 @@ import com.lowagie.text.exceptions.IllegalPdfSyntaxException;
 import com.lowagie.text.pdf.internal.PdfAnnotationsImp;
 import com.lowagie.text.pdf.internal.PdfXConformanceImp;
 
+import static com.lowagie.text.pdf.ExtendedColor.MAX_COLOR_VALUE;
+import static com.lowagie.text.pdf.ExtendedColor.MAX_FLOAT_COLOR_VALUE;
+import static com.lowagie.text.pdf.ExtendedColor.MAX_INT_COLOR_VALUE;
+
 /**
  * <CODE>PdfContentByte</CODE> is an object containing the user positioned
  * text and graphic contents of a page. It knows how to apply the proper
@@ -112,10 +116,20 @@ public class PdfContentByte {
         /** The current word spacing */
         protected float wordSpace = 0;
 
+        protected ExtendedColor colorFill = GrayColor.GRAYBLACK;
+
+        protected ExtendedColor colorStroke = GrayColor.GRAYBLACK;
+
+        protected PdfObject extGState = null;
+
         GraphicState() {
         }
 
         GraphicState(GraphicState cp) {
+            copyParameters(cp);
+        }
+
+        void copyParameters(final GraphicState cp) {
             fontDetails = cp.fontDetails;
             colorDetails = cp.colorDetails;
             size = cp.size;
@@ -125,6 +139,13 @@ public class PdfContentByte {
             scale = cp.scale;
             charSpace = cp.charSpace;
             wordSpace = cp.wordSpace;
+            colorFill = cp.colorFill;
+            colorStroke = cp.colorStroke;
+            extGState = cp.extGState;
+        }
+
+        void restore(final GraphicState restore) {
+            copyParameters(restore);
         }
     }
 
@@ -500,6 +521,11 @@ public class PdfContentByte {
      */
 
     public void setGrayFill(float gray) {
+        setGrayFill(gray, MAX_FLOAT_COLOR_VALUE);
+    }
+
+    public void setGrayFill(float gray, float alpha) {
+        saveColorFill(new GrayColor(gray, alpha));
         content.append(gray).append(" g").append_i(separator);
     }
 
@@ -508,6 +534,7 @@ public class PdfContentByte {
      */
 
     public void resetGrayFill() {
+        saveColorFill(GrayColor.GRAYBLACK);
         content.append("0 g").append_i(separator);
     }
 
@@ -521,6 +548,10 @@ public class PdfContentByte {
      */
 
     public void setGrayStroke(float gray) {
+        setGrayStroke(gray, MAX_FLOAT_COLOR_VALUE);
+    }
+    public void setGrayStroke(float gray, float alpha) {
+        saveColorStroke(new GrayColor(gray, alpha));
         content.append(gray).append(" G").append_i(separator);
     }
 
@@ -529,7 +560,18 @@ public class PdfContentByte {
      */
 
     public void resetGrayStroke() {
+        saveColorStroke(GrayColor.GRAYBLACK);
         content.append("0 G").append_i(separator);
+    }
+
+    /**
+     * Helper to validate and write the RGB color components
+     * @param   red     the intensity of red. A value between 0 and 255
+     * @param   green   the intensity of green. A value between 0 and 255
+     * @param   blue    the intensity of blue. A value between 0 and 255
+     */
+    private void HelperRGB(int red, int green, int blue) {
+        HelperRGB((float)(red & MAX_COLOR_VALUE) / MAX_INT_COLOR_VALUE, (float)(green & MAX_COLOR_VALUE) / MAX_INT_COLOR_VALUE, (float)(blue & MAX_COLOR_VALUE) / MAX_INT_COLOR_VALUE);
     }
 
     /**
@@ -540,18 +582,18 @@ public class PdfContentByte {
      */
     private void HelperRGB(float red, float green, float blue) {
         PdfXConformanceImp.checkPDFXConformance(writer, PdfXConformanceImp.PDFXKEY_RGB, null);
-        if (red < 0)
+        if (red < 0.0f)
             red = 0.0f;
-        else if (red > 1.0f)
-            red = 1.0f;
-        if (green < 0)
+        else if (red > MAX_FLOAT_COLOR_VALUE)
+            red = MAX_FLOAT_COLOR_VALUE;
+        if (green < 0.0f)
             green = 0.0f;
-        else if (green > 1.0f)
-            green = 1.0f;
-        if (blue < 0)
+        else if (green > MAX_FLOAT_COLOR_VALUE)
+            green = MAX_FLOAT_COLOR_VALUE;
+        if (blue < 0.0f)
             blue = 0.0f;
-        else if (blue > 1.0f)
-            blue = 1.0f;
+        else if (blue > MAX_FLOAT_COLOR_VALUE)
+            blue = MAX_FLOAT_COLOR_VALUE;
         content.append(red).append(' ').append(green).append(' ').append(blue);
     }
 
@@ -570,16 +612,21 @@ public class PdfContentByte {
      */
 
     public void setRGBColorFillF(float red, float green, float blue) {
+        setRGBColorFillF(red, green, blue, MAX_FLOAT_COLOR_VALUE);
+    }
+    public void setRGBColorFillF(float red, float green, float blue, float alpha) {
+        saveColorFill(new RGBColor(red, green, blue, alpha));
         HelperRGB(red, green, blue);
         content.append(" rg").append_i(separator);
     }
 
     /**
      * Changes the current color for filling paths to black.
+     * Resetting using gray color to keep the backward compatibility.
      */
 
     public void resetRGBColorFill() {
-        content.append("0 g").append_i(separator);
+        resetGrayFill();
     }
 
     /**
@@ -597,17 +644,30 @@ public class PdfContentByte {
      */
 
     public void setRGBColorStrokeF(float red, float green, float blue) {
+        saveColorStroke(new RGBColor(red, green, blue));
         HelperRGB(red, green, blue);
         content.append(" RG").append_i(separator);
     }
 
     /**
      * Changes the current color for stroking paths to black.
-     *
+     * Resetting using gray color to keep the backward compatibility.
      */
 
     public void resetRGBColorStroke() {
-        content.append("0 G").append_i(separator);
+        resetGrayStroke();
+    }
+
+    /**
+     * Helper to validate and write the CMYK color components.
+     *
+     * @param   cyan    the intensity of cyan. A value between 0 and 255
+     * @param   magenta the intensity of magenta. A value between 0 and 255
+     * @param   yellow  the intensity of yellow. A value between 0 and 255
+     * @param   black   the intensity of black. A value between 0 and 255
+     */
+    private void HelperCMYK(int cyan, int magenta, int yellow, int black) {
+        HelperCMYK((float)(cyan & MAX_COLOR_VALUE) / MAX_INT_COLOR_VALUE, (float)(magenta & MAX_COLOR_VALUE) / MAX_INT_COLOR_VALUE, (float)(yellow & MAX_COLOR_VALUE) / MAX_INT_COLOR_VALUE, (float)(black & MAX_COLOR_VALUE) / MAX_INT_COLOR_VALUE);
     }
 
     /**
@@ -619,22 +679,22 @@ public class PdfContentByte {
      * @param   black   the intensity of black. A value between 0 and 1
      */
     private void HelperCMYK(float cyan, float magenta, float yellow, float black) {
-        if (cyan < 0)
+        if (cyan < 0.0f)
             cyan = 0.0f;
-        else if (cyan > 1.0f)
-            cyan = 1.0f;
-        if (magenta < 0)
+        else if (cyan > MAX_FLOAT_COLOR_VALUE)
+            cyan = MAX_FLOAT_COLOR_VALUE;
+        if (magenta < 0.0f)
             magenta = 0.0f;
-        else if (magenta > 1.0f)
-            magenta = 1.0f;
-        if (yellow < 0)
+        else if (magenta > MAX_FLOAT_COLOR_VALUE)
+            magenta = MAX_FLOAT_COLOR_VALUE;
+        if (yellow < 0.0f)
             yellow = 0.0f;
-        else if (yellow > 1.0f)
-            yellow = 1.0f;
-        if (black < 0)
+        else if (yellow > MAX_FLOAT_COLOR_VALUE)
+            yellow = MAX_FLOAT_COLOR_VALUE;
+        if (black < 0.0f)
             black = 0.0f;
-        else if (black > 1.0f)
-            black = 1.0f;
+        else if (black > MAX_FLOAT_COLOR_VALUE)
+            black = MAX_FLOAT_COLOR_VALUE;
         content.append(cyan).append(' ').append(magenta).append(' ').append(yellow).append(' ').append(black);
     }
 
@@ -654,6 +714,11 @@ public class PdfContentByte {
      */
 
     public void setCMYKColorFillF(float cyan, float magenta, float yellow, float black) {
+        setCMYKColorFillF(cyan, magenta, yellow, black, MAX_FLOAT_COLOR_VALUE);
+    }
+
+    public void setCMYKColorFillF(float cyan, float magenta, float yellow, float black, float alpha) {
+        saveColorFill(new CMYKColor(cyan, magenta, yellow, black, alpha));
         HelperCMYK(cyan, magenta, yellow, black);
         content.append(" k").append_i(separator);
     }
@@ -664,7 +729,9 @@ public class PdfContentByte {
      */
 
     public void resetCMYKColorFill() {
-        content.append("0 0 0 1 k").append_i(separator);
+        saveColorFill(new CMYKColor(0.0f, 0.0f, 0.0f, MAX_FLOAT_COLOR_VALUE));
+        HelperCMYK(0.0f, 0.0f, 0.0f, MAX_FLOAT_COLOR_VALUE);
+        content.append(" k").append_i(separator);
     }
 
     /**
@@ -683,6 +750,10 @@ public class PdfContentByte {
      */
 
     public void setCMYKColorStrokeF(float cyan, float magenta, float yellow, float black) {
+        setCMYKColorStrokeF(cyan, magenta, yellow, black, MAX_FLOAT_COLOR_VALUE);
+    }
+    public void setCMYKColorStrokeF(float cyan, float magenta, float yellow, float black, float alpha) {
+        saveColorStroke(new CMYKColor(cyan, magenta, yellow, black, alpha));
         HelperCMYK(cyan, magenta, yellow, black);
         content.append(" K").append_i(separator);
     }
@@ -693,7 +764,9 @@ public class PdfContentByte {
      */
 
     public void resetCMYKColorStroke() {
-        content.append("0 0 0 1 K").append_i(separator);
+        saveColorStroke(new CMYKColor(0.0f, 0.0f, 0.0f, MAX_FLOAT_COLOR_VALUE));
+        HelperCMYK(0.0f, 0.0f, 0.0f, MAX_FLOAT_COLOR_VALUE);
+        content.append(" K").append_i(separator);
     }
 
     /**
@@ -1319,7 +1392,8 @@ public class PdfContentByte {
      */
     public void saveState() {
         content.append("q").append_i(separator);
-        stateList.add(new GraphicState(state));
+        GraphicState gstate = new GraphicState(state);
+        stateList.add(gstate);
     }
 
     /**
@@ -1332,6 +1406,7 @@ public class PdfContentByte {
         if (idx < 0)
             throw new IllegalPdfSyntaxException(MessageLocalization.getComposedMessage("unbalanced.save.restore.state.operators"));
         state = stateList.get(idx);
+        state.restore(state);
         stateList.remove(idx);
     }
 
@@ -2109,13 +2184,7 @@ public class PdfContentByte {
      */
 
     public void setCMYKColorFill(int cyan, int magenta, int yellow, int black) {
-        content.append((float)(cyan & 0xFF) / 0xFF);
-        content.append(' ');
-        content.append((float)(magenta & 0xFF) / 0xFF);
-        content.append(' ');
-        content.append((float)(yellow & 0xFF) / 0xFF);
-        content.append(' ');
-        content.append((float)(black & 0xFF) / 0xFF);
+        HelperCMYK(cyan, magenta, yellow, black);
         content.append(" k").append_i(separator);
     }
     /**
@@ -2136,13 +2205,7 @@ public class PdfContentByte {
      */
 
     public void setCMYKColorStroke(int cyan, int magenta, int yellow, int black) {
-        content.append((float)(cyan & 0xFF) / 0xFF);
-        content.append(' ');
-        content.append((float)(magenta & 0xFF) / 0xFF);
-        content.append(' ');
-        content.append((float)(yellow & 0xFF) / 0xFF);
-        content.append(' ');
-        content.append((float)(black & 0xFF) / 0xFF);
+        HelperCMYK(cyan, magenta, yellow, black);
         content.append(" K").append_i(separator);
     }
 
@@ -2164,7 +2227,11 @@ public class PdfContentByte {
      */
 
     public void setRGBColorFill(int red, int green, int blue) {
-        HelperRGB((float)(red & 0xFF) / 0xFF, (float)(green & 0xFF) / 0xFF, (float)(blue & 0xFF) / 0xFF);
+        setRGBColorFill(red, green, blue, MAX_COLOR_VALUE);
+    }
+    public void setRGBColorFill(int red, int green, int blue, int alpha) {
+        saveColorFill(new RGBColor(red, green, blue, alpha));
+        HelperRGB(red, green, blue);
         content.append(" rg").append_i(separator);
     }
 
@@ -2185,7 +2252,11 @@ public class PdfContentByte {
      */
 
     public void setRGBColorStroke(int red, int green, int blue) {
-        HelperRGB((float)(red & 0xFF) / 0xFF, (float)(green & 0xFF) / 0xFF, (float)(blue & 0xFF) / 0xFF);
+        setRGBColorStroke(red, green, blue, MAX_COLOR_VALUE);
+    }
+    public void setRGBColorStroke(int red, int green, int blue, int alpha) {
+        saveColorStroke(new RGBColor(red, green, blue, alpha));
+        HelperRGB(red, green, blue);
         content.append(" RG").append_i(separator);
     }
 
@@ -2198,12 +2269,13 @@ public class PdfContentByte {
         int type = ExtendedColor.getType(color);
         switch (type) {
             case ExtendedColor.TYPE_GRAY: {
-                setGrayStroke(((GrayColor)color).getGray());
+                final GrayColor grayColor = (GrayColor) color;
+                setGrayStroke(grayColor.getGray(), grayColor.getAlpha());
                 break;
             }
             case ExtendedColor.TYPE_CMYK: {
                 CMYKColor cmyk = (CMYKColor)color;
-                setCMYKColorStrokeF(cmyk.getCyan(), cmyk.getMagenta(), cmyk.getYellow(), cmyk.getBlack());
+                setCMYKColorStrokeF(cmyk.getCyan(), cmyk.getMagenta(), cmyk.getYellow(), cmyk.getBlack(), cmyk.getAlpha());
                 break;
             }
             case ExtendedColor.TYPE_SEPARATION: {
@@ -2222,8 +2294,16 @@ public class PdfContentByte {
                 break;
             }
             default:
-                setRGBColorStroke(color.getRed(), color.getGreen(), color.getBlue());
+                setRGBColorStroke(color.getRed(), color.getGreen(), color.getBlue(), color.getAlpha());
         }
+    }
+
+    private void saveColorStroke(ExtendedColor extendedColor) {
+        PdfGState gState = new PdfGState();
+        gState.setStrokeOpacity(extendedColor.getAlpha() / MAX_INT_COLOR_VALUE);
+        setGState(gState);
+
+        state.colorStroke = extendedColor;
     }
 
     /** Sets the fill color. <CODE>color</CODE> can be an
@@ -2235,16 +2315,17 @@ public class PdfContentByte {
         int type = ExtendedColor.getType(color);
         switch (type) {
             case ExtendedColor.TYPE_GRAY: {
-                setGrayFill(((GrayColor)color).getGray());
+                GrayColor grayColor = (GrayColor) color;
+                setGrayFill(grayColor.getGray(), color.getAlpha() / MAX_INT_COLOR_VALUE);
                 break;
             }
             case ExtendedColor.TYPE_CMYK: {
-                CMYKColor cmyk = (CMYKColor)color;
-                setCMYKColorFillF(cmyk.getCyan(), cmyk.getMagenta(), cmyk.getYellow(), cmyk.getBlack());
+                CMYKColor cmyk = (CMYKColor) color;
+                setCMYKColorFillF(cmyk.getCyan(), cmyk.getMagenta(), cmyk.getYellow(), cmyk.getBlack(), cmyk.getAlpha() / MAX_INT_COLOR_VALUE);
                 break;
             }
             case ExtendedColor.TYPE_SEPARATION: {
-                SpotColor spot = (SpotColor)color;
+                SpotColor spot = (SpotColor) color;
                 setColorFill(spot.getPdfSpotColor(), spot.getTint());
                 break;
             }
@@ -2259,8 +2340,16 @@ public class PdfContentByte {
                 break;
             }
             default:
-                setRGBColorFill(color.getRed(), color.getGreen(), color.getBlue());
+                setRGBColorFill(color.getRed(), color.getGreen(), color.getBlue(), color.getAlpha());
         }
+    }
+
+    private void saveColorFill(ExtendedColor extendedColor) {
+        PdfGState gState = new PdfGState();
+        gState.setFillOpacity(extendedColor.getAlpha() / MAX_INT_COLOR_VALUE);
+        setGState(gState);
+
+        state.colorFill = extendedColor;
     }
 
     /** Sets the fill color to a spot color.
@@ -2270,6 +2359,7 @@ public class PdfContentByte {
      */
     public void setColorFill(PdfSpotColor sp, float tint) {
         checkWriter();
+        saveColorFill(new SpotColor(sp,tint));
         state.colorDetails = writer.addSimple(sp);
         PageResources prs = getPageResources();
         PdfName name = state.colorDetails.getColorName();
@@ -2284,6 +2374,7 @@ public class PdfContentByte {
      */
     public void setColorStroke(PdfSpotColor sp, float tint) {
         checkWriter();
+        saveColorStroke(new SpotColor(sp,tint));
         state.colorDetails = writer.addSimple(sp);
         PageResources prs = getPageResources();
         PdfName name = state.colorDetails.getColorName();
@@ -2301,6 +2392,7 @@ public class PdfContentByte {
             return;
         }
         checkWriter();
+        saveColorFill(new PatternColor(p));
         PageResources prs = getPageResources();
         PdfName name = writer.addSimplePattern(p);
         name = prs.addPattern(name, p.getIndirectReference());
@@ -2316,11 +2408,11 @@ public class PdfContentByte {
         int type = ExtendedColor.getType(color);
         switch (type) {
             case ExtendedColor.TYPE_RGB:
-                content.append((float)(color.getRed()) / 0xFF);
+                content.append((float)(color.getRed()) / MAX_INT_COLOR_VALUE);
                 content.append(' ');
-                content.append((float)(color.getGreen()) / 0xFF);
+                content.append((float)(color.getGreen()) / MAX_INT_COLOR_VALUE);
                 content.append(' ');
-                content.append((float)(color.getBlue()) / 0xFF);
+                content.append((float)(color.getBlue()) / MAX_INT_COLOR_VALUE);
                 break;
             case ExtendedColor.TYPE_GRAY:
                 content.append(((GrayColor)color).getGray());
@@ -2357,8 +2449,10 @@ public class PdfContentByte {
      */
     public void setPatternFill(PdfPatternPainter p, Color color, float tint) {
         checkWriter();
-        if (!p.isStencil())
+        if (!p.isStencil()) {
             throw new RuntimeException(MessageLocalization.getComposedMessage("an.uncolored.pattern.was.expected"));
+        }
+        saveColorFill(new RGBColor(color.getRed(), color.getGreen(), color.getBlue(), color.getAlpha()));
         PageResources prs = getPageResources();
         PdfName name = writer.addSimplePattern(p);
         name = prs.addPattern(name, p.getIndirectReference());
@@ -2389,6 +2483,7 @@ public class PdfContentByte {
         checkWriter();
         if (!p.isStencil())
             throw new RuntimeException(MessageLocalization.getComposedMessage("an.uncolored.pattern.was.expected"));
+        saveColorStroke(new PatternColor(p));
         PageResources prs = getPageResources();
         PdfName name = writer.addSimplePattern(p);
         name = prs.addPattern(name, p.getIndirectReference());
@@ -2409,6 +2504,7 @@ public class PdfContentByte {
             return;
         }
         checkWriter();
+        saveColorStroke(new PatternColor(p));
         PageResources prs = getPageResources();
         PdfName name = writer.addSimplePattern(p);
         name = prs.addPattern(name, p.getIndirectReference());
@@ -2442,6 +2538,8 @@ public class PdfContentByte {
      * @param shading the shading pattern
      */
     public void setShadingFill(PdfShadingPattern shading) {
+        checkWriter();
+        saveColorFill(new ShadingColor(shading));
         writer.addSimpleShadingPattern(shading);
         PageResources prs = getPageResources();
         PdfName name = prs.addPattern(shading.getPatternName(), shading.getPatternReference());
@@ -2456,6 +2554,8 @@ public class PdfContentByte {
      * @param shading the shading pattern
      */
     public void setShadingStroke(PdfShadingPattern shading) {
+        checkWriter();
+        saveColorStroke(new ShadingColor(shading));
         writer.addSimpleShadingPattern(shading);
         PageResources prs = getPageResources();
         PdfName name = prs.addPattern(shading.getPatternName(), shading.getPatternReference());
@@ -2659,6 +2759,7 @@ public class PdfContentByte {
         if (llx > urx) { float x = llx; llx = urx; urx = x; }
         if (lly > ury) { float y = lly; lly = ury; ury = y; }
         // silver circle
+        saveState();
         setLineWidth(1);
         setLineCap(1);
         setColorStroke(new Color(0xC0, 0xC0, 0xC0));
@@ -2684,6 +2785,7 @@ public class PdfContentByte {
             arc(llx + 4f, lly + 4f, urx - 4f, ury - 4f, 0, 360);
             fill();
         }
+        restoreState();
     }
 
     /**
@@ -2697,6 +2799,7 @@ public class PdfContentByte {
         if (llx > urx) { float x = llx; llx = urx; urx = x; }
         if (lly > ury) { float y = lly; lly = ury; ury = y; }
         // silver rectangle not filled
+        saveState();
         setColorStroke(new Color(0xC0, 0xC0, 0xC0));
         setLineWidth(1);
         setLineCap(0);
@@ -2705,7 +2808,7 @@ public class PdfContentByte {
         // white rectangle filled
         setLineWidth(1);
         setLineCap(0);
-        setColorFill(new Color(0xFF, 0xFF, 0xFF));
+        setColorFill(new Color(MAX_COLOR_VALUE, MAX_COLOR_VALUE, MAX_COLOR_VALUE));
         rectangle(llx + 0.5f, lly + 0.5f, urx - llx - 1f, ury -lly - 1f);
         fill();
         // silver lines
@@ -2732,6 +2835,7 @@ public class PdfContentByte {
         lineTo(llx + 2f, ury - 2f);
         lineTo(urx - 2f, ury - 2f);
         stroke();
+        restoreState();
     }
 
     /**
@@ -2748,6 +2852,7 @@ public class PdfContentByte {
         if (llx > urx) { float x = llx; llx = urx; urx = x; }
         if (lly > ury) { float y = lly; lly = ury; ury = y; }
         // black rectangle not filled
+        saveState();
         setColorStroke(new Color(0x00, 0x00, 0x00));
         setLineWidth(1);
         setLineCap(0);
@@ -2760,7 +2865,7 @@ public class PdfContentByte {
         rectangle(llx + 0.5f, lly + 0.5f, urx - llx - 1f, ury -lly - 1f);
         fill();
         // white lines
-        setColorStroke(new Color(0xFF, 0xFF, 0xFF));
+        setColorStroke(new Color(MAX_COLOR_VALUE, MAX_COLOR_VALUE, MAX_COLOR_VALUE));
         setLineWidth(1);
         setLineCap(0);
         moveTo(llx + 1f, lly + 1f);
@@ -2781,6 +2886,7 @@ public class PdfContentByte {
         setFontAndSize(bf, size);
         showTextAligned(PdfContentByte.ALIGN_CENTER, text, llx + (urx - llx) / 2, lly + (ury - lly - size) / 2, 0);
         endText();
+        restoreState();
     }
 
     /** Gets a <CODE>Graphics2D</CODE> to write on. The graphics
@@ -2936,6 +3042,7 @@ public class PdfContentByte {
         PdfObject[] obj = writer.addSimpleExtGState(gstate);
         PageResources prs = getPageResources();
         PdfName name = prs.addExtGState((PdfName)obj[0], (PdfIndirectReference)obj[1]);
+        state.extGState = gstate;
         content.append(name.getBytes()).append(" gs").append_i(separator);
     }
 

--- a/openpdf/src/main/java/com/lowagie/text/pdf/PdfDocument.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/PdfDocument.java
@@ -1472,6 +1472,8 @@ public class PdfDocument extends Document {
                         tabPosition = tmp;
                     }
                     if (chunk.isAttribute(Chunk.BACKGROUND)) {
+                        graphics.saveState();
+
                         float subtract = lastBaseFactor;
                         if (nextChunk != null && nextChunk.isAttribute(Chunk.BACKGROUND))
                             subtract = 0;
@@ -1481,7 +1483,9 @@ public class PdfDocument extends Document {
                         float ascender = chunk.font().getFont().getFontDescriptor(BaseFont.ASCENT, fontSize);
                         float descender = chunk.font().getFont().getFontDescriptor(BaseFont.DESCENT, fontSize);
                         Object[] bgr = (Object[]) chunk.getAttribute(Chunk.BACKGROUND);
-                        graphics.setColorFill((Color)bgr[0]);
+
+                        graphics.setColorFill((ExtendedColor) bgr[0]);
+
                         float[] extra = (float[]) bgr[1];
                         graphics.rectangle(xMarker - extra[0],
                             yMarker + descender - extra[1] + chunk.getTextRise(),
@@ -1489,6 +1493,8 @@ public class PdfDocument extends Document {
                             ascender - descender + extra[1] + extra[3]);
                         graphics.fill();
                         graphics.setGrayFill(0);
+
+                        graphics.restoreState();
                     }
                     if (chunk.isAttribute(Chunk.UNDERLINE)) {
                         float subtract = lastBaseFactor;

--- a/openpdf/src/main/java/com/lowagie/text/pdf/PdfDocument.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/PdfDocument.java
@@ -1484,7 +1484,7 @@ public class PdfDocument extends Document {
                         float descender = chunk.font().getFont().getFontDescriptor(BaseFont.DESCENT, fontSize);
                         Object[] bgr = (Object[]) chunk.getAttribute(Chunk.BACKGROUND);
 
-                        graphics.setColorFill((ExtendedColor) bgr[0]);
+                        graphics.setColorFill((Color) bgr[0]);
 
                         float[] extra = (float[]) bgr[1];
                         graphics.rectangle(xMarker - extra[0],

--- a/openpdf/src/main/java/com/lowagie/text/pdf/PdfGState.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/PdfGState.java
@@ -113,8 +113,8 @@ public class PdfGState extends PdfDictionary {
     }
     
     /**
-     * Sets the current stroking alpha constant, specifying the constant shape or
-     * constant opacity value to be used for nonstroking operations in the transparent
+     * Sets the current fill alpha constant, specifying the constant shape or
+     * constant opacity value to be used for filling operations in the transparent
      * imaging model.
      * @param n
      */

--- a/openpdf/src/main/java/com/lowagie/text/pdf/RGBColor.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/RGBColor.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 1999-2004 The Apache Software Foundation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.lowagie.text.pdf;
+
+/**
+ *
+ * @author  Douglas SIX (http://github.com/sixdouglas)
+ */
+public class RGBColor extends ExtendedColor {
+
+    /**
+     * Constructs a RGB Color based on 3 color values (values are integers from 0 to 255).
+     * @param intRed
+     * @param intGreen
+     * @param intBlue
+     */
+    public RGBColor(int intRed, int intGreen, int intBlue) {
+        this(normalize(intRed) / MAX_INT_COLOR_VALUE, normalize(intGreen) / MAX_INT_COLOR_VALUE, normalize(intBlue) / MAX_INT_COLOR_VALUE, MAX_FLOAT_COLOR_VALUE);
+    }
+
+    /**
+     * Constructs a RGB Color based on 3 color values (values are integers from 0 to 255).
+     * @param intRed
+     * @param intGreen
+     * @param intBlue
+     * @param intAlpha
+     */
+    public RGBColor(int intRed, int intGreen, int intBlue, int intAlpha) {
+        this(normalize(intRed) / MAX_INT_COLOR_VALUE, normalize(intGreen) / MAX_INT_COLOR_VALUE, normalize(intBlue) / MAX_INT_COLOR_VALUE, normalize(intAlpha) / MAX_INT_COLOR_VALUE);
+    }
+
+    /**
+     * Construct a RGB Color (values are floats from 0 to 1).
+     * @param floatRed
+     * @param floatGreen
+     * @param floatBlue
+     */
+    public RGBColor(float floatRed, float floatGreen, float floatBlue) {
+        this(floatRed, floatGreen, floatBlue, MAX_FLOAT_COLOR_VALUE);
+    }
+
+    /**
+     * Construct a RGB Color (values are floats from 0 to 1).
+     * @param floatRed
+     * @param floatGreen
+     * @param floatBlue
+     * @param floatAlpha
+     */
+    public RGBColor(float floatRed, float floatGreen, float floatBlue, float floatAlpha) {
+        super(TYPE_RGB, normalize(floatRed), normalize(floatGreen), normalize(floatBlue), normalize(floatAlpha));
+    }
+}

--- a/openpdf/src/main/java/com/lowagie/text/pdf/SpotColor.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/SpotColor.java
@@ -49,6 +49,8 @@
 
 package com.lowagie.text.pdf;
 
+import java.awt.Color;
+
 /**
  *
  * @author  psoares
@@ -60,14 +62,20 @@ public class SpotColor extends ExtendedColor {
     float tint;
 
     public SpotColor(PdfSpotColor spot, float tint) {
-        super(TYPE_SEPARATION,
-            (spot.getAlternativeCS().getRed() / 255f - 1f) * tint + 1,
-            (spot.getAlternativeCS().getGreen() / 255f - 1f) * tint + 1,
-            (spot.getAlternativeCS().getBlue() / 255f - 1f) * tint + 1);
+        this((spot.getAlternativeCS().getRed() / MAX_INT_COLOR_VALUE - MAX_FLOAT_COLOR_VALUE) * tint + 1,
+            (spot.getAlternativeCS().getGreen() / MAX_INT_COLOR_VALUE - MAX_FLOAT_COLOR_VALUE) * tint + 1,
+            (spot.getAlternativeCS().getBlue() / MAX_INT_COLOR_VALUE - MAX_FLOAT_COLOR_VALUE) * tint + 1,
+            (spot.getAlternativeCS().getAlpha() / MAX_INT_COLOR_VALUE - MAX_FLOAT_COLOR_VALUE) * tint + 1,
+                tint);
         this.spot = spot;
+    }
+
+    public SpotColor(float red, float green, float blue, float alpha, float tint) {
+        super(TYPE_SEPARATION, red, green, blue, alpha);
+        this.spot = new PdfSpotColor("Color rgba(" + red + ", " + green + ", " + blue+ ", " + alpha + ")", new Color(red, green, blue, alpha));
         this.tint = tint;
     }
-    
+
     public PdfSpotColor getPdfSpotColor() {
         return spot;
     }

--- a/pdf-toolbox/src/test/java/com/lowagie/examples/directcontent/colors/TableCellTransparency.java
+++ b/pdf-toolbox/src/test/java/com/lowagie/examples/directcontent/colors/TableCellTransparency.java
@@ -1,0 +1,133 @@
+/*
+ * $Id: Transparency.java 3838 2009-04-07 18:34:15Z mstorer $
+ *
+ * This code is part of the 'OpenPDF Tutorial'.
+ * You can find the complete tutorial at the following address:
+ * https://github.com/LibrePDF/OpenPDF/wiki/Tutorial
+ *
+ * This code is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ *
+ */
+package com.lowagie.examples.directcontent.colors;
+
+import com.lowagie.text.Document;
+import com.lowagie.text.Font;
+import com.lowagie.text.FontFactory;
+import com.lowagie.text.PageSize;
+import com.lowagie.text.Phrase;
+import com.lowagie.text.Rectangle;
+import com.lowagie.text.pdf.CMYKColor;
+import com.lowagie.text.pdf.PdfContentByte;
+import com.lowagie.text.pdf.PdfPCell;
+import com.lowagie.text.pdf.PdfPTable;
+import com.lowagie.text.pdf.PdfPatternPainter;
+import com.lowagie.text.pdf.PdfTemplate;
+import com.lowagie.text.pdf.PdfWriter;
+import com.lowagie.text.pdf.RGBColor;
+
+import java.awt.Color;
+import java.io.FileOutputStream;
+
+/**
+ * Demonstrates transparency and images.
+ */
+public class TableCellTransparency {
+
+    /**
+     * Demonstrates the Table Cell Transparency functionality.
+     *
+     * @param args no arguments needed
+     */
+    public static void main(String[] args) {
+        System.out.println("Table Cell Transparency");
+
+        try (Document document = new Document(PageSize.A4, 50, 50, 50, 50)) {
+            PdfWriter writer = PdfWriter.getInstance(document, new FileOutputStream("table-cell-transparency.pdf"));
+            document.open();
+            Rectangle page = document.getPageSize();
+            PdfContentByte cb = writer.getDirectContent();
+            Font fontPlain = FontFactory.getFont(FontFactory.HELVETICA, Font.DEFAULTSIZE, Font.NORMAL, new Color(255, 255, 255, 255));
+            Font fontHalf = FontFactory.getFont(FontFactory.HELVETICA, Font.DEFAULTSIZE, Font.NORMAL, new Color(255, 255, 255, 125));
+
+            // Table cell transparency with RGB Color
+            PdfPTable pdfTableRGB = new PdfPTable(3);
+            PdfPCell cell;
+
+            for (int k = 1; k <= 6; ++k) {
+                cell = new PdfPCell(new Phrase("Content Plain" + k, fontHalf));
+                cell.setBackgroundColor(new RGBColor(0, 204, 255));
+                pdfTableRGB.addCell(cell);
+                cell = new PdfPCell(new Phrase("Content Alpha Half" + k, fontPlain));
+                cell.setBackgroundColor(new RGBColor(0, 204, 255, 125));
+                pdfTableRGB.addCell(cell);
+            }
+            pdfTableRGB.setTotalWidth(page.getWidth() - document.leftMargin() - document.rightMargin());
+            pdfTableRGB.writeSelectedRows(0, -1, document.leftMargin(), page.getHeight() - document.topMargin(), cb);
+
+            // Table cell transparency with CMYK Color
+            PdfPTable pdfPTableCMYK = new PdfPTable(3);
+
+            for (int k = 1; k <= 6; ++k) {
+                cell = new PdfPCell(new Phrase("Content Plain" + k, fontHalf));
+                cell.setBackgroundColor(new CMYKColor(255, 95, 232, 23));
+                pdfPTableCMYK.addCell(cell);
+                cell = new PdfPCell(new Phrase("Content Alpha Half" + k, fontPlain));
+                cell.setBackgroundColor(new CMYKColor(255, 95, 232, 23, 125));
+                pdfPTableCMYK.addCell(cell);
+            }
+            pdfPTableCMYK.setTotalWidth(page.getWidth() - document.leftMargin() - document.rightMargin());
+            pdfPTableCMYK.writeSelectedRows(0, -1, document.leftMargin(), page.getHeight() - document.topMargin() - pdfTableRGB.getTotalHeight() - 10f, cb);
+
+            // Draw pattern filled rectangle using CMYK Color
+            PdfTemplate tp = addPatternFilledRectangle(cb, new CMYKColor(.8f, .2f, .1f, .5f, .5f));
+            cb.addTemplate(tp, 50, 50);
+
+            tp = addPatternFilledRectangle(cb, new CMYKColor(.8f, .2f, .1f, .5f));
+            cb.addTemplate(tp, 250, 50);
+
+            // Draw pattern filled rectangle using RGB Color
+            tp = addPatternFilledRectangle(cb, new RGBColor(.1f, .8f, .2f, .5f));
+            cb.addTemplate(tp, 50, 350);
+
+            tp = addPatternFilledRectangle(cb, new RGBColor(.1f, .8f, .2f));
+            cb.addTemplate(tp, 250, 350);
+
+            // Draw plain rectangle using CMYK Color
+            drawRedRectangle(cb);
+
+            cb.sanityCheck();
+        } catch (Exception de) {
+            de.printStackTrace();
+        }
+    }
+
+    private static PdfTemplate addPatternFilledRectangle(PdfContentByte cb, Color patternColor) {
+        PdfPatternPainter pat = cb.createPattern(15, 15, null);
+        pat.rectangle(5, 5, 8, 8);
+        pat.fill();
+        pat.sanityCheck();
+
+        PdfTemplate tp = cb.createTemplate(400, 300);
+        // 60, 80, 0, 10
+        tp.setPatternFill(pat, patternColor, .9F);
+        tp.rectangle(0, 0, 200, 200);
+        tp.fill();
+        tp.sanityCheck();
+        return tp;
+    }
+
+    private static void drawRedRectangle(PdfContentByte cb) {
+        cb.moveTo(100f, 20f);
+        cb.lineTo(100f, 830f);
+        cb.lineTo(400f, 830f);
+        cb.lineTo(400f, 20f);
+        // because we change the fill color BEFORE we stroke the triangle
+        // the color of the triangle will be red instead of green
+        cb.setCMYKColorFillF(0f, 0f, 200f, 0f, .5f);
+        cb.closePathFillStroke();
+        cb.resetGrayFill();
+    }
+}


### PR DESCRIPTION
Fixing the #276 : the PdfPCell background color alpha layer is not taken into account.

