### PR TITLE
Bug fix 529: error /toUnicode

### DIFF
--- a/openpdf/src/main/java/com/lowagie/text/pdf/FopGlyphProcessor.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/FopGlyphProcessor.java
@@ -68,7 +68,7 @@ public class FopGlyphProcessor {
             Integer glyphCode = processedChars[i];
             if (!longTag.containsKey(glyphCode)) {
                 longTag.put(glyphCode,
-                        new int[] { processedChars[i], ttu.getGlyphWidth(processedChars[i]), processedChars[i] });
+                        new int[] { processedChars[i], ttu.getGlyphWidth(processedChars[i]), charBuffer.get(i) });
             }
         }
         return new String(charEncodedGlyphCodes).getBytes(CJKFont.CJK_ENCODING);


### PR DESCRIPTION
## Description of the new Feature/Bugfix
OpenPDF should mapping the processedChar to origin char.

**The /Tounicode after changing**
![image](https://user-images.githubusercontent.com/60342704/116028260-5a42f500-a689-11eb-9478-0e0f737ee8e5.png)

**The copy value of "ετε" in html**
![image](https://user-images.githubusercontent.com/60342704/116028367-924a3800-a689-11eb-80af-10e8a7f374fc.png)

Related Issue: #529 

## Unit-Tests for the new Feature/Bugfix
- [x] Unit-Tests added to reproduce the bug
- [ ] Unit-Tests added to the added feature
```java
void testToUnicode() throws Exception {
        Document document = new Document();
        Document.compress = false;
        FileOutputStream outputStream = new FileOutputStream("output.pdf");
        PdfWriter.getInstance(document, outputStream);
        document.open();

        document.add(new Chunk("ετε", new Font(Font.SYMBOL)));
        document.close();
        PdfTextExtractor pdfTextExtractor = new PdfTextExtractor(new PdfReader("output.pdf"));
        Assertions.assertEquals("ετε", pdfTextExtractor.getTextFromPage(1));
    }
```
other Test:
It can pass the failed test of pull request #521 after providing true UnicodeMap
https://github.com/LibrePDF/OpenPDF/blob/23fba37597a48c4d3d3486bed8f2c31132239182/openpdf/src/test/java/com/lowagie/text/pdf/parser/PdfTextExtractorTest.java#L85-L101
## Compatibilities Issues
No

## Testing details
No

