### PR TITLE
Check if the annotation belongs to a valid page

### DIFF
--- a/openpdf/src/main/java/com/lowagie/text/pdf/PdfStamperImp.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/PdfStamperImp.java
@@ -847,6 +847,8 @@ class PdfStamperImp extends PdfWriter {
                 if (ff != null)
                     flags = ff.intValue();
                 int page = item.getPage(k);
+                if (page == -1)
+                	continue;
                 PdfDictionary appDic = merged.getAsDict(PdfName.AP);
                 if (appDic != null && (flags & PdfFormField.FLAGS_PRINT) != 0 && (flags & PdfFormField.FLAGS_HIDDEN) == 0) {
                     PdfObject obj = appDic.get(PdfName.N);


### PR DESCRIPTION
## Description of the new Feature/Bugfix
Hello!

Could someone more experienced with the library please check if this fix makes sense? We are replacing iText:2.1.5 with OpenPDF in an application, and I found a [very old] unit test (with a PDF document which, at least for now, I can't share) that fails with the following stacktrace:

```
java.lang.NullPointerException
	at com.lowagie.text.pdf.PdfStamperImp.flatFields(PdfStamperImp.java:880)
	at com.lowagie.text.pdf.PdfStamperImp.close(PdfStamperImp.java:162)
	at com.lowagie.text.pdf.PdfStamper.close(PdfStamper.java:246)
	at [ommited-package-name].PdfTest.getStampedPdf(PdfTest.java:60)
	at [ommited-package-name].PdfTest.shouldLoadAndFlatAPdfStamped(PdfTest.java:51)
```

The unit test had a comment on it saying that [_once upon a time..._] iText was bumped from 2.1.5 to 2.1.7 but this issue arised, so they reverted it [and kept until today...] to 2.1.5. I was able to find out that [this block of code](https://github.com/LibrePDF/OpenPDF/blob/master/openpdf/src/main/java/com/lowagie/text/pdf/AcroFields.java#L239) didn't exist in 2.1.5 but was there in 2.1.7. After debugging said unit test, I came up with this fix.

The commit message has more details. Basically, it doesn't assume a PdfAppearance for a "pageless annotation" anymore.

Related Issue: #
None.

## Unit-Tests for the new Feature/Bugfix
No unit tests were added or modified.

## Compatibilities Issues
No compatibility issues. Existing unit tests execute correctly.

## Testing details
We have a PDF document which would trigger the issue, but unfortunatelly we cannot share it.