### PR TITLE
fix issue: 534

### DIFF
--- a/openpdf/src/main/java/com/lowagie/text/pdf/LayoutProcessor.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/LayoutProcessor.java
@@ -100,6 +100,10 @@ public class LayoutProcessor {
         return enabled;
     }
 
+    public static int getFlags() {
+        return flags;
+    }
+
     public static boolean supportsFont(BaseFont baseFont) {
         boolean supports = enabled && (awtFontMap.get(baseFont) != null);
         return supports;

--- a/openpdf/src/main/java/com/lowagie/text/pdf/PdfDocument.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/PdfDocument.java
@@ -1700,7 +1700,10 @@ public class PdfDocument extends Document {
                     text.showText(s);
                 else {
                     float spaceCorrection = - baseWordSpacing * 1000f / chunk.font.size() / hScale;
-                    PdfTextArray textArray = new PdfTextArray(s.substring(0, idx));
+                    PdfTextArray textArray = new PdfTextArray();
+                    if (LayoutProcessor.isEnabled()&&LayoutProcessor.getFlags() == java.awt.Font.LAYOUT_RIGHT_TO_LEFT)
+                        textArray.setRTL(true);
+                    textArray.add(s.substring(0, idx));
                     int lastIdx = idx;
                     while ((idx = s.indexOf(' ', lastIdx + 1)) >= 0) {
                         textArray.add(spaceCorrection);

--- a/openpdf/src/main/java/com/lowagie/text/pdf/PdfTextArray.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/PdfTextArray.java
@@ -49,7 +49,7 @@
 
 package com.lowagie.text.pdf;
 
-import java.util.ArrayList;
+import java.util.LinkedList;
 import java.util.List;
 
 /**
@@ -63,7 +63,7 @@ import java.util.List;
  */
 
 public class PdfTextArray{
-    private List<Object> arrayList = new ArrayList<>();
+    private List<Object> arrayList = new LinkedList<>();
     
     // To emit a more efficient array, we consolidate
     // repeated numbers or strings into single array entries.
@@ -72,6 +72,7 @@ public class PdfTextArray{
     // --Mark Storer, May 12, 2008
     private String lastStr;
     private Float lastNum;
+    private boolean isRTL = false;
     
     // constructors
     public PdfTextArray(String str) {
@@ -97,11 +98,14 @@ public class PdfTextArray{
                 if (lastNum != 0) {
                     replaceLast(lastNum);
                 } else {
-                    arrayList.remove(arrayList.size() - 1);
+                    arrayList.remove(isRTL ? 0 : arrayList.size() - 1);
                 }
             } else {
                 lastNum = number;
-                arrayList.add(lastNum);
+                if (isRTL)
+                    arrayList.add(0, lastNum);
+                else
+                    arrayList.add(lastNum);
             }
             
             lastStr = null;
@@ -110,13 +114,22 @@ public class PdfTextArray{
     }
     
     public void add(String str) {
+        if (isRTL)
+            str = new StringBuffer(str).reverse().toString();
         if (str.length() > 0) {
             if (lastStr != null) {
-                lastStr = lastStr + str;
+                if (isRTL)
+                    lastStr = str + lastStr;
+                else
+                    lastStr = lastStr + str;
                 replaceLast(lastStr);
             } else {
                 lastStr = str;
-                arrayList.add(lastStr);
+                if (isRTL) {
+                    arrayList.add(0, lastStr);
+                }else {
+                    arrayList.add(lastStr);
+                }
             }
             lastNum = null;
         }
@@ -129,6 +142,17 @@ public class PdfTextArray{
     
     private void replaceLast(Object obj) {
         // deliberately throw the IndexOutOfBoundsException if we screw up.
-        arrayList.set(arrayList.size() - 1, obj);
+        if (isRTL)
+            arrayList.set(0, obj);
+        else
+            arrayList.set(arrayList.size() - 1, obj);
+    }
+
+    public void setRTL(boolean isRTL){
+        this.isRTL = isRTL;
+    }
+
+    public boolean getRTL(){
+        return this.isRTL;
     }
 }


### PR DESCRIPTION
## Description of the new Feature/Bugfix
the issue happen when we use `ALIGN_JUSTIFIED`, it will call `showText(TextArray)`. `TextArray` don't support RTL. so my method is to let `TextArray` support RTL.

related code:
https://github.com/LibrePDF/OpenPDF/blob/515fb2e648fcd11fbf5ece6cd8c37eabeb763c95/openpdf/src/main/java/com/lowagie/text/pdf/PdfDocument.java#L1703-L1712

Related Issue: #534 

## Unit-Tests for the new Feature/Bugfix
- [x] Unit-Tests added to reproduce the bug
```java
public void TabTest1() throws IOException {
        Document document = new Document(PageSize.A4.rotate(), 10, 10, 10, 10);
        Document.compress = false;
        FileOutputStream stream = new FileOutputStream("test.pdf");
        PdfWriter.getInstance(document, stream);
        document.open();
        LayoutProcessor.enable(java.awt.Font.LAYOUT_RIGHT_TO_LEFT);
        String text = "56789 4985410 85641 865ε43198 65419865 4986543 865431 8653421 986541 9864531" +
                " 9864531 687453 7896123 864531 897645312 8654312 86453 8465 846532 8976453 798645 " +
                "89645 78465 798465 864 5398 465";
        text = text + text;
        Paragraph p1= new Paragraph(new Chunk(text));
        p1.setAlignment(Element.ALIGN_JUSTIFIED);
        document.add(p1);
        document.close();
    }
```

## Compatibilities Issues
add isRTL in TextArray to support RTL.

## Testing details
screen:
![image](https://user-images.githubusercontent.com/60342704/118119042-543a6b80-b420-11eb-82a7-e514ad0a07a5.png)
