### PR TITLE
Check if the returned ANNOTS object is not PdfNull

### DIFF
--- a/openpdf/src/main/java/com/lowagie/text/pdf/AcroFields.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/AcroFields.java
@@ -162,7 +162,8 @@ public class AcroFields {
     }
     for (int k = 1; k <= reader.getNumberOfPages(); ++k) {
       PdfDictionary page = reader.getPageNRelease(k);
-      PdfArray annots = (PdfArray) PdfReader.getPdfObjectRelease(page.get(PdfName.ANNOTS), page);
+      Object o = PdfReader.getPdfObjectRelease(page.get(PdfName.ANNOTS), page);
+      PdfArray annots = (o instanceof PdfArray) ? (PdfArray) o : null;
       if (annots == null) {
         continue;
       }


### PR DESCRIPTION
## Description of the new Feature/Bugfix

Can someone more knowledgeable with PDF internals check if the patch I made make sense? I have a PDF document (which unfortunately I can't share...) which fails with following exception:

```
Caused by: java.lang.ClassCastException: com.lowagie.text.pdf.PdfNull cannot be cast to com.lowagie.text.pdf.PdfArray
	at com.lowagie.text.pdf.AcroFields.fill(AcroFields.java:167)
	at com.lowagie.text.pdf.AcroFields.<init>(AcroFields.java:154)
	at com.lowagie.text.pdf.PdfStamperImp.getAcroFields(PdfStamperImp.java:803)
	at com.lowagie.text.pdf.PdfStamper.getAcroFields(PdfStamper.java:386)

```

I inspected the code and indeed in the mentioned line in AcroFields class PdfNull object cast to PdfArray and it is failing. 

I am not sure if the document is broken or maybe some case is not handled properly in OpenPDF. I tested the same PDF with aspose-pdf and pdfbox and it gets opened just fine, so looks like this is OpenPDF related. Also the PDF document is opened in Okular, Acrobat reader without any issues.

The document is processed by properly by OpenPDF with the patch applied. 

Related Issue: #

No issue created yet.

## Unit-Tests for the new Feature/Bugfix

No unit tests were added or modified.

## Compatibilities Issues

No compatibility issues. Existing unit tests execute correctly.

## Testing details

A PDF document which triggers the issue is required, as mentioned above I have one but it is confidential and I cannot share it.
