### PR TITLE
[Bug-fix] IndexOutOfBoundsException is thrown while getting Metadata of huge files

### DIFF
--- a/openpdf/src/main/java/com/lowagie/text/pdf/PdfReader.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/PdfReader.java
@@ -3212,7 +3212,7 @@ public class PdfReader implements PdfViewerPreferences, Closeable {
           PdfObject v = dic.get(key);
           if (v.isIndirect()) {
             int num = ((PRIndirectReference) v).getNumber();
-            if (num >= xrefObj.size() || (!partial && xrefObj.get(num) == null)) {
+            if (num < 0 || num >= xrefObj.size() || (!partial && xrefObj.get(num) == null)) {
               dic.put(key, PdfNull.PDFNULL);
               continue;
             }


### PR DESCRIPTION
## Description of the issue
When we instanciate a PdfReader `PdfReader reader = new PdfReader(pdfPath.getPath());` on a big PDF/A file ( > 600 Mb) we get  this Exception `Exception in thread "main" java.lang.IndexOutOfBoundsException: Index -1 out of bounds for length 230039`.

This is not the case when we tried the same code with iTextPdf and it worked fine

### Here are the lines of code to reproduce the issue:
`PdfReader reader = new PdfReader(pdfPath.getPath());`
`String xmlMetadata = new String(reader.getMetadata());`

## Description of the new Feature/Bugfix
In order to fixe the issue we added  a check on the object number `num < 0` inside **PdfReader.java** file
The same check is added to the itextpdf source code [click here](https://github.com/itext/itextpdf/blob/02034fd978365b4d1db08c3e671d7d8daecf86bd/itext/src/main/java/com/itextpdf/text/pdf/PdfReader.java#L3526)


