### PR TITLE
Fix #399: KeepTogether in paragraph broken with more than one chunk and different font

### DIFF
--- a/openpdf/src/test/java/com/lowagie/text/pdf/PdfDocumentTest.java
+++ b/openpdf/src/test/java/com/lowagie/text/pdf/PdfDocumentTest.java
@@ -32,7 +32,7 @@ class PdfDocumentTest {
         mainParagraph.add(table);
         mainParagraph.add(paragraph2);
 
-        PdfPTable result = PdfDocument.createInOneCell(mainParagraph.iterator());
+        PdfPTable result = PdfDocument.createInOneCell(mainParagraph);
         return Arrays.asList(
                 DynamicTest.dynamicTest("row size should be 1", () -> assertThat(result.getRows().size(), equalTo(1))),
                 DynamicTest.dynamicTest("cell size should be 1", () -> {

--- a/openpdf/src/test/java/com/lowagie/text/pdf/SingleParagraphTest.java
+++ b/openpdf/src/test/java/com/lowagie/text/pdf/SingleParagraphTest.java
@@ -1,0 +1,44 @@
+package com.lowagie.text.pdf;
+
+import com.lowagie.text.Chunk;
+import com.lowagie.text.Document;
+import com.lowagie.text.FontFactory;
+import com.lowagie.text.Paragraph;
+import com.lowagie.text.pdf.parser.PdfTextExtractor;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import javax.print.Doc;
+import java.io.ByteArrayOutputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+
+public class SingleParagraphTest {
+
+    @Test
+    void testSingleParagraph() throws IOException {
+        Document document = new Document();
+        ByteArrayOutputStream stream = new ByteArrayOutputStream();
+        PdfWriter.getInstance(document, stream);
+        document.open();
+
+        Chunk chunk1 = new Chunk("Hier ", FontFactory.getFont(BaseFont.COURIER, 10));
+        Chunk chunk2 = new Chunk("fetter", FontFactory.getFont(BaseFont.COURIER_BOLD, 10));
+        Chunk chunk3 = new Chunk(" Text", FontFactory.getFont(BaseFont.COURIER, 10));
+
+        Paragraph paragraph = new Paragraph();
+        paragraph.add(chunk1);
+        paragraph.add(chunk2);
+        paragraph.add(chunk3);
+        paragraph.setKeepTogether(true);
+
+        document.add(paragraph);
+        document.close();
+
+        PdfReader reader = new PdfReader(stream.toByteArray());
+        PdfTextExtractor pdfTextExtractor = new PdfTextExtractor(reader);
+        String text = pdfTextExtractor.getTextFromPage(1);
+        Assertions.assertEquals(text, "Hier fetter Text");
+    }
+
+}


### PR DESCRIPTION
## Description of the new Feature/Bugfix
Chunks with different fonts in a paragraph are written into different lines.

Related Issue: #399

## Unit-Tests for the new Feature/Bugfix
- [x] Unit-Tests added to reproduce the bug
- [ ] Unit-Tests added to the added feature

## Compatibilities Issues
**Anything broken**: After the fix, when a paragraph is added to a `Document` object, the continuous chunks in the paragraph are put together in a single subparagraph. The gap between chunks and other type of elements in a paragraph are slightly narrower. This difference can be produced by the codes in https://github.com/LibrePDF/OpenPDF/issues/271.

**Changes in method signatures**: The method signature `static PdfTable createInOneCell(Iterator<Element> elements) ` in the class `PdfDocument` is changed to `static PdfTable createInOnecell(Paragraph paragraph)`.

## Testing details
The fix can be tested by adding multiple chunks with different fonts to a single paragraph. See the added test `SingleParagraphTest`.