### PR TITLE
Fixed issues introduced with Apache FOP:

### DIFF
--- a/openpdf/src/main/java/com/lowagie/text/Document.java
+++ b/openpdf/src/main/java/com/lowagie/text/Document.java
@@ -50,6 +50,7 @@
 package com.lowagie.text;
 
 import com.lowagie.text.error_messages.MessageLocalization;
+import com.lowagie.text.pdf.FopGlyphProcessor;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -201,7 +202,15 @@ public class Document implements AutoCloseable, DocListener {
     
     /** This is a chapter number in case ChapterAutoNumber is used. */
     protected int chapternumber = 0;
-    
+
+    /**
+     * The default language of the document. Can be set to values like "en_US".
+     * This language is used in {@link FopGlyphProcessor} to determine which glyphs are to be substituted.
+     * The default "dflt" means that all glyphs which can be replaced will be substituted.
+     * @since 3.1.15
+     */
+    String documentLanguage = "dflt";
+
     // constructor
 
     /**
@@ -890,5 +899,13 @@ public class Document implements AutoCloseable, DocListener {
      */    
     public boolean isMarginMirroring() {
         return marginMirroring;
+    }
+
+    public void setDocumentLanguage(String documentLanguage) {
+        this.documentLanguage = documentLanguage;
+    }
+
+    public String getDocumentLanguage() {
+        return documentLanguage;
     }
 }

--- a/openpdf/src/main/java/com/lowagie/text/pdf/FontDetails.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/FontDetails.java
@@ -172,7 +172,7 @@ class FontDetails {
      * @param text the text to convert
      * @return the conversion
      */    
-    byte[] convertToBytes(String text) {
+    byte[] convertToBytes(String text, String language) {
         byte[] b = null;
         switch (fontType) {
             case BaseFont.FONT_TYPE_T3:
@@ -219,7 +219,7 @@ class FontDetails {
                         String fileName = ((TrueTypeFontUnicode)getBaseFont()).fileName;
                         if (FopGlyphProcessor.isFopSupported() && (fileName!=null && fileName.length()>0 
                                                                    &&( fileName.contains(".ttf") || fileName.contains(".TTF")))){
-                            return FopGlyphProcessor.convertToBytesWithGlyphs(ttu,text,fileName,longTag);
+                            return FopGlyphProcessor.convertToBytesWithGlyphs(ttu,text,fileName,longTag,language);
                         }else {
                             return convertToBytesWithGlyphs(text);
                         }

--- a/openpdf/src/main/java/com/lowagie/text/pdf/FopGlyphProcessor.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/FopGlyphProcessor.java
@@ -15,12 +15,7 @@ import org.apache.fop.fonts.truetype.TTFFile;
  */
 public class FopGlyphProcessor {
 
-    /**
-     * This character will be used if some unicode character used for which glyph index not defined in font.
-     */
-    private static final char CHAR_TO_USE_IF_GLYPH_NOT_FOUND = '#';
-
-    private static boolean isFopSupported = false;
+    private static boolean isFopSupported;
 
     static {
         try {
@@ -36,27 +31,29 @@ public class FopGlyphProcessor {
     }
 
     public static byte[] convertToBytesWithGlyphs(BaseFont font, String text, String fileName,
-                                                  Map<Integer, int[]> longTag) throws UnsupportedEncodingException {
+                                                  Map<Integer, int[]> longTag, String language) throws UnsupportedEncodingException {
         TrueTypeFontUnicode ttu = (TrueTypeFontUnicode)font;
         IntBuffer charBuffer = IntBuffer.allocate(text.length());
-        IntBuffer ghyphBuffer = IntBuffer.allocate(text.length());
+        IntBuffer glyphBuffer = IntBuffer.allocate(text.length());
+        int textLength = text.length();
         for (char c : text.toCharArray()) {
             int[] metrics = ttu.getMetricsTT(c);
-            // metrics will be null in case glyph not defined in TTF font, so default character should be used.
+            // metrics will be null in case glyph not defined in TTF font, skip these characters.
             if (metrics == null){
-                c = CHAR_TO_USE_IF_GLYPH_NOT_FOUND;
-                metrics = ttu.getMetricsTT(c);
+                textLength--;
+                continue;
             }
             charBuffer.put(c);
-            ghyphBuffer.put(metrics[0]);
+            glyphBuffer.put(metrics[0]);
         }
+        charBuffer.limit(textLength);
+        glyphBuffer.limit(textLength);
 
-        GlyphSequence glyphSequence = new GlyphSequence(charBuffer, ghyphBuffer, null);
+        GlyphSequence glyphSequence = new GlyphSequence(charBuffer, glyphBuffer, null);
         TTFFile ttf = TTFCache.getTTFFile(fileName);
         GlyphSubstitutionTable gsubTable = ttf.getGSUB();
         if (gsubTable != null) {
             String script = CharScript.scriptTagFromCode(CharScript.dominantScript(text));
-            String language = "dflt";
             if ("zyyy".equals(script) || "auto".equals(script)) {
                 script = "*";
             }

--- a/openpdf/src/main/java/com/lowagie/text/pdf/PdfContentByte.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/PdfContentByte.java
@@ -1501,7 +1501,7 @@ public class PdfContentByte {
     private void showText2(String text) {
         if (state.fontDetails == null)
             throw new NullPointerException(MessageLocalization.getComposedMessage("font.and.size.must.be.set.before.writing.any.text"));
-        byte[] b = state.fontDetails.convertToBytes(text);
+        byte[] b = state.fontDetails.convertToBytes(text, getPdfDocument().getDocumentLanguage());
         escapeString(b, content);
     }
 

--- a/openpdf/src/test/java/com/lowagie/text/pdf/fonts/AdvanceTypographyTest.java
+++ b/openpdf/src/test/java/com/lowagie/text/pdf/fonts/AdvanceTypographyTest.java
@@ -24,7 +24,7 @@ public class AdvanceTypographyTest {
         char[] expectedOutput = {660,666,911,656,1130};
         byte[] processedContent = FopGlyphProcessor.convertToBytesWithGlyphs(
                 BaseFont.createFont("fonts/jaldi/Jaldi-Regular.ttf", BaseFont.IDENTITY_H, false)
-                , "नमस्ते", "fonts/jaldi/Jaldi-Regular.ttf", new HashMap<>());
+                , "नमस्ते", "fonts/jaldi/Jaldi-Regular.ttf", new HashMap<>(), "dflt");
         String str = new String(processedContent, "UnicodeBigUnmarked");
 
         assertArrayEquals(expectedOutput,str.toCharArray());
@@ -40,7 +40,7 @@ public class AdvanceTypographyTest {
         char[] expectedOutput = {254,278,390,314,331,376,254,285,278};
         byte[] processedContent = FopGlyphProcessor.convertToBytesWithGlyphs(
                 BaseFont.createFont("fonts/Viaoda_Libre/ViaodaLibre-Regular.ttf", BaseFont.IDENTITY_H, false)
-                , "instruction", "fonts/Viaoda_Libre/ViaodaLibre-Regular.ttf", new HashMap<>());
+                , "instruction", "fonts/Viaoda_Libre/ViaodaLibre-Regular.ttf", new HashMap<>(), "dflt");
         String str = new String(processedContent, "UnicodeBigUnmarked");
         assertArrayEquals(expectedOutput,str.toCharArray());
     }


### PR DESCRIPTION
When updating to the latest OpenPDF version we observed that adopting Apache FOP led to some unexpected changes of behavior. I've tried to restore previous behavior with the code changes of this pull request, or at least to mitigate the effects. This pull requests addresses the following two issues:

1. With Apache FOP, if a glyph was not found in a font, there would be inserted the character '#'. This is different to previous behavior where nothing was changed, and it is especially annoying when one has got a string containing '\n' or similar characters. Therefore, I've restored the previous behavior.

2. Apache FOP supports ligatures. Because ligatures are not used in the same way in every language, Apache FOP asks for the language before substituting anything. The current default of OpenPDF is the language "dflt", which just means: Use ligatures wherever possible. I've not restored the previous default in this case (because using ligatures is fine), but made the language configurable per document, as some kind of work-around. I know that more would desireable here (e.g. specifying the language of each phrase), but I can't spend more time to this point at the moment (especially because I'm currently investigating more cases of changed behavior).

I hope you are ok with these changes.