### PR TITLE
Fix #413: Update dependencies & enable dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "maven"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/pom.xml
+++ b/pom.xml
@@ -42,22 +42,22 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
-        <bouncycastle.bcpkix.version>1.65</bouncycastle.bcpkix.version>
-        <bouncycastle.bcprov.version>1.65.01</bouncycastle.bcprov.version>
+        <bouncycastle.bcpkix.version>1.66</bouncycastle.bcpkix.version>
+        <bouncycastle.bcprov.version>1.66</bouncycastle.bcprov.version>
 
-        <spotbugs.version>4.0.3</spotbugs.version>
+        <spotbugs.version>4.1.3</spotbugs.version>
         <hamcrest.version>2.2</hamcrest.version>
         <java-module-name>com.github.librepdf.openpdf.parent</java-module-name>
-        <jupiter.version>5.5.2</jupiter.version>
+        <jupiter.version>5.7.0</jupiter.version>
         <maven.clean.plugin.version>3.1.0</maven.clean.plugin.version>
         <maven.compiler.plugin.version>3.8.1</maven.compiler.plugin.version>
-        <maven.dependency.plugin.version>3.1.1</maven.dependency.plugin.version>
-        <maven.jar.plugin.version>3.1.2</maven.jar.plugin.version>
-        <maven.javadoc.plugin.version>3.0.1</maven.javadoc.plugin.version>
-        <maven.plugin.bundle.version>4.2.0</maven.plugin.bundle.version>
-        <maven.plugin.repository.version>2.3.1</maven.plugin.repository.version>
+        <maven.dependency.plugin.version>3.1.2</maven.dependency.plugin.version>
+        <maven.jar.plugin.version>3.2.0</maven.jar.plugin.version>
+        <maven.javadoc.plugin.version>3.2.0</maven.javadoc.plugin.version>
+        <maven.plugin.bundle.version>5.1.1</maven.plugin.bundle.version>
+        <maven.plugin.repository.version>2.4</maven.plugin.repository.version>
         <maven.release.plugin.version>2.5.3</maven.release.plugin.version>
-        <maven.source.version>3.0.1</maven.source.version>
+        <maven.source.version>3.2.1</maven.source.version>
         <maven.surefire.plugin.version>2.22.1</maven.surefire.plugin.version>
         <maven.test.failure.ignore>false</maven.test.failure.ignore>
         <mockito.version>2.25.1</mockito.version>


### PR DESCRIPTION
This PR updates several dependencies along with the required `maven-bundle-plugin` update for building on JDK15. 

It also enables Dependabot to automate such dependency version updates.

Btw, I've not updated following dependency versions:
* `maven-release-plugin` : `3.0.0-M1`
* `maven-surefire-plugin` : `3.0.0-M5`
* `mockito-core` : `3.5.13`

Please review. If any of the earlier versions are to be retained, I can revert those changes. 