### PR TITLE
fix issue 454

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,14 @@
+## Description of the new Feature/Bugfix
+Describe here how you fixed the bug, or implemented the new feature.
+
+Related Issue: #
+
+## Unit-Tests for the new Feature/Bugfix
+- [ ] Unit-Tests added to reproduce the bug
+- [ ] Unit-Tests added to the added feature
+
+## Compatibilities Issues
+Is anything broken because of the new code? Any changes in method signatures?
+
+## Testing details
+Any other details about how to test the new feature or bugfix?

--- a/openpdf/src/main/java/com/lowagie/text/pdf/PdfChunk.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/PdfChunk.java
@@ -210,7 +210,7 @@ public class PdfChunk {
              */
 
             // Check if the chunk content is text
-            if (chunk.getContent().chars().allMatch(c -> (c >= 0x20 && c <= 0xFF))) {
+            if (chunk.getContent().chars().allMatch(c -> ((c >= 0x20 && c <= 0xFF) || c == 0x09))) {
                 // translation of the font-family to a PDF font-family
                 baseFont = f.getCalculatedBaseFont(false);
             } else {

--- a/openpdf/src/test/java/com/lowagie/text/pdf/TabTest.java
+++ b/openpdf/src/test/java/com/lowagie/text/pdf/TabTest.java
@@ -1,0 +1,25 @@
+package com.lowagie.text.pdf;
+
+import com.lowagie.text.Chunk;
+import com.lowagie.text.Document;
+import com.lowagie.text.DocumentException;
+import com.lowagie.text.PageSize;
+
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+
+public class TabTest {
+    public static void main(String[] args) throws FileNotFoundException, DocumentException {
+        Document document = new Document(PageSize.A4.rotate(), 10, 10, 10, 10);
+        Document.compress = false;
+        try {
+            PdfWriter.getInstance(document,
+                    new FileOutputStream("TabsTable.pdf"));
+            document.open();
+            document.add(new Chunk("data\ttable"));
+        } catch (Exception de) {
+            de.printStackTrace();
+        }
+        document.close();
+    }
+}

--- a/openpdf/src/test/java/com/lowagie/text/pdf/TabTest.java
+++ b/openpdf/src/test/java/com/lowagie/text/pdf/TabTest.java
@@ -2,24 +2,32 @@ package com.lowagie.text.pdf;
 
 import com.lowagie.text.Chunk;
 import com.lowagie.text.Document;
-import com.lowagie.text.DocumentException;
 import com.lowagie.text.PageSize;
+import com.lowagie.text.pdf.parser.PdfTextExtractor;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
-import java.io.FileNotFoundException;
-import java.io.FileOutputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 
 public class TabTest {
-    public static void main(String[] args) throws FileNotFoundException, DocumentException {
+    @Test
+    public void TabTest1() throws IOException {
         Document document = new Document(PageSize.A4.rotate(), 10, 10, 10, 10);
         Document.compress = false;
+        ByteArrayOutputStream stream = new ByteArrayOutputStream();
         try {
             PdfWriter.getInstance(document,
-                    new FileOutputStream("TabsTable.pdf"));
+                    stream);
             document.open();
-            document.add(new Chunk("data\ttable"));
+            Chunk a = new Chunk("data\ttable");
+            document.add(a);
         } catch (Exception de) {
             de.printStackTrace();
         }
         document.close();
+        PdfReader rd = new PdfReader(stream.toByteArray());
+        PdfTextExtractor pdfTextExtractor = new PdfTextExtractor(rd);
+        Assertions.assertEquals(pdfTextExtractor.getTextFromPage(1), "data\ttable ");
     }
 }


### PR DESCRIPTION
## Description of the new Feature/Bugfix
This issue is caused by that when we use \t, PdfChunk will change font to font-fallback/LiberationSans-Regular.ttf. But this font can not support \t, when it meet \t in bytesArray it will ignore it and don't encode it. So my solution is that when we use  \t, use default font which actually support \t. 

Related Issue: #454

## Unit-Tests for the new Feature/Bugfix
- [x] Unit-Tests added to reproduce the bug
```
public static void main(String[] args) throws FileNotFoundException, DocumentException {
        Document document = new Document(PageSize.A4.rotate(), 10, 10, 10, 10);
        Document.compress = false;
        try {
            PdfWriter.getInstance(document,
                    new FileOutputStream("TabsTable.pdf"));
            document.open();
            document.add(new Chunk("data\ttable"));
        } catch (Exception de) {
            de.printStackTrace();
        }
        document.close();
    }
```

## Compatibilities Issues
No

## Testing details
No
