### PR TITLE
Clean room implementation of `detectCharsetFromBOM`

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,6 @@ Make sure that your contributions can be released with a dual LGPL and MPL licen
 ## Dependencies ##
 ### Required Dependencies: ###
  - Java 8 or later is required to use OpenPDF. All versions Java 8 to Java OpenJDK 13 have been tested to work.
- - [Juniversalchardet](https://github.com/albfernandez/juniversalchardet)
 
 ### Optional: ###
 
@@ -94,7 +93,7 @@ Significant [Contributors to OpenPDF](https://github.com/LibrePDF/OpenPDF/graphs
   [@ubermichael](https://github.com/ubermichael) - Michael Joyce  
   [@weiyeh](https://github.com/weiyeh)  
   [@SuperPat45](https://github.com/SuperPat45)  
-  [@lapo-luchini](https://github.com/lapo-luchini)  
+  [@lapo-luchini](https://github.com/lapo-luchini)  - Lapo Luchini
   [@MartinKocour](https://github.com/MartinKocour)  - Martin Kocour  
   [@jokimaki](https://github.com/jokimaki)  
   [@sullis](https://github.com/sullis)  

--- a/openpdf/pom.xml
+++ b/openpdf/pom.xml
@@ -13,16 +13,10 @@
 
     <properties>
         <java-module-name>com.github.librepdf.openpdf</java-module-name>
-        <juniversalchardet.version>2.3.2</juniversalchardet.version>
         <imageio-tiff.version>3.5</imageio-tiff.version>
     </properties>
 
     <dependencies>
-        <dependency>
-            <groupId>com.github.albfernandez</groupId>
-            <artifactId>juniversalchardet</artifactId>
-            <version>${juniversalchardet.version}</version>
-        </dependency>
         <dependency>
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcprov-jdk15on</artifactId>

--- a/openpdf/src/main/java/com/lowagie/text/xml/simpleparser/SimpleXMLParser.java
+++ b/openpdf/src/main/java/com/lowagie/text/xml/simpleparser/SimpleXMLParser.java
@@ -50,8 +50,12 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.Reader;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.nio.charset.UnsupportedCharsetException;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Stack;
 
 /**
@@ -550,7 +554,7 @@ public final class SimpleXMLParser {
     }
 
     /** Detect charset from BOM, as per <a href="https://unicode.org/faq/utf_bom.html#bom4">Unicode FAQ</a>. */
-    private static String detectCharsetFromBOM(byte[] bom) {
+    private static Optional<Charset> detectCharsetFromBOM(byte[] bom) {
         // 00 00 FE FF  UTF-32BE
         // EF BB BF ..  UTF-8
         // FE FF .. ..  UTF-16BE
@@ -559,26 +563,26 @@ public final class SimpleXMLParser {
         switch (bom[0]) {
             case (byte) 0x00:
                 if (bom[1] == (byte) 0x00 && bom[2] == (byte) 0xFE && bom[3] == (byte) 0xFF)
-                    return "UTF-32BE";
+                    return Optional.of(Charset.forName("UTF-32BE"));
                 break;
             case (byte) 0xEF:
                 if (bom[1] == (byte) 0xBB && bom[2] == (byte) 0xBF)
-                    return "UTF-8";
+                    return Optional.of(StandardCharsets.UTF_8);
                 break;
             case (byte) 0xFE:
                 if (bom[1] == (byte) 0xFF)
-                    return "UTF-16BE";
+                    return Optional.of(StandardCharsets.UTF_16BE);
                 break;
             case (byte) 0xFF:
                 if (bom[1] == (byte) 0xFE) {
                     if (bom[2] == (byte) 0x00 && bom[3] == (byte) 0x00)
-                        return "UTF-32LE";
+                        return Optional.of(Charset.forName("UTF-32LE"));
                     else
-                        return "UTF-16LE";
+                        return Optional.of(StandardCharsets.UTF_16LE);
                 }
                 break;
         }
-        return null;
+        return Optional.empty();
     }
 
     /**
@@ -592,11 +596,8 @@ public final class SimpleXMLParser {
         int count = in.read(b4);
         if (count != 4)
             throw new IOException(MessageLocalization.getComposedMessage("insufficient.length"));
-        String encoding = detectCharsetFromBOM(b4);
-        if (encoding == null) encoding = "UTF-8"; //UTF-8 is default.
-
-        String decl = null;
-        if (encoding.equals("UTF-8")) {
+        Charset encoding = detectCharsetFromBOM(b4).orElse(null);
+        if (encoding == null) {
             StringBuilder sb = new StringBuilder();
             int c;
             while ((c = in.read()) != -1) {
@@ -604,14 +605,17 @@ public final class SimpleXMLParser {
                     break;
                 sb.append((char)c);
             }
-            decl = sb.toString();
+            String decl = getDeclaredEncoding(sb.toString());
+            if (decl == null)
+                encoding = StandardCharsets.UTF_8;
+            else
+                try {
+                    encoding = Charset.forName(decl);
+                } catch (UnsupportedCharsetException e) {
+                    encoding = Charset.forName(IanaEncodings.getJavaEncoding(decl));
+                }
         }
-        if (decl != null) {
-            decl = getDeclaredEncoding(decl);
-            if (decl != null)
-                encoding = decl;
-        }
-        parse(doc, new InputStreamReader(in, IanaEncodings.getJavaEncoding(encoding)));
+        parse(doc, new InputStreamReader(in, encoding));
     }
     
     private static String getDeclaredEncoding(String decl) {

--- a/openpdf/src/main/java/com/lowagie/text/xml/simpleparser/SimpleXMLParser.java
+++ b/openpdf/src/main/java/com/lowagie/text/xml/simpleparser/SimpleXMLParser.java
@@ -46,7 +46,6 @@ package com.lowagie.text.xml.simpleparser;
 import com.lowagie.text.error_messages.MessageLocalization;
 
 import java.io.BufferedReader;
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;

--- a/openpdf/src/main/java/com/lowagie/text/xml/simpleparser/SimpleXMLParser.java
+++ b/openpdf/src/main/java/com/lowagie/text/xml/simpleparser/SimpleXMLParser.java
@@ -576,16 +576,6 @@ public final class SimpleXMLParser {
             }
             decl = sb.toString();
         }
-        else if (encoding.equals("CP037")) {
-            ByteArrayOutputStream bi = new ByteArrayOutputStream();
-            int c;
-            while ((c = in.read()) != -1) {
-                if (c == 0x6e) // that's '>' in ebcdic
-                    break;
-                bi.write(c);
-            }
-            decl = new String(bi.toByteArray(), "CP037");
-        }
         if (decl != null) {
             decl = getDeclaredEncoding(decl);
             if (decl != null)

--- a/openpdf/src/test/java/com/lowagie/text/xml/simpleparser/SimpleXMLParserTest.java
+++ b/openpdf/src/test/java/com/lowagie/text/xml/simpleparser/SimpleXMLParserTest.java
@@ -13,18 +13,31 @@ import org.junit.jupiter.api.Test;
 public class SimpleXMLParserTest {
 
     static final String bom = "\uFEFF";
-    static final String content = "\u79C1";
-    static final String xmlRaw = "<?xml version='1.0'?><a>" + content + "</a>";
+    static final String euro = "\u20AC";
+    static final String xmlRaw = "<?xml version='1.0'?><a>" + euro + "</a>";
     static final String xmlBOM = bom + xmlRaw;
+    static final String xmlI15 = "<?xml version='1.0' encoding='ISO-8859-15'?><a>" + euro + "</a>";
 
     @Test
-    void testParse() throws IOException {
+    void testDetectUnicode() throws IOException {
         testCharset(xmlRaw, StandardCharsets.UTF_8);
         testCharset(xmlBOM, StandardCharsets.UTF_8);
         testCharset(xmlBOM, StandardCharsets.UTF_16BE);
         testCharset(xmlBOM, StandardCharsets.UTF_16LE);
         testCharset(xmlBOM, Charset.forName("UTF-32BE"));
         testCharset(xmlBOM, Charset.forName("UTF-32LE"));
+        testCharset(xmlI15, Charset.forName("ISO-8859-15"));
+    }
+
+    @Test
+    void testDetectedOverDeclared() throws IOException {
+        String xml = bom + xmlI15;
+        testCharset(xml, StandardCharsets.UTF_8);
+        testCharset(xml, StandardCharsets.UTF_16BE);
+        testCharset(xml, StandardCharsets.UTF_16LE);
+        testCharset(xml, Charset.forName("UTF-32BE"));
+        testCharset(xml, Charset.forName("UTF-32LE"));
+        testCharset(xml, Charset.forName("ISO-8859-15"));
     }
 
     static void testCharset(String xml, Charset charset) throws IOException {
@@ -62,7 +75,7 @@ public class SimpleXMLParserTest {
 
         @Override
         public void text(String str) {
-            Assertions.assertEquals(content, str, "text content in " + charset);
+            Assertions.assertEquals(euro, str, "text content in " + charset);
             called = true;
         }
 

--- a/openpdf/src/test/java/com/lowagie/text/xml/simpleparser/SimpleXMLParserTest.java
+++ b/openpdf/src/test/java/com/lowagie/text/xml/simpleparser/SimpleXMLParserTest.java
@@ -1,0 +1,75 @@
+package com.lowagie.text.xml.simpleparser;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class SimpleXMLParserTest {
+
+    static final String bom = "\uFEFF";
+    static final String content = "\u79C1";
+    static final String xmlRaw = "<?xml version='1.0'?><a>" + content + "</a>";
+    static final String xmlBOM = bom + xmlRaw;
+
+    @Test
+    void testParse() throws IOException {
+        testCharset(xmlRaw, StandardCharsets.UTF_8);
+        testCharset(xmlBOM, StandardCharsets.UTF_8);
+        testCharset(xmlBOM, StandardCharsets.UTF_16BE);
+        testCharset(xmlBOM, StandardCharsets.UTF_16LE);
+        testCharset(xmlBOM, Charset.forName("UTF-32BE"));
+        testCharset(xmlBOM, Charset.forName("UTF-32LE"));
+    }
+
+    static void testCharset(String xml, Charset charset) throws IOException {
+        try (
+                TestHandler h = new TestHandler(charset);
+                ByteArrayInputStream is = new ByteArrayInputStream(xml.getBytes(charset))
+        ) {
+            SimpleXMLParser.parse(h, is);
+        }
+    }
+
+    static class TestHandler implements SimpleXMLDocHandler, AutoCloseable {
+
+        volatile boolean called = false;
+        final String charset;
+
+        TestHandler(Charset charset) {
+            this.charset = charset.displayName();
+        }
+
+        @Override
+        public void startElement(String tag, HashMap h) {}
+
+        @Override
+        public void startElement(String tag, Map<String, String> h) {}
+
+        @Override
+        public void endElement(String tag) {}
+
+        @Override
+        public void startDocument() {}
+
+        @Override
+        public void endDocument() {}
+
+        @Override
+        public void text(String str) {
+            Assertions.assertEquals(content, str, "text content in " + charset);
+            called = true;
+        }
+
+        @Override
+        public void close() {
+            Assertions.assertTrue(called, "was not called");
+        }
+    }
+
+}


### PR DESCRIPTION
I re-wrote `detectCharsetFromBOM` starting [from specs](https://unicode.org/faq/utf_bom.html#bom4).

Tested with the following code:
```Java
for (String test : new String[] { "0000FEFF", "EFBBBF77", "FEFF7777", "FFFE0000", "FFFE7777", "77777777" }) {
    byte[] buf = Hex.decode(test);
    String our = detectCharsetFromBOM(buf);
    String prev = org.mozilla.universalchardet.UniversalDetector.detectCharsetFromBOM(buf);
    System.out.printf("%-8s %-8s %-8s %b%n", test, our, prev, Objects.equals(our, prev));
}
```

which produces

```
0000FEFF UTF-32BE UTF-32BE true
EFBBBF77 UTF-8    UTF-8    true
FEFF7777 UTF-16BE UTF-16BE true
FFFE0000 UTF-32LE UTF-32LE true
FFFE7777 UTF-16LE UTF-16LE true
77777777 null     null     true
```
(creating an actual test would be difficult, and also would need to keep old dependency)