### PR TITLE
make use of compositeFontDrawer configurable

### DIFF
--- a/openpdf/src/main/java/com/lowagie/text/pdf/PdfGraphics2D.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/PdfGraphics2D.java
@@ -50,6 +50,8 @@
 package com.lowagie.text.pdf;
 
 import com.lowagie.text.pdf.internal.PolylineShape;
+import com.lowagie.text.utils.SystemPropertyUtil;
+
 import java.awt.AlphaComposite;
 import java.awt.BasicStroke;
 import java.awt.Color;
@@ -191,6 +193,9 @@ public class PdfGraphics2D extends Graphics2D {
     
     private final CompositeFontDrawer compositeFontDrawer = new CompositeFontDrawer();
 
+    // make use of compositeFontDrawer configurable ... note: must be explicitly set to false otherwise always true (backwards compatibility).
+    private final boolean isCompositeFontDrawerEnabled = SystemPropertyUtil.getBoolean("com.github.librepdf.openpdf.compositeFontDrawerEnabled", true);
+    
     private PdfGraphics2D() {
         dg2.setRenderingHint(RenderingHints.KEY_FRACTIONALMETRICS, RenderingHints.VALUE_FRACTIONALMETRICS_ON);
         setRenderingHint(RenderingHints.KEY_FRACTIONALMETRICS, RenderingHints.VALUE_FRACTIONALMETRICS_ON);
@@ -388,7 +393,7 @@ public class PdfGraphics2D extends Graphics2D {
                 return;
             }
             double width = 0;
-            if (CompositeFontDrawer.isSupported() && compositeFontDrawer.isCompositeFont(font)) {
+            if (isCompositeFontDrawerEnabled && CompositeFontDrawer.isSupported() && compositeFontDrawer.isCompositeFont(font)) {
                 width = compositeFontDrawer.drawString(s, font, x, y, this::getCachedBaseFont, this::drawString);
             } else {
                 // Splitting string to the parts depending on they visibility preserves

--- a/openpdf/src/main/java/com/lowagie/text/pdf/PdfGraphics2D.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/PdfGraphics2D.java
@@ -193,8 +193,8 @@ public class PdfGraphics2D extends Graphics2D {
     
     private final CompositeFontDrawer compositeFontDrawer = new CompositeFontDrawer();
 
-    // make use of compositeFontDrawer configurable ... note: must be explicitly set to false otherwise always true (backwards compatibility).
-    private final boolean isCompositeFontDrawerEnabled = SystemPropertyUtil.getBoolean("com.github.librepdf.openpdf.compositeFontDrawerEnabled", true);
+    // make use of compositeFontDrawer configurable ... may be set via property or directly via setter
+    private boolean isCompositeFontDrawerEnabled = SystemPropertyUtil.getBoolean("com.github.librepdf.openpdf.compositeFontDrawerEnabled", true);
     
     private PdfGraphics2D() {
         dg2.setRenderingHint(RenderingHints.KEY_FRACTIONALMETRICS, RenderingHints.VALUE_FRACTIONALMETRICS_ON);
@@ -1377,8 +1377,15 @@ public class PdfGraphics2D extends Graphics2D {
     //        implementation specific methods
     //
     //
-    
-    
+
+    /**
+     * Enables/Disables the composite font drawer due to issues with custom font mappers that do not always default to one specific font but allow custom fonts.
+     * @param compositeFontDrawerEnabled true if the composite font drawer should be used else false.
+     */
+    public void setCompositeFontDrawerEnabled(boolean compositeFontDrawerEnabled) {
+        isCompositeFontDrawerEnabled = compositeFontDrawerEnabled;
+    }
+
     private void followPath(Shape s, int drawType) {
         if (s==null) return;
         if (drawType==STROKE) {

--- a/openpdf/src/main/java/com/lowagie/text/utils/SystemPropertyUtil.java
+++ b/openpdf/src/main/java/com/lowagie/text/utils/SystemPropertyUtil.java
@@ -1,0 +1,18 @@
+package com.lowagie.text.utils;
+
+public class SystemPropertyUtil {
+	/**
+	 * Similar to {@link Boolean#getBoolean(String)} but uses the given default value if property were not set.
+	 * @param propertyKey the system property key
+	 * @param defaultValue the default value to use if property is not defined.
+	 * @return true if the property is defined and contains "true" (ignoring case), else if system property is not set then the provided defaultValue, else false.
+	 */
+	public static boolean getBoolean(String propertyKey, boolean defaultValue) {
+		String propertyValue = System.getProperty(propertyKey);
+		if(propertyValue == null) {
+			return defaultValue;
+		}
+		
+		return Boolean.parseBoolean(propertyValue);
+	}
+}


### PR DESCRIPTION
## Description of the new Feature/Bugfix
Made the use of the 2019s introduced `CompositeFontDrawer` configurable via system property or by setting it programmatically via setter. Staying backwards compatible by enabling the compositeFontDrawer by default.

Related Issue: https://github.com/LibrePDF/OpenPDF/issues/587

## Compatibilities Issues
Backwards compatible

## Testing details
Generate PDF with custom mapper that does not default to Helvetica and use different fonts from Sans-Serif. Try using Helvetica without having it installed (e.g. Windows or *nix) and it will simply choose another Sans-Serif font(s) that is able to display the specified character(s).

With the new flag enabled the old behaviour is used which works perfectly fine for us since the given fonts in `PdfGraphics2D` were correctly initialized in our code. If in any case on the target system the specified font cannot be found an exception should be thrown rather than using another font (which was done with the old behaviour).

