### PR TITLE
fix possible ArrayIndexOutOfBoundsException

### DIFF
--- a/openpdf/src/main/java/com/lowagie/text/pdf/CJKFont.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/CJKFont.java
@@ -732,6 +732,9 @@ class CJKFont extends BaseFont {
      */
     @Override
     public boolean charExists(int c) {
+        if (c >= translationMap.length) {
+            return false;
+        }
         return translationMap[c] != 0;
     }
 


### PR DESCRIPTION
Add a condition to check if the index exists before accessing an array element

## Description of the new Feature/Bugfix
A simple fix to prevent ArrayIndexOutOfBoundsException
For example, on my project I'm getting this error. It's failing because of emoji character:
Exception in thread "main" java.lang.ArrayIndexOutOfBoundsException: Index 128578 out of bounds for length 65536
	at com.lowagie.text.pdf.CJKFont.charExists(CJKFont.java:735)
	at com.lowagie.text.pdf.FontSelector.process(FontSelector.java:109)

Related Issue: #

## Unit-Tests for the new Feature/Bugfix
- [No] Unit-Tests added to reproduce the bug
- [No] Unit-Tests added to the added feature

## Compatibilities Issues
It should not break anything as it's a simple fix to prevent ArrayIndexOutOfBoundsException

## Testing details
Any other details about how to test the new feature or bugfix?
Tha's a very simple fix
