### PR TITLE
Fix encoding of ByteBuffer.append(long) > 16777216

### DIFF
--- a/openpdf/src/main/java/com/lowagie/text/pdf/ByteBuffer.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/ByteBuffer.java
@@ -271,9 +271,18 @@ public class ByteBuffer extends OutputStream {
      * @return a reference to this <CODE>ByteBuffer</CODE> object
      */
     public ByteBuffer append(int i) {
-        return append((double)i);
+        return append(String.valueOf(i));
     }
-    
+
+    /**
+     * Appends the string representation of a <CODE>long</CODE>.
+     * @param l the <CODE>long</CODE> to be appended
+     * @return a reference to this <CODE>ByteBuffer</CODE> object
+     */
+    public ByteBuffer append(long l) {
+        return append(String.valueOf(l));
+    }
+
     public ByteBuffer append(byte b) {
         return append_i(b);
     }


### PR DESCRIPTION
And use an easier code path for `ByteBuffer.appent(int)` too.
Closes #383.