### PR TITLE
Fix module-info.java for jfreechart update from 1.5.0 to 1.5.1 in pdftoolbox (#444)

### DIFF
--- a/pdf-toolbox/src/main/java9/module-info.java
+++ b/pdf-toolbox/src/main/java9/module-info.java
@@ -1,6 +1,6 @@
 module com.github.librepdf.pdfToolbox {
     requires com.github.librepdf.openpdf;
-    requires jfreechart;
+    requires org.jfree.jfreechart;
     requires jcommon;
 
     exports com.lowagie.toolbox;


### PR DESCRIPTION
update module-info.java for jfreechart