### PR TITLE
feat: keeptogether on a ListItem

### DIFF
--- a/openpdf/src/main/java/com/lowagie/text/pdf/PdfDocument.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/PdfDocument.java
@@ -651,22 +651,36 @@ public class PdfDocument extends Document {
                     leading = listItem.getTotalLeading();
                     carriageReturn();
 
-                    // we prepare the current line to be able to show us the listsymbol
-                    line.setListItem(listItem);
-                    // we process the item
-                    element.process(this);
+                    // if a listitem has to be kept together, we wrap it in a table object
+                    if (listItem.getKeepTogether()) {
+                        carriageReturn();
+                        PdfPTable table = createInOneCell(listItem);
+                        indentation.indentLeft += listItem.getIndentationLeft();
+                        indentation.indentRight += listItem.getIndentationRight();
 
-                    addSpacing(listItem.getSpacingAfter(), listItem.getTotalLeading(), listItem.getFont());
+                        this.add(table);
 
-                    // if the last line is justified, it should be aligned to the left
-                    if (line.hasToBeJustified()) {
-                        line.resetAlignment();
+                        indentation.indentLeft += listItem.getIndentationLeft();
+                        indentation.indentRight += listItem.getIndentationRight();
                     }
-                    // some parameters are set back to normal again
-                    carriageReturn();
-                    indentation.listIndentLeft -= listItem.getIndentationLeft();
-                    indentation.indentRight -= listItem.getIndentationRight();
-                    leadingCount--;
+                    else {
+                        // we prepare the current line to be able to show us the listsymbol
+                        line.setListItem(listItem);
+                        // we process the item
+                        element.process(this);
+
+                        addSpacing(listItem.getSpacingAfter(), listItem.getTotalLeading(), listItem.getFont());
+
+                        // if the last line is justified, it should be aligned to the left
+                        if (line.hasToBeJustified()) {
+                            line.resetAlignment();
+                        }
+                        // some parameters are set back to normal again
+                        carriageReturn();
+                        indentation.listIndentLeft -= listItem.getIndentationLeft();
+                        indentation.indentRight -= listItem.getIndentationRight();
+                        leadingCount--;
+                    }
                     break;
                 }
                 case Element.RECTANGLE: {

--- a/openpdf/src/test/java/com/lowagie/text/pdf/SingleListItemTest.java
+++ b/openpdf/src/test/java/com/lowagie/text/pdf/SingleListItemTest.java
@@ -1,0 +1,39 @@
+package com.lowagie.text.pdf;
+
+import com.lowagie.text.*;
+import com.lowagie.text.pdf.parser.PdfTextExtractor;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+
+public class SingleListItemTest {
+
+    @Test
+    void testSingleParagraph() throws IOException {
+        Document document = new Document();
+        ByteArrayOutputStream stream = new ByteArrayOutputStream();
+        PdfWriter.getInstance(document, stream);
+        document.open();
+
+        Chunk chunk1 = new Chunk("Hier ", FontFactory.getFont(BaseFont.COURIER, 10));
+        Chunk chunk2 = new Chunk("fetter", FontFactory.getFont(BaseFont.COURIER_BOLD, 10));
+        Chunk chunk3 = new Chunk(" Text", FontFactory.getFont(BaseFont.COURIER, 10));
+
+        ListItem listItem = new ListItem();
+        listItem.add(chunk1);
+        listItem.add(chunk2);
+        listItem.add(chunk3);
+        listItem.setKeepTogether(true);
+
+        document.add(listItem);
+        document.close();
+
+        PdfReader reader = new PdfReader(stream.toByteArray());
+        PdfTextExtractor pdfTextExtractor = new PdfTextExtractor(reader);
+        String text = pdfTextExtractor.getTextFromPage(1);
+        Assertions.assertEquals(text, "Hier fetter Text");
+    }
+
+}


### PR DESCRIPTION
I'm working on the issue. Don't merge until the Unit-Test is passed.

## Description of the new Feature/Bugfix
ListItem has an option for setKeepTogether(true). However, the "keep together" setting is ignored in the PdfDocument yet.
To implement the "keep together" for ListItem, I just use the same approach as we handle the Element.PARAGRAPH.

Related Issue: #380 

## Unit-Tests for the new Feature/Bugfix
- [ ] Unit-Tests added to reproduce the bug
- [x] Unit-Tests added to the added feature
