### PR TITLE
avoid NPE in StandardDecryption#finish

### DIFF
--- a/openpdf/src/main/java/com/lowagie/text/pdf/StandardDecryption.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/StandardDecryption.java
@@ -107,7 +107,7 @@ public class StandardDecryption {
     }
     
     public byte[] finish() {
-        if (aes) {
+        if (aes && cipher != null) {
             return cipher.doFinal();
         }
         else

--- a/openpdf/src/test/java/com/lowagie/text/pdf/StandardDecryptionTest.java
+++ b/openpdf/src/test/java/com/lowagie/text/pdf/StandardDecryptionTest.java
@@ -1,0 +1,25 @@
+package com.lowagie.text.pdf;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class StandardDecryptionTest {
+
+    @Test
+    public void testAESDecryptionOnEmptyArray() {
+        // setup AES 128 encryption
+        PdfEncryption decrypt = new PdfEncryption();
+        decrypt.setCryptoMode(PdfWriter.ENCRYPTION_AES_128, 0);
+        byte[] key = new byte[16]; // create fake key, it does not matter for this test
+        decrypt.setupByEncryptionKey(key, 128);
+        decrypt.setHashKey(0, 0);
+
+        // try to decrypt an empty array - expected no NPE
+        byte[] result = decrypt.decryptByteArray(new byte[]{});
+
+        // verify empty array returned
+        Assertions.assertNotNull(result);
+        Assertions.assertEquals(result.length, 0);
+    }
+
+}


### PR DESCRIPTION
NullPointerException occurs at com.lowagie.text.pdf.StandardDecryption#finish(StandardDecryption.java:105)
in PDF enctypted with AES while decrypting object of empty stream (cipher is not initialized in this case)

sample pdf object that causes NPE if try to modify (using PDFStamper) encrypted PDF with such object

```
    41 0 obj
    <</Length 0/Type/Pattern/PatternType 1/PaintType 1/TilingType 2/BBox[0 0 10 10]/XStep 10/YStep 10/Resources 42 0 R>>stream

    endstream
    endobj
```

stacktrace of error

```
java.lang.NullPointerException
	at com.lowagie.text.pdf.StandardDecryption.finish(StandardDecryption.java:105)
	at com.lowagie.text.pdf.PdfEncryption.decryptByteArray(PdfEncryption.java:582)
	at com.lowagie.text.pdf.PdfReader.getStreamBytesRaw(PdfReader.java:2355)
	at com.lowagie.text.pdf.PdfReader.getStreamBytesRaw(PdfReader.java:2385)
	at com.lowagie.text.pdf.PRStream.toPdf(PRStream.java:222)
	at com.lowagie.text.pdf.PdfIndirectObject.writeTo(PdfIndirectObject.java:164)
	at com.lowagie.text.pdf.PdfWriter$PdfBody.add(PdfWriter.java:410)
	at com.lowagie.text.pdf.PdfWriter.addToBody(PdfWriter.java:841)
	at com.lowagie.text.pdf.PdfStamperImp.close(PdfStamperImp.java:320)
	at com.lowagie.text.pdf.PdfStamper.close(PdfStamper.java:246)