### PR TITLE
Fix: An improper assertion of TabTest

### DIFF
--- a/openpdf/src/test/java/com/lowagie/text/pdf/TabTest.java
+++ b/openpdf/src/test/java/com/lowagie/text/pdf/TabTest.java
@@ -28,6 +28,6 @@ public class TabTest {
         document.close();
         PdfReader rd = new PdfReader(stream.toByteArray());
         PdfTextExtractor pdfTextExtractor = new PdfTextExtractor(rd);
-        Assertions.assertEquals(pdfTextExtractor.getTextFromPage(1), "data\ttable ");
+        Assertions.assertEquals(pdfTextExtractor.getTextFromPage(1), "data\ttable");
     }
 }


### PR DESCRIPTION
## Description of the new Feature/Bugfix

Issue:

The unit test `TabTest`, which is introduced recently by this commit dfeb112df39733d0103f513c0d94c12a80664eef, failed when running 'All Tests' for `openpdf` module after importing the project from GitHub using the latest IntelliJ IDEA.

Environment:

- OS: macOS 11.2.3
- IDE: IntelliJ IDEA 2021.1
- JDK:
  - Oracle JDK 11.0.11
  - AdoptOpenJDK (Hotspot) 11.0.11 / 16.0.1

The extra space in `actual` string, which is what this test expects to see, may not exist. After removing it, this test succeeds to pass.
