### PR TITLE
Fix NPE when adding illegal child to nameless PdfLayer

### DIFF
--- a/openpdf/src/main/java/com/lowagie/text/pdf/PdfLayer.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/PdfLayer.java
@@ -111,8 +111,13 @@ public class PdfLayer extends PdfDictionary implements PdfOCG {
      * @param child the child layer
      */    
     public void addChild(PdfLayer child) {
-        if (child.parent != null)
-            throw new IllegalArgumentException(MessageLocalization.getComposedMessage("the.layer.1.already.has.a.parent", ((PdfString)child.get(PdfName.NAME)).toUnicodeString()));
+        if (child.parent != null) {
+            String name = null;
+            PdfString pdfName = child.getAsString(PdfName.NAME);
+            if (pdfName != null)
+                name = pdfName.toUnicodeString();
+            throw new IllegalArgumentException(MessageLocalization.getComposedMessage("the.layer.1.already.has.a.parent", name));
+        }
         child.parent = this;
         if (children == null)
             children = new ArrayList<>();


### PR DESCRIPTION
When a `PdfLayer` is created without a name, e.g., via `PdfLayer.createTitle()` or when reading OCProperties, and later a child that has already another parent is added to this layer, the `addChild(PdfLayer)` method throws a `NullPointerException`. The is because the name is retrieved and immediately converted to a Unicode string, even if it is `null`.

This problem was identified by our automated detector [MUDetect](https://github.com/stg-tud/MUDetect/). We would very much appreciate your feedback on our patch. Thank you very much!

Migrates https://github.com/LibrePDF/OpenPDF5/pull/2.