### PR TITLE
Replacing signing maven plugin to avoid using external gpg

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
         <maven-checkstyle-plugin.version>3.1.2</maven-checkstyle-plugin.version>
         <maven-clean-plugin.version>3.1.0</maven-clean-plugin.version>
         <maven.compiler.plugin.version>3.8.1</maven.compiler.plugin.version>
-        <maven-gpg-plugin.version>1.6</maven-gpg-plugin.version>
+        <sign-maven-plugin.version>0.3.0</sign-maven-plugin.version>
         <maven-jar-plugin.version>3.2.0</maven-jar-plugin.version>
         <maven-javadoc-plugin.version>3.2.0</maven-javadoc-plugin.version>
         <maven-release-plugin.version>2.5.3</maven-release-plugin.version>
@@ -309,9 +309,9 @@
             </plugin>
             <!-- GPG signing config -->
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-gpg-plugin</artifactId>
-                <version>${maven-gpg-plugin.version}</version>
+                <groupId>org.simplify4u.plugins</groupId>
+                <artifactId>sign-maven-plugin</artifactId>
+                <version>${sign-maven-plugin.version}</version>
                 <executions>
                     <execution>
                         <id>sign-artifacts</id>


### PR DESCRIPTION
## Description of the Bugfix
I had an problem on building the library, because I do not have GPG installed.

Here is the log:
```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-gpg-plugin:1.6:sign (sign-artifacts) on project openpdf-parent: Unable to execute gpg command: Error while executing process. Cannot run program "gpg.exe": CreateProcess error=2, The system cannot find the file specified -> [Help 1]
[ERROR]
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR]
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoExecutionException
```
As suggested here:
https://stackoverflow.com/questions/59281804/maven-unable-to-execute-gpg-command

I just replaced the plugin to 
https://www.simplify4u.org/sign-maven-plugin/key-prepare.html
and everything worked out just well.

Now I can build the library without any errors.

Though I do not know the consequences.

Related Issue: no issue