### PR TITLE
Support Text Extract for symbol font and ZapfDingbats font

### DIFF
--- a/openpdf/src/main/java/com/lowagie/text/pdf/DocumentFont.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/DocumentFont.java
@@ -286,7 +286,11 @@ public class DocumentFont extends BaseFont {
   private void doType1TT() {
     PdfObject enc = PdfReader.getPdfObject(font.get(PdfName.ENCODING));
     if (enc == null) {
-      fillEncoding(null);
+      PdfName baseFont = this.font.getAsName(PdfName.BASEFONT);
+      if(PdfName.SYMBOL.equals(baseFont)||PdfName.ZAPFDINGBATS.equals(baseFont))
+        fillEncoding(baseFont);
+      else
+        fillEncoding(null);
     } else {
       if (enc.isName()) {
         fillEncoding((PdfName) enc);
@@ -400,7 +404,8 @@ public class DocumentFont extends BaseFont {
   }
 
   private void fillEncoding(PdfName encoding) {
-    if (PdfName.MAC_ROMAN_ENCODING.equals(encoding) || PdfName.WIN_ANSI_ENCODING.equals(encoding)) {
+    if (PdfName.MAC_ROMAN_ENCODING.equals(encoding) || PdfName.WIN_ANSI_ENCODING.equals(encoding)
+            ||PdfName.SYMBOL.equals(encoding)||PdfName.ZAPFDINGBATS.equals(encoding)) {
       byte[] b = new byte[256];
       for (int k = 0; k < 256; ++k) {
         b[k] = (byte) k;
@@ -408,6 +413,10 @@ public class DocumentFont extends BaseFont {
       String enc = WINANSI;
       if (PdfName.MAC_ROMAN_ENCODING.equals(encoding)) {
         enc = MACROMAN;
+      }else if (PdfName.SYMBOL.equals(encoding)){
+        enc = SYMBOL;
+      }else if (PdfName.ZAPFDINGBATS.equals(encoding)){
+        enc = ZAPFDINGBATS;
       }
       String cv = PdfEncodings.convertToString(b, enc);
       char[] arr = cv.toCharArray();

--- a/openpdf/src/main/java/com/lowagie/text/pdf/PdfEncodings.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/PdfEncodings.java
@@ -764,12 +764,15 @@ public class PdfEncodings {
         private static final IntHashtable t1 = new IntHashtable();
         private static final IntHashtable t2 = new IntHashtable();
         private IntHashtable translation;
+        private char[] revTranslation;
 
         SymbolConversion(boolean symbol) {
             if (symbol) {
                 translation = t1;
+                revTranslation = table1;
             } else {
                 translation = t2;
+                revTranslation = table2;
             }
         }
 
@@ -805,7 +808,16 @@ public class PdfEncodings {
 
         @Override
         public String byteToChar(byte[] b, String encoding) {
-            return null;
+            int len = b.length;
+            char[] chars = new char[len];
+            for(int i = 0; i < len; i++) {
+                int pos = b[i]&0xff;
+                if(pos < 32)
+                    chars[i] = 0;
+                else
+                    chars[i] = revTranslation[pos - 32];
+            }
+            return new String(chars);
         }
 
         private final static char[] table1 = {' ', '!', '\u2200', '#',

--- a/openpdf/src/test/java/com/lowagie/text/pdf/parser/PdfTextExtractorTest.java
+++ b/openpdf/src/test/java/com/lowagie/text/pdf/parser/PdfTextExtractorTest.java
@@ -49,6 +49,21 @@ class PdfTextExtractorTest {
     }
 
     @Test
+    void testZapfDingbatsFont() throws Exception {
+        Document document = new Document();
+        Document.compress = false;
+        ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+        PdfWriter.getInstance(document, byteArrayOutputStream);
+        document.open();
+
+        //There has some problem to write Greek with Font.ZAPFDINGBATS, but show in html it is "✧❒❅❅❋"
+        document.add(new Chunk("Greek", new Font(Font.ZAPFDINGBATS)));
+        document.close();
+        PdfTextExtractor pdfTextExtractor = new PdfTextExtractor(new PdfReader(byteArrayOutputStream.toByteArray()));
+        Assertions.assertEquals("✧❒❅❅❋", pdfTextExtractor.getTextFromPage(1));
+    }
+
+    @Test
     void testSymbolFont() throws Exception {
         Document document = new Document();
         Document.compress = false;

--- a/openpdf/src/test/java/com/lowagie/text/pdf/parser/PdfTextExtractorTest.java
+++ b/openpdf/src/test/java/com/lowagie/text/pdf/parser/PdfTextExtractorTest.java
@@ -15,8 +15,11 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
+import com.lowagie.text.pdf.FontSelector;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import com.lowagie.text.Font;
 import com.lowagie.text.Chunk;
 import com.lowagie.text.Document;
 import com.lowagie.text.Element;
@@ -43,6 +46,22 @@ class PdfTextExtractorTest {
     @Test
     void testInvalidPageNumber() throws Exception {
         assertThat(getString("HelloWorldMeta.pdf", 0), is(emptyString()));
+    }
+
+    @Test
+    void testSymbolFont() throws Exception {
+        Document document = new Document();
+        Document.compress = false;
+        ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+        PdfWriter.getInstance(document, byteArrayOutputStream);
+        document.open();
+
+        FontSelector selector = new FontSelector();
+        selector.addFont(new Font(Font.SYMBOL));
+        document.add(selector.process("ετε"));
+        document.close();
+        PdfTextExtractor pdfTextExtractor = new PdfTextExtractor(new PdfReader(byteArrayOutputStream.toByteArray()));
+        Assertions.assertEquals("ετε", pdfTextExtractor.getTextFromPage(1));
     }
 
     @Test


### PR DESCRIPTION
## Description of the new Feature/Bugfix
Support text extractor for symbol font and ZapfDingbats font. The idea to realize it is that OpenPDF have a class `SymbolConversion` to support encoding conversion of  symbol font and ZapfDingbats font. 
So when we meet some strings with symbol font and ZapfDingbats font, we can use `CMapAwareDocumentFont.uni2byte` to decode the strings. Then I find the method byteToChar is not realized which is important to get uni2byte. I realize it by inversing the method charToByte.

Related Issue: #

## Unit-Tests for the new Feature/Bugfix
- [ ] Unit-Tests added to reproduce the bug
- [x] Unit-Tests added to the added feature
https://github.com/LibrePDF/OpenPDF/blob/e128dfe0103c16af3adea5b2255eebb1eac4d94d/openpdf/src/test/java/com/lowagie/text/pdf/parser/PdfTextExtractorTest.java#L51-L65

## Compatibilities Issues
No

## Testing details
It has some problems to write  ZapfDingbats font by OpenPDF, I will add Unit Test for ZapfDingbats font later.
