### PR TITLE
Bug Fix 512: Fix wrong OSGI header for javax.annotation package

### DIFF
--- a/openpdf/pom.xml
+++ b/openpdf/pom.xml
@@ -89,7 +89,7 @@
                         <!-- All com.lowagie.text.* packages are 'public' -->
                         <Export-Package>com.lowagie.text.*;version="${project.version}"</Export-Package>
                         <!-- Declare the Bouncycastle dependencies as optional -->
-                        <Import-Package>org.bouncycastle.*;resolution:=optional,!com.lowagie.*,*</Import-Package>
+                        <Import-Package>org.bouncycastle.*;resolution:=optional,!com.lowagie.*,javax.annotation.*;version="[1,4)",*</Import-Package>
                     </instructions>
                 </configuration>
             </plugin>


### PR DESCRIPTION
Related Issue: #512
