### PR TITLE
Cleanup WebColors API (open for discussion, breaking change)

### DIFF
--- a/openpdf/src/main/java/com/lowagie/text/html/WebColors.java
+++ b/openpdf/src/main/java/com/lowagie/text/html/WebColors.java
@@ -67,7 +67,7 @@ import com.lowagie.text.error_messages.MessageLocalization;
  * 
  * @author blowagie
  */
-public class WebColors {
+public final class WebColors {
     
     
     /** HashMap containing all the names and corresponding color values. */

--- a/openpdf/src/main/java/com/lowagie/text/html/WebColors.java
+++ b/openpdf/src/main/java/com/lowagie/text/html/WebColors.java
@@ -52,7 +52,9 @@ package com.lowagie.text.html;
 import java.awt.Color;
 import java.util.HashMap;
 import java.util.Locale;
+import java.util.Map;
 import java.util.StringTokenizer;
+
 import com.lowagie.text.error_messages.MessageLocalization;
 
 /**
@@ -65,11 +67,11 @@ import com.lowagie.text.error_messages.MessageLocalization;
  * 
  * @author blowagie
  */
-public class WebColors extends HashMap<String, int[]> {
+public class WebColors {
     
-    private static final long serialVersionUID = 3542523100813372896L;
+    
     /** HashMap containing all the names and corresponding color values. */
-    public static final WebColors NAMES = new WebColors();
+    private static final Map<String, int[]> NAMES = new HashMap<>();
     static {
         NAMES.put("aliceblue", new int[] { 0xf0, 0xf8, 0xff, 0xff });
         NAMES.put("antiquewhite", new int[] { 0xfa, 0xeb, 0xd7, 0xff });


### PR DESCRIPTION
WebColors extends HashMap, only to define a public NAMES WebColor (HashMap).

This change make WebColors final and not extending any Class.
Also makes static variable NAMES private, and change it to HashMap.

This change doesn't break OpenPDF (The only use of WebColors in OpenPDF is in com.lowagie.text.html.Markup and call to WebColors.getRGBColor)

It's strange any other code uses WebColors as HashMap or using NAMES directly.