### PR TITLE
fix and improve 526

### DIFF
--- a/openpdf/src/main/java/com/lowagie/text/pdf/FontSelector.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/FontSelector.java
@@ -71,10 +71,18 @@ public class FontSelector {
         fonts.add(font);
     }
 
+    /**
+     * change the color of default font in <CODE>FontSelector</CODE>.
+     * @param color the <CODE>Color</CODE> of default font
+     */
     public void setDefaultColor(Color color){
         fonts.get(fonts.size()-1).setColor(color);
     }
 
+    /**
+     * change the size of default font in <CODE>FontSelector</CODE>.
+     * @param size the size of default font
+     */
     public void setDefaultSize(float size){
         fonts.get(fonts.size()-1).setSize(size);
     }

--- a/openpdf/src/main/java/com/lowagie/text/pdf/FontSelector.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/FontSelector.java
@@ -46,11 +46,14 @@
  */
 package com.lowagie.text.pdf;
 
-import java.awt.*;
+import java.awt.Color;
 import java.util.ArrayList;
 
-import com.lowagie.text.*;
 import com.lowagie.text.Font;
+import com.lowagie.text.FontFactory;
+import com.lowagie.text.Phrase;
+import com.lowagie.text.Chunk;
+import com.lowagie.text.Utilities;
 import com.lowagie.text.error_messages.MessageLocalization;
 
 /** Selects the appropriate fonts that contain the glyphs needed to

--- a/openpdf/src/main/java/com/lowagie/text/pdf/FontSelector.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/FontSelector.java
@@ -46,14 +46,12 @@
  */
 package com.lowagie.text.pdf;
 
+import java.awt.*;
 import java.util.ArrayList;
 
-import com.lowagie.text.error_messages.MessageLocalization;
-
-import com.lowagie.text.Chunk;
+import com.lowagie.text.*;
 import com.lowagie.text.Font;
-import com.lowagie.text.Phrase;
-import com.lowagie.text.Utilities;
+import com.lowagie.text.error_messages.MessageLocalization;
 
 /** Selects the appropriate fonts that contain the glyphs needed to
  * render text correctly. The fonts are checked in order until the 
@@ -67,18 +65,32 @@ public class FontSelector {
 
     protected ArrayList<Font> fonts = new ArrayList<>();
 
+    public FontSelector(){
+        FontFactory.register("font-fallback/LiberationSans-Regular.ttf", "sans");
+        Font font= FontFactory.getFont("sans", BaseFont.IDENTITY_H);
+        fonts.add(font);
+    }
+
+    public void setDefaultColor(Color color){
+        fonts.get(fonts.size()-1).setColor(color);
+    }
+
+    public void setDefaultSize(float size){
+        fonts.get(fonts.size()-1).setSize(size);
+    }
+
     /**
      * Adds a <CODE>Font</CODE> to be searched for valid characters.
      * @param font the <CODE>Font</CODE>
      */
     public void addFont(Font font) {
         if (font.getBaseFont() != null) {
-            fonts.add(font);
+            fonts.add(fonts.size()-1, font);
             return;
         }
         BaseFont bf = font.getCalculatedBaseFont(true);
         Font f2 = new Font(bf, font.getSize(), font.getCalculatedStyle(), font.getColor());
-        fonts.add(f2);
+        fonts.add(fonts.size()-1, f2);
     }
 
     /**
@@ -105,7 +117,6 @@ public class FontSelector {
             }
             if (Utilities.isSurrogatePair(cc, k)) {
                 int u = Utilities.convertToUtf32(cc, k);
-                boolean hasValidFontInList = false;
                 for (int f = 0; f < fsize; ++f) {
                     font = fonts.get(f);
                     if (font.getBaseFont().charExists(u)) {
@@ -121,24 +132,10 @@ public class FontSelector {
                         if (cc.length > k + 1) {
                             sb.append(cc[++k]);
                         }
-                        hasValidFontInList = true;
                         break;
                     }
                 }
-                if (!hasValidFontInList) {
-                    if (sb.length() > 0 && lastidx != -1) {
-                        Chunk ck = new Chunk(sb.toString());
-                        ret.add(ck);
-                        sb.setLength(0);
-                        lastidx = -1;
-                    }
-                    sb.append(c);
-                    if (cc.length > k + 1) {
-                        sb.append(cc[++k]);
-                    }
-                }
             } else {
-                boolean hasValidFontInList = false;
                 for (int f = 0; f < fsize; ++f) {
                     font = fonts.get(f);
                     if (font.getBaseFont().charExists(c)) {
@@ -151,18 +148,8 @@ public class FontSelector {
                             lastidx = f;
                         }
                         sb.append(c);
-                        hasValidFontInList = true;
                         break;
                     }
-                }
-                if (!hasValidFontInList) {
-                    if (sb.length() > 0 && lastidx != -1) {
-                        Chunk ck = new Chunk(sb.toString());
-                        ret.add(ck);
-                        sb.setLength(0);
-                        lastidx = -1;
-                    }
-                    sb.append(c);
                 }
             }
         }

--- a/openpdf/src/test/java/com/lowagie/text/pdf/FontSelectorTest.java
+++ b/openpdf/src/test/java/com/lowagie/text/pdf/FontSelectorTest.java
@@ -13,7 +13,7 @@ import java.io.IOException;
 
 public class FontSelectorTest {
     @Test
-    public void TestDefaultFont() throws IOException {
+    public void testDefaultFont() throws IOException {
         Document document = new Document(PageSize.A4.rotate(), 10, 10, 10, 10);
         ByteArrayOutputStream stream = new ByteArrayOutputStream();
         PdfWriter.getInstance(document, stream);

--- a/openpdf/src/test/java/com/lowagie/text/pdf/FontSelectorTest.java
+++ b/openpdf/src/test/java/com/lowagie/text/pdf/FontSelectorTest.java
@@ -1,0 +1,31 @@
+package com.lowagie.text.pdf;
+
+import com.lowagie.text.Chunk;
+import com.lowagie.text.Document;
+import com.lowagie.text.Font;
+import com.lowagie.text.PageSize;
+import com.lowagie.text.pdf.parser.PdfTextExtractor;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+
+public class FontSelectorTest {
+    @Test
+    public void TestDefaultFont() throws IOException {
+        Document document = new Document(PageSize.A4.rotate(), 10, 10, 10, 10);
+        ByteArrayOutputStream stream = new ByteArrayOutputStream();
+        PdfWriter.getInstance(document, stream);
+        document.open();
+
+        FontSelector selector = new FontSelector();
+        selector.addFont(new Font(Font.HELVETICA));
+        document.add(selector.process("ΧαίρετεGreek -"));
+        document.close();
+
+        PdfReader rd = new PdfReader(stream.toByteArray());
+        PdfTextExtractor pdfTextExtractor = new PdfTextExtractor(rd);
+        Assertions.assertEquals(pdfTextExtractor.getTextFromPage(1), "ΧαίρετεGreek -");
+    }
+}


### PR DESCRIPTION
## Description of the new Feature/Bugfix
the method used by 526 is to used default chunk, but it can not cosider the condition that invalid character appear at the head of sentence. so I change the pull request, we can know default chunk will use  `font-fallback/LiberationSans-Regular.ttf`, so I remove the redundant code of #526 and add this font to the list, and support user to modify its color and size

Related Issue: #526

## Unit-Tests for the new Feature/Bugfix
- [x] Unit-Tests added to reproduce the bug

## Compatibilities Issues
add new method setDefaultSize and setDefaultColor

## Testing details
no
