### PR TITLE
fix issue 500

### DIFF
--- a/openpdf/src/main/java/com/lowagie/text/pdf/PdfCopyFieldsImp.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/PdfCopyFieldsImp.java
@@ -218,8 +218,10 @@ class PdfCopyFieldsImp extends PdfWriter {
                     if (ob != null && ob.isIndirect()) {
                         PRIndirectReference ind = (PRIndirectReference) ob;
                         if (!isVisited(ind) && !isPage(ind)) {
-                            PdfIndirectReference ref = getNewReference(ind);
-                            propagate(PdfReader.getPdfObjectRelease(ind), restricted);
+                            if (((PRIndirectReference) ob).getReader().getPdfObject(ind.getNumber()) != null) {
+                                PdfIndirectReference ref = getNewReference(ind);
+                                propagate(PdfReader.getPdfObjectRelease(ind), restricted);
+                            }
                         }
                     } else {
                         propagate(ob, restricted);


### PR DESCRIPTION
## Description of the new Feature/Bugfix
the issue is caused by that `pdfCopyFields.addDocument(reader, "1");` which deletes noused pdfObject, but page 1 has the link to page 2. So the solution is to check if adding the noused pdfObject to readers2intrefs.

Related Issue: 500#

## Unit-Tests for the new Feature/Bugfix
`@Test
    void nullpointerExceptionTest() {
        //given when
        Assertions.assertDoesNotThrow(this::pdfCopyTest);
    }
    
    private void pdfCopyTest() throws IOException {
        InputStream stream = PdfTestBase.class.getResourceAsStream("openpdf_bug_test.pdf");

        PdfReader reader = new PdfReader(stream);

        byte[] bytes;

        try (ByteArrayOutputStream baos = new ByteArrayOutputStream()) {

            PdfCopyFields pdfCopyFields = new PdfCopyFields(baos);

            pdfCopyFields.addDocument(reader, "1"); // <-- just the table of contents

            pdfCopyFields.close(); // <-- bang

            baos.flush();

            bytes = baos.toByteArray();
        }

        try (OutputStream os = new FileOutputStream(new File("output.pdf"))) {
            os.write(bytes);
        }
    }`
[](url)

## Compatibilities Issues
No anything broken because of the new code, no thing change in method signatures.

## Testing details
you can change the page to "1,2", and you can find the link of page 1 is valid.
[openpdf_bug_test.pdf](https://github.com/LibrePDF/OpenPDF/files/6309741/openpdf_bug_test.pdf)

