### PR TITLE
Fixes #411 - Release 1.3.21 (on Maven Central) is broken on Java 8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -293,6 +293,9 @@
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-compiler-plugin</artifactId>
                         <version>${maven.compiler.plugin.version}</version>
+                        <configuration>
+                            <release>8</release>
+                        </configuration>
                         <executions>
                             <execution>
                                 <id>compile-java-9</id>


### PR DESCRIPTION
Please review and test the built jar from JDK9+ by running tests on Java 8.