### PR TITLE
fix and improve 526

### DIFF
--- a/openpdf/src/main/java/com/lowagie/text/pdf/FontSelector.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/FontSelector.java
@@ -46,17 +46,18 @@
  */
 package com.lowagie.text.pdf;
 
+import java.awt.Color;
 import java.util.ArrayList;
-
-import com.lowagie.text.error_messages.MessageLocalization;
 
 import com.lowagie.text.Chunk;
 import com.lowagie.text.Font;
+import com.lowagie.text.FontFactory;
 import com.lowagie.text.Phrase;
 import com.lowagie.text.Utilities;
+import com.lowagie.text.error_messages.MessageLocalization;
 
 /** Selects the appropriate fonts that contain the glyphs needed to
- * render text correctly. The fonts are checked in order until the 
+ * render text correctly. The fonts are checked in order until the
  * character is found.
  * <p>
  * The built in fonts "Symbol" and "ZapfDingbats", if used, have a special encoding
@@ -67,18 +68,40 @@ public class FontSelector {
 
     protected ArrayList<Font> fonts = new ArrayList<>();
 
+    public FontSelector() {
+        FontFactory.register("font-fallback/LiberationSans-Regular.ttf", "sans");
+        Font font = FontFactory.getFont("sans", BaseFont.IDENTITY_H);
+        fonts.add(font);
+    }
+
+    /**
+     * change the color of default font in <CODE>FontSelector</CODE>.
+     * @param color the <CODE>Color</CODE> of default font
+     */
+    public void setDefaultColor(Color color) {
+        fonts.get(fonts.size() - 1).setColor(color);
+    }
+
+    /**
+     * change the size of default font in <CODE>FontSelector</CODE>.
+     * @param size the size of default font
+     */
+    public void setDefaultSize(float size) {
+        fonts.get(fonts.size() - 1).setSize(size);
+    }
+
     /**
      * Adds a <CODE>Font</CODE> to be searched for valid characters.
      * @param font the <CODE>Font</CODE>
      */
     public void addFont(Font font) {
         if (font.getBaseFont() != null) {
-            fonts.add(font);
+            fonts.add(fonts.size() - 1, font);
             return;
         }
         BaseFont bf = font.getCalculatedBaseFont(true);
         Font f2 = new Font(bf, font.getSize(), font.getCalculatedStyle(), font.getColor());
-        fonts.add(f2);
+        fonts.add(fonts.size() - 1, f2);
     }
 
     /**
@@ -105,7 +128,6 @@ public class FontSelector {
             }
             if (Utilities.isSurrogatePair(cc, k)) {
                 int u = Utilities.convertToUtf32(cc, k);
-                boolean hasValidFontInList = false;
                 for (int f = 0; f < fsize; ++f) {
                     font = fonts.get(f);
                     if (font.getBaseFont().charExists(u)) {
@@ -121,24 +143,10 @@ public class FontSelector {
                         if (cc.length > k + 1) {
                             sb.append(cc[++k]);
                         }
-                        hasValidFontInList = true;
                         break;
                     }
                 }
-                if (!hasValidFontInList) {
-                    if (sb.length() > 0 && lastidx != -1) {
-                        Chunk ck = new Chunk(sb.toString());
-                        ret.add(ck);
-                        sb.setLength(0);
-                        lastidx = -1;
-                    }
-                    sb.append(c);
-                    if (cc.length > k + 1) {
-                        sb.append(cc[++k]);
-                    }
-                }
             } else {
-                boolean hasValidFontInList = false;
                 for (int f = 0; f < fsize; ++f) {
                     font = fonts.get(f);
                     if (font.getBaseFont().charExists(c)) {
@@ -151,18 +159,8 @@ public class FontSelector {
                             lastidx = f;
                         }
                         sb.append(c);
-                        hasValidFontInList = true;
                         break;
                     }
-                }
-                if (!hasValidFontInList) {
-                    if (sb.length() > 0 && lastidx != -1) {
-                        Chunk ck = new Chunk(sb.toString());
-                        ret.add(ck);
-                        sb.setLength(0);
-                        lastidx = -1;
-                    }
-                    sb.append(c);
                 }
             }
         }

--- a/openpdf/src/main/java/com/lowagie/text/pdf/FontSelector.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/FontSelector.java
@@ -54,7 +54,6 @@ import com.lowagie.text.Font;
 import com.lowagie.text.FontFactory;
 import com.lowagie.text.Phrase;
 import com.lowagie.text.Utilities;
-import com.lowagie.text.error_messages.MessageLocalization;
 
 /** Selects the appropriate fonts that contain the glyphs needed to
  * render text correctly. The fonts are checked in order until the

--- a/openpdf/src/main/java/com/lowagie/text/pdf/FontSelector.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/FontSelector.java
@@ -111,6 +111,7 @@ public class FontSelector {
      * @return a <CODE>Phrase</CODE> with one or more chunks
      */
     public Phrase process(String text) {
+        int fsize = fonts.size();
         char[] cc = text.toCharArray();
         int len = cc.length;
         StringBuilder sb = new StringBuilder();

--- a/openpdf/src/main/java/com/lowagie/text/pdf/FontSelector.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/FontSelector.java
@@ -111,9 +111,6 @@ public class FontSelector {
      * @return a <CODE>Phrase</CODE> with one or more chunks
      */
     public Phrase process(String text) {
-        int fsize = fonts.size();
-        if (fsize == 0)
-            throw new IndexOutOfBoundsException(MessageLocalization.getComposedMessage("no.font.is.defined"));
         char[] cc = text.toCharArray();
         int len = cc.length;
         StringBuilder sb = new StringBuilder();

--- a/openpdf/src/test/java/com/lowagie/text/pdf/FontSelectorTest.java
+++ b/openpdf/src/test/java/com/lowagie/text/pdf/FontSelectorTest.java
@@ -1,0 +1,32 @@
+package com.lowagie.text.pdf;
+
+import com.lowagie.text.Document;
+import com.lowagie.text.Font;
+import com.lowagie.text.PageSize;
+import com.lowagie.text.pdf.parser.PdfTextExtractor;
+
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+
+public class FontSelectorTest {
+    @Test
+    public void testDefaultFont() throws IOException {
+        Document document = new Document(PageSize.A4.rotate(), 10, 10, 10, 10);
+        ByteArrayOutputStream stream = new ByteArrayOutputStream();
+        PdfWriter.getInstance(document, stream);
+        document.open();
+
+        FontSelector selector = new FontSelector();
+        selector.addFont(new Font(Font.HELVETICA));
+        document.add(selector.process("ΧαίρετεGreek -"));
+        document.close();
+
+        PdfReader rd = new PdfReader(stream.toByteArray());
+        PdfTextExtractor pdfTextExtractor = new PdfTextExtractor(rd);
+        Assertions.assertEquals(pdfTextExtractor.getTextFromPage(1), "ΧαίρετεGreek -");
+    }
+}


### PR DESCRIPTION
## Description of the new Feature/Bugfix
the method used by 526 is to used default chunk, but it can not cosider the condition that invalid character appear at the head of sentence. so I change the pull request, we can know default chunk will use  `font-fallback/LiberationSans-Regular.ttf`, so I remove the redundant code of #526 and add this font to the list, and support user to modify its color and size

Related Issue: #392

## Unit-Tests for the new Feature/Bugfix
- [x] Unit-Tests added to reproduce the bug

## Compatibilities Issues
add new method setDefaultSize and setDefaultColor

## Testing details
no