### PR TITLE
fix: PdfPTable missing line using setSplitLate

### DIFF
--- a/openpdf/src/main/java/com/lowagie/text/pdf/PdfPRow.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/PdfPRow.java
@@ -624,9 +624,22 @@ public class PdfPRow {
                 float y;
                 ColumnText ct = ColumnText.duplicate(cell.getColumn());
                 float left = cell.getLeft() + cell.getEffectivePaddingLeft();
+                float right = cell.getRight() - cell.getEffectivePaddingRight();
+                /*
+                    ────────────┬───────────────────────────────┐cell.getTop()
+                          ▲     │      effectivePaddingTop      │
+                          │     │                               │
+                          │     │      ┌─────────────────┬──────►float top
+                     newHeight  │      │                 │      │
+                          │     │      │       CELL      │      │
+                          │     │      │                 │      │
+                          │     │      └─────────────────┴──────►float bottom
+                          │     │                               │
+                          ▼     │      effectivePaddingBottom   │
+                    ────────────┴───────────────────────────────┘
+                 */
                 float top = cell.getTop() - cell.getEffectivePaddingTop();
                 float bottom = cell.getTop() - newHeight + cell.getEffectivePaddingBottom();
-                float right = cell.getRight() - cell.getEffectivePaddingRight();
                 switch (cell.getRotation()) {
                     case 90:
                     case 270:

--- a/openpdf/src/main/java/com/lowagie/text/pdf/PdfPRow.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/PdfPRow.java
@@ -625,7 +625,7 @@ public class PdfPRow {
                 ColumnText ct = ColumnText.duplicate(cell.getColumn());
                 float left = cell.getLeft() + cell.getEffectivePaddingLeft();
                 float top = cell.getTop() - cell.getEffectivePaddingTop();
-                float bottom = top + cell.getEffectivePaddingBottom() - newHeight;
+                float bottom = cell.getTop() - newHeight + cell.getEffectivePaddingBottom();
                 float right = cell.getRight() - cell.getEffectivePaddingRight();
                 switch (cell.getRotation()) {
                     case 90:

--- a/openpdf/src/test/java/com/lowagie/text/PdfPTableTest.java
+++ b/openpdf/src/test/java/com/lowagie/text/PdfPTableTest.java
@@ -1,0 +1,37 @@
+package com.lowagie.text;
+
+import com.lowagie.text.pdf.PdfPTable;
+import com.lowagie.text.pdf.PdfWriter;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.util.stream.IntStream;
+
+public class PdfPTableTest {
+    @Test
+    void writePDF() throws FileNotFoundException {
+        File file = new File("output.pdf");
+        Document document = new Document(PageSize.A4);
+        PdfWriter.getInstance(document, new FileOutputStream(file));
+
+        document.open();
+        IntStream.range(0, 30)
+                .mapToObj(idx -> new Paragraph("Fill line"))
+                .forEach(document::add);
+
+        PdfPTable table = new PdfPTable(1);
+        table.setSplitLate(false);
+
+        IntStream.range(0, 3)
+                .mapToObj(idx -> new Paragraph("Row " + idx + " Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi eu cursus purus, id efficitur arcu. " +
+                        "Pellentesque eu arcu elit. Phasellus in mattis diam. Donec in augue eget ligula consectetur pretium. Maecenas scelerisque non massa ut faucibus. " +
+                        "Nam sit amet malesuada nisl. Duis varius vitae leo venenatis ullamcorper. Morbi at vestibulum tortor, vel blandit erat."))
+                .forEach(table::addCell);
+
+        table.addCell("Line 1\nLine 2\nThis line should be in the PDF\nLine 4");
+        document.add(table);
+        document.close();
+    }
+}


### PR DESCRIPTION
Due to the fix for issue #258 on pull request #260, these lines of code in `com.lowagie.text.pdf.PdfRow::splitRow` have been changed from

```java
float bottom = cell.getTop() + cell.getEffectivePaddingBottom() - newHeight;
float top = cell.getTop() - cell.getEffectivePaddingTop();
```

to

```java
float top = cell.getTop() - cell.getEffectivePaddingTop();
float bottom = top + cell.getEffectivePaddingBottom() - newHeight;
```

However, the change is actually wrong, which introduced a bug found in issue #345.

I draw a figure to show the calculation process. To calculate the correct value of `bottom`, the original lines of code is correct.

![](https://ftp.bmp.ovh/imgs/2021/04/5d630c4661761045.png)


To test the code, please use the code mentioned in issue #345.
