### PR TITLE
Bug fix: 536

### DIFF
--- a/openpdf/src/main/java/com/lowagie/text/pdf/PdfDocument.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/PdfDocument.java
@@ -2532,14 +2532,13 @@ public class PdfDocument extends Document {
         }
         // add dummy paragraph if we aren't at the top of a page, so that
         // spacingBefore will be taken into account by ColumnText
-        if (currentHeight > 0) {
+        if (currentHeight > 0 || ptable.isSkipFirstHeader()) {
             Paragraph p = new Paragraph();
             p.setLeading(0);
             ct.addElement(p);
         }
         ct.addElement(ptable);
         boolean he = ptable.isHeadersInEvent();
-        ptable.setHeadersInEvent(true);
         int loop = 0;
         while (true) {
             ct.setSimpleColumn(indentLeft(), indentBottom(), indentRight(), indentTop() - currentHeight);

--- a/openpdf/src/main/java/com/lowagie/text/pdf/PdfDocument.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/PdfDocument.java
@@ -2539,6 +2539,7 @@ public class PdfDocument extends Document {
         }
         ct.addElement(ptable);
         boolean he = ptable.isHeadersInEvent();
+        ptable.setHeadersInEvent(true);
         int loop = 0;
         while (true) {
             ct.setSimpleColumn(indentLeft(), indentBottom(), indentRight(), indentTop() - currentHeight);


### PR DESCRIPTION
## Description of the new Feature/Bugfix
if table skip the first head, it also should add a dummy paragraph to let `firstPass` in ct.go be false.
issue position:
`adjustFirstLine` usually is true
https://github.com/LibrePDF/OpenPDF/blob/515fb2e648fcd11fbf5ece6cd8c37eabeb763c95/openpdf/src/main/java/com/lowagie/text/pdf/ColumnText.java#L1156
in origin version, the `firstPass` is true in this position, but if we add a Paragraph will let it be false.
https://github.com/LibrePDF/OpenPDF/blob/515fb2e648fcd11fbf5ece6cd8c37eabeb763c95/openpdf/src/main/java/com/lowagie/text/pdf/ColumnText.java#L1374

Related Issue: #536 

## Unit-Tests for the new Feature/Bugfix
- [x] Unit-Tests added to reproduce the bug
```java
    @Test
    public void TabTest2() throws IOException {
        Document document = new Document(PageSize.A4.rotate(), 10, 10, 10, 10);
        Document.compress = false;
        FileOutputStream stream = new FileOutputStream("test.pdf");
        PdfWriter.getInstance(document, stream);
        document.open();

        PdfPCell cell;
        PdfPTable mainTable = new PdfPTable(1);
        mainTable.setWidthPercentage(100);

        cell = new PdfPCell(new Phrase("HEADER 1"));
        cell.setBorder(Rectangle.BOX);
        mainTable.addCell(cell);

        cell = new PdfPCell(new Phrase("HEADER 2"));
        cell.setBorder(Rectangle.BOX);
        mainTable.addCell(cell);

        cell = new PdfPCell(new Phrase("HEADER 3"));
        cell.setBorder(Rectangle.BOX);
        mainTable.addCell(cell);

        for (int i = 0; i < 100; i++) {
            cell = new PdfPCell(new Phrase("ROW "+i));
            cell.setBorder(Rectangle.BOX);
            mainTable.addCell(cell);
        }

        mainTable.setHeaderRows(3);
        mainTable.setSkipFirstHeader(true);
        mainTable.setSplitLate(false);
        document.add(mainTable);
        document.close();
    }
```
## Compatibilities Issues
No

## Testing details
Screen:
![image](https://user-images.githubusercontent.com/60342704/117896157-8057ce80-b2f2-11eb-83e6-b3197ae6ba98.png)
