### PR TITLE
HTTP Proxy in OCSP and TSA clients and other config for TSA

### DIFF
--- a/openpdf/src/main/java/com/lowagie/text/pdf/OcspClientBouncyCastle.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/OcspClientBouncyCastle.java
@@ -105,6 +105,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.math.BigInteger;
 import java.net.HttpURLConnection;
+import java.net.Proxy;
 import java.net.URL;
 import java.security.Provider;
 import java.security.Security;
@@ -144,6 +145,8 @@ public class OcspClientBouncyCastle implements OcspClient {
   private final X509Certificate checkCert;
   /** OCSP URL */
   private final String url;
+  /** HTTP proxy used to access the OCSP URL */
+  private Proxy proxy;
 
   /**
    * Creates an instance of an OcspClient that will be using BouncyCastle.
@@ -233,7 +236,8 @@ public class OcspClientBouncyCastle implements OcspClient {
           checkCert.getSerialNumber());
       byte[] array = request.getEncoded();
       URL urlt = new URL(url);
-      HttpURLConnection con = (HttpURLConnection) urlt.openConnection();
+      Proxy tmpProxy = proxy == null ? Proxy.NO_PROXY : proxy;
+      HttpURLConnection con = (HttpURLConnection) urlt.openConnection(tmpProxy);
       con.setRequestProperty("Content-Type", "application/ocsp-request");
       con.setRequestProperty("Accept", "application/ocsp-response");
       con.setDoOutput(true);
@@ -278,5 +282,21 @@ public class OcspClientBouncyCastle implements OcspClient {
       throw new ExceptionConverter(ex);
     }
     return null;
+  }
+
+  /**
+   * Sets Proxy which will be used for URL connection.
+   * @param aProxy Proxy to set
+   */
+  public void setProxy(final Proxy aProxy) {
+    this.proxy = aProxy;
+  }
+
+  /**
+   * Returns Proxy object used for URL connections.
+   * @return configured proxy
+   */
+  public Proxy getProxy() {
+    return proxy;
   }
 }

--- a/openpdf/src/main/java/com/lowagie/text/pdf/PdfPKCS7.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/PdfPKCS7.java
@@ -273,6 +273,16 @@ public class PdfPKCS7 {
     }
 
     /**
+     * Gets the oid for given digest name.
+     *
+     * @param digestName digest name (for instance "SHA-256")
+     * @return a digest OID (for instance "2.16.840.1.101.3.4.2.1") or {@code null} if the oid for provided name is not found
+     */
+    public static String getDigestOid(String digestName) {
+        return digestName != null ? allowedDigests.get(digestName) : null;
+    }
+
+    /**
      * Gets the timestamp token if there is one.
      *
      * @return the timestamp token or null


### PR DESCRIPTION
This PR allows a more fine-grained configuration of TSA and OCSP bouncy castle clients.

The proposed changes come from my JSignPdf maintained fork of iText (currently living in https://github.com/kwart/jsignpdf/tree/master/jsignpdf-itxt)
I would like to switch JSignPdf to use the OpenPDF in the future.
