### PR TITLE
added module-info to newly created module openpdf-fonts-extra

### DIFF
--- a/openpdf-fonts-extra/pom.xml
+++ b/openpdf-fonts-extra/pom.xml
@@ -10,6 +10,11 @@
   <modelVersion>4.0.0</modelVersion>
 
   <artifactId>openpdf-fonts-extra</artifactId>
+
+  <properties>
+    <java-module-name>com.github.librepdf.pdfFontsExtra</java-module-name>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>com.github.librepdf</groupId>

--- a/openpdf-fonts-extra/src/main/java9/module-info.java
+++ b/openpdf-fonts-extra/src/main/java9/module-info.java
@@ -1,0 +1,5 @@
+module com.github.librepdf.pdfFontsExtra {
+    requires com.github.librepdf.openpdf;
+
+    exports org.librepdf.openpdf.fonts;
+}


### PR DESCRIPTION
I had missed adding `module-info` to the newly created module `openpdf-fonts-extra` in the pull request #395 . So this PR adds it. 

I've set the module name as: `com.github.librepdf.pdfFontsExtra` following the convention in other modules. Please review.