### PR TITLE
Issue-365: correct javadoc tag (use '</code>' instead of '</cide>')

### DIFF
--- a/openpdf/src/main/java/com/lowagie/text/Element.java
+++ b/openpdf/src/main/java/com/lowagie/text/Element.java
@@ -99,16 +99,16 @@ public interface Element {
     /** This is a possible type of <CODE>Element</CODE>. */
     int KEYWORDS = 3;
 
-    /** This is a possible type of <CODE>Element </CIDE>. */
+    /** This is a possible type of <CODE>Element </CODE>. */
     int AUTHOR = 4;
 
-    /** This is a possible type of <CODE>Element </CIDE>. */
+    /** This is a possible type of <CODE>Element </CODE>. */
     int PRODUCER = 5;
 
-    /** This is a possible type of <CODE>Element </CIDE>. */
+    /** This is a possible type of <CODE>Element </CODE>. */
     int CREATIONDATE = 6;
 
-    /** This is a possible type of <CODE>Element </CIDE>. */
+    /** This is a possible type of <CODE>Element </CODE>. */
     int CREATOR = 7;
 
     // static membervariables (content)


### PR DESCRIPTION
PR for [Issue-365](https://github.com/LibrePDF/OpenPDF/issues/365)

Existing Error:
![image](https://user-images.githubusercontent.com/6236263/80858303-3a474400-8c76-11ea-8992-4f4d16ea50ce.png)

After correction (javadoc)
![image](https://user-images.githubusercontent.com/6236263/80858313-48956000-8c76-11ea-851c-37035fb22ba0.png)
