### PR TITLE
Re-use the already set document language in new PdfWriter instances.

### DIFF
--- a/openpdf/src/main/java/com/lowagie/text/pdf/PdfCopy.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/PdfCopy.java
@@ -152,6 +152,7 @@ public class PdfCopy extends PdfWriter {
    */
   public PdfCopy(Document document, OutputStream os) throws DocumentException {
     super(new PdfDocument(), os);
+    this.document.setDocumentLanguage(document.getDocumentLanguage());
     document.addDocListener(pdf);
     pdf.addWriter(this);
     indirectMap = new HashMap<>();

--- a/openpdf/src/main/java/com/lowagie/text/pdf/PdfWriter.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/PdfWriter.java
@@ -604,6 +604,7 @@ public class PdfWriter extends DocWriter implements
     public static PdfWriter getInstance(Document document, OutputStream os)
     throws DocumentException {
         PdfDocument pdf = new PdfDocument();
+        pdf.setDocumentLanguage(document.getDocumentLanguage());
         document.addDocListener(pdf);
         PdfWriter writer = new PdfWriter(pdf, os);
         pdf.addWriter(writer);
@@ -623,6 +624,7 @@ public class PdfWriter extends DocWriter implements
     public static PdfWriter getInstance(Document document, OutputStream os, DocListener listener)
     throws DocumentException {
         PdfDocument pdf = new PdfDocument();
+        pdf.setDocumentLanguage(document.getDocumentLanguage());
         pdf.addDocListener(listener);
         document.addDocListener(pdf);
         PdfWriter writer = new PdfWriter(pdf, os);


### PR DESCRIPTION
I've noticed that it is necessary to propagate the document language introduced in Pull Request #352 whenever a new PdfReader is constructed. Otherwise, when one writes to PdfContentByte returned by PdfWriter#getDirectContent or PdfWriter#getDirectContentUnder, the document language would be "dflt" again and could only be changed after document.open() has been called.