### PR TITLE
Fixes issue #322 (Subclasses of List render "bulletpoint"-characters properly again)

### DIFF
--- a/openpdf/src/main/java/com/lowagie/text/GreekList.java
+++ b/openpdf/src/main/java/com/lowagie/text/GreekList.java
@@ -57,7 +57,7 @@ import com.lowagie.text.factories.GreekAlphabetFactory;
 
 public class GreekList extends List {
 
-// constructors
+    // constructors
     
     /**
      * Initialization
@@ -66,6 +66,7 @@ public class GreekList extends List {
         super(true);
         setGreekFont();
     }
+
     /**
      * Initialization
      * 
@@ -87,7 +88,7 @@ public class GreekList extends List {
         setGreekFont();
     }
 
-// helper method
+    // helper method
     
     /**
      * change the font to SYMBOL
@@ -97,15 +98,16 @@ public class GreekList extends List {
         symbol.setFont(FontFactory.getFont(FontFactory.SYMBOL, fontsize, Font.NORMAL));
     }
 
-// overridden method
+    // overridden methods
     
     /**
-     * Adds an <CODE>Object</CODE> to the <CODE>List</CODE>.
+     * Adds an <CODE>Element</CODE> to the <CODE>List</CODE>.
      *
-     * @param    o    the object to add.
-     * @return true if adding the object succeeded
+     * @param    o    the element to add.
+     * @return true if adding the element succeeded
      */
-    public boolean add(Object o) {
+    @Override
+    public boolean add(Element o) {
         if (o instanceof ListItem) {
             ListItem item = (ListItem) o;
             Chunk chunk = new Chunk(preSymbol, symbol.getFont());
@@ -120,10 +122,19 @@ public class GreekList extends List {
             nested.setIndentationLeft(nested.getIndentationLeft() + symbolIndent);
             first--;
             return list.add(nested);
-        } else if (o instanceof String) {
-            return this.add(new ListItem((String) o));
         }
         return false;
+    }
+
+    /**
+     * Adds a <CODE>String</CODE> to the <CODE>List</CODE>.
+     *
+     * @param    s    the string to add.
+     * @return true if adding the string succeeded
+     */
+    @Override
+    public boolean add(String s) {
+        return this.add(new ListItem(s));
     }
 
 }

--- a/openpdf/src/main/java/com/lowagie/text/List.java
+++ b/openpdf/src/main/java/com/lowagie/text/List.java
@@ -261,10 +261,10 @@ public class List implements TextElementArray {
     // methods to set the membervariables
     
     /**
-     * Adds an <CODE>Object</CODE> to the <CODE>List</CODE>.
+     * Adds an <CODE>Element</CODE> to the <CODE>List</CODE>.
      *
-     * @param    o        the object to add.
-     * @return true if adding the object succeeded
+     * @param    o        the element to add.
+     * @return true if adding the element succeeded
      */
     public boolean add(Element o) {
         if (o instanceof ListItem) {
@@ -289,17 +289,29 @@ public class List implements TextElementArray {
         return false;
     }
 
+    /**
+     * Adds a nested <CODE>List</CODE> to the <CODE>List</CODE>.
+     *
+     * @param    nested        the nested list to add.
+     * @return true if adding the nested list succeeded
+     */
     public boolean add(List nested) {
         nested.setIndentationLeft(nested.getIndentationLeft() + symbolIndent);
         first--;
         return list.add(nested);
     }
 
-    public boolean add(String o) {
-        return this.add(new ListItem(o));
+    /**
+     * Adds a <CODE>String</CODE> to the <CODE>List</CODE>.
+     *
+     * @param    s        the string to add.
+     * @return true if adding the string succeeded
+     */
+    public boolean add(String s) {
+        return this.add(new ListItem(s));
     }
 
-        // extra methods
+    // extra methods
     
     /** Makes sure all the items in the list have the same indentation. */
     public void normalizeIndentation() {

--- a/openpdf/src/main/java/com/lowagie/text/RomanList.java
+++ b/openpdf/src/main/java/com/lowagie/text/RomanList.java
@@ -57,7 +57,7 @@ import com.lowagie.text.factories.RomanNumberFactory;
 
 public class RomanList extends List {
 
-// constructors
+    // constructors
     
     /**
      * Initialization
@@ -85,15 +85,16 @@ public class RomanList extends List {
         this.lowercase = lowercase;
     }
 
-// overridden method
+    // overridden methods
     
     /**
-     * Adds an <CODE>Object</CODE> to the <CODE>List</CODE>.
+     * Adds an <CODE>Element</CODE> to the <CODE>List</CODE>.
      *
-     * @param    o    the object to add.
-     * @return true if adding the object succeeded
+     * @param    o    the element to add.
+     * @return true if adding the element succeeded
      */
-    public boolean add(Object o) {
+    @Override
+    public boolean add(Element o) {
         if (o instanceof ListItem) {
             ListItem item = (ListItem) o;
             Chunk chunk;
@@ -109,10 +110,19 @@ public class RomanList extends List {
             nested.setIndentationLeft(nested.getIndentationLeft() + symbolIndent);
             first--;
             return list.add(nested);
-        } else if (o instanceof String) {
-            return this.add(new ListItem((String) o));
         }
         return false;
+    }
+
+    /**
+     * Adds a <CODE>String</CODE> to the <CODE>List</CODE>.
+     *
+     * @param    s    the string to add.
+     * @return true if adding the string succeeded
+     */
+    @Override
+    public boolean add(String s) {
+        return this.add(new ListItem(s));
     }
 
 }

--- a/openpdf/src/main/java/com/lowagie/text/ZapfDingbatsList.java
+++ b/openpdf/src/main/java/com/lowagie/text/ZapfDingbatsList.java
@@ -106,12 +106,13 @@ public class ZapfDingbatsList extends List {
     }
 
     /**
-     * Adds an <CODE>Object</CODE> to the <CODE>List</CODE>.
+     * Adds an <CODE>Element</CODE> to the <CODE>List</CODE>.
      *
-     * @param    o    the object to add.
-     * @return true if adding the object succeeded
+     * @param    o    the element to add.
+     * @return true if adding the element succeeded
      */
-    public boolean add(Object o) {
+    @Override
+    public boolean add(Element o) {
         if (o instanceof ListItem) {
             ListItem item = (ListItem) o;
             Chunk chunk = new Chunk(preSymbol, symbol.getFont());
@@ -126,9 +127,19 @@ public class ZapfDingbatsList extends List {
             nested.setIndentationLeft(nested.getIndentationLeft() + symbolIndent);
             first--;
             return list.add(nested);
-        } else if (o instanceof String) {
-            return this.add(new ListItem((String) o));
         }
         return false;
     }
+
+    /**
+     * Adds a <CODE>String</CODE> to the <CODE>List</CODE>.
+     *
+     * @param    s    the string to add.
+     * @return true if adding the string succeeded
+     */
+    @Override
+    public boolean add(String s) {
+        return this.add(new ListItem(s));
+    }
+
 }

--- a/openpdf/src/main/java/com/lowagie/text/ZapfDingbatsNumberList.java
+++ b/openpdf/src/main/java/com/lowagie/text/ZapfDingbatsNumberList.java
@@ -105,12 +105,13 @@ public class ZapfDingbatsNumberList extends List {
     }
 
     /**
-     * Adds an <CODE>Object</CODE> to the <CODE>List</CODE>.
+     * Adds an <CODE>Element</CODE> to the <CODE>List</CODE>.
      *
-     * @param    o    the object to add.
-     * @return true if adding the object succeeded
+     * @param    o    the element to add.
+     * @return true if adding the element succeeded
      */
-    public boolean add(Object o) {
+    @Override
+    public boolean add(Element o) {
         if (o instanceof ListItem) {
             ListItem item = (ListItem) o;
             Chunk chunk = new Chunk(preSymbol, symbol.getFont());
@@ -137,9 +138,18 @@ public class ZapfDingbatsNumberList extends List {
             nested.setIndentationLeft(nested.getIndentationLeft() + symbolIndent);
             first--;
             return list.add(nested);
-        } else if (o instanceof String) {
-            return this.add(new ListItem((String) o));
         }
         return false;
+    }
+
+    /**
+     * Adds a <CODE>String</CODE> to the <CODE>List</CODE>.
+     *
+     * @param    s    the string to add.
+     * @return true if adding the string succeeded
+     */
+    @Override
+    public boolean add(String s) {
+        return this.add(new ListItem(s));
     }
 }


### PR DESCRIPTION
This PR fixes issue #322 so subclasses of `List` render "bulletpoint"-characters properly again.

* Subclasses of `List` now accept an `Element` or a `String` instead of an `Object` in their `add`-method (equivalent to base class) => _potentially_ a braking change
* `@Override` was added in order to prevent this issue from reoccurring should the signature change again
* Improved Javadoc of affected methods
* Minor formatting adjustments