### PR TITLE
Resolve #513: For attachments if file name is not PdfDocEncoding then…

### DIFF
--- a/openpdf/src/main/java/com/lowagie/text/pdf/PdfFileSpecification.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/PdfFileSpecification.java
@@ -171,7 +171,7 @@ public class PdfFileSpecification extends PdfDictionary {
         PdfFileSpecification fs = new PdfFileSpecification();
         fs.writer = writer;
         fs.put(PdfName.F, new PdfString(fileDisplay));
-        fs.setUnicodeFileName(fileDisplay, false);
+        fs.setUnicodeFileName(fileDisplay, !PdfEncodings.isPdfDocEncoding(fileDisplay));
         PdfEFStream stream;
         InputStream in = null;
         PdfIndirectReference ref;
@@ -243,7 +243,7 @@ public class PdfFileSpecification extends PdfDictionary {
         PdfFileSpecification fs = new PdfFileSpecification();
         fs.writer = writer;
         fs.put(PdfName.F, new PdfString(filePath));
-        fs.setUnicodeFileName(filePath, false);
+        fs.setUnicodeFileName(filePath, !PdfEncodings.isPdfDocEncoding(filePath));
         return fs;
     }
     


### PR DESCRIPTION
… sets unicode file name True.

## Description of the new Feature/Bugfix
If the file name contains non-ASCII character (or at least non-Latin symbols) the file name won't be shown.
This solution resolves this problem.

Related Issue: #513 