### PR TITLE
Fix #502: Changed constructor for PdfDocument

### DIFF
--- a/openpdf/src/main/java/com/lowagie/text/pdf/PdfDocument.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/PdfDocument.java
@@ -330,6 +330,8 @@ public class PdfDocument extends Document {
      */
     public PdfDocument() {
         super();
+        addProducer();
+        addCreationDate();
     }
 
     /** The <CODE>PdfWriter</CODE>. */

--- a/openpdf/src/test/java/com/lowagie/text/pdf/metadata/CleanMetaDataTest.java
+++ b/openpdf/src/test/java/com/lowagie/text/pdf/metadata/CleanMetaDataTest.java
@@ -36,6 +36,8 @@ public class CleanMetaDataTest {
 
 	@Test
 	public void testProducer() throws Exception {
+		String PRODUCER = "OpenPDF 1.3.26-SNAPSHOT";
+
 		ByteArrayOutputStream baos = new ByteArrayOutputStream();
 		Document document = new Document();
 
@@ -45,7 +47,7 @@ public class CleanMetaDataTest {
 		document.close();
 
 		try (PdfReader r = new PdfReader(baos.toByteArray())) {
-			Assertions.assertNull(r.getInfo().get("Producer"));
+			Assertions.assertEquals(PRODUCER, r.getInfo().get("Producer"));
 		}
 		
 	}


### PR DESCRIPTION
## Description of the new Feature/Bugfix
Changed constructor for PdfDocument so it matches constructor from iText library (needed for exporting JasperPrint to PDF/A document).

Related Issue: #502

## Unit-Tests for the new Feature/Bugfix
- [ ] Unit-Tests added to reproduce the bug
- [ ] Unit-Tests added to the added feature

## Compatibilities Issues

## Testing details
Can be tested with jasper reports library. 

Example code for converting JasperPrint to PDF/A document:

```
	public byte[] exportJasperPrintToPDFADocument(JasperPrint print) throws JRException {
		byte[] bytes = null;

		ByteArrayOutputStream stream = new ByteArrayOutputStream();
		JRPdfExporter exporter = new JRPdfExporter();
		exporter.setExporterInput(new SimpleExporterInput(print));
		exporter.setExporterOutput(new SimpleOutputStreamExporterOutput(
				stream));

		SimplePdfExporterConfiguration spec = new SimplePdfExporterConfiguration();
		spec.setPdfaConformance(PdfaConformanceEnum.PDFA_1A);
		spec.setIccProfilePath("eci.icc");
		spec.setMetadataTitle(print.getName());
		exporter.setConfiguration(spec);
		
		exporter.exportReport();
		return stream.toByteArray();
			
	}
```