### PR TITLE
Extent HeaderFooter functionality to create without before Phrase part

### DIFF
--- a/openpdf/src/main/java/com/lowagie/text/HeaderFooter.java
+++ b/openpdf/src/main/java/com/lowagie/text/HeaderFooter.java
@@ -105,7 +105,7 @@ public class HeaderFooter extends Rectangle {
  * Constructs a <CODE>Header</CODE>-object with a pagenumber at the end.
  *
  * @param    before        the <CODE>Phrase</CODE> before the pagenumber
- * @param    numbered    <CODE>true</CODE> if the page has to be numbered
+ * @param    numbered      page will be numbered if <CODE>true</CODE>
  */
     
     public HeaderFooter(Phrase before, boolean numbered) {
@@ -116,7 +116,34 @@ public class HeaderFooter extends Rectangle {
         this.numbered = numbered;
         this.before = before;
     }
-    
+
+/**
+ * Constructs a <CODE>Header</CODE>-object with a pagenumber at the beginning.
+ *
+ * @param numbered      page will be numbered if <CODE>true</CODE>
+ * @param after         the <CODE>Phrase</CODE> after the pagenumber
+ */
+
+    public HeaderFooter(boolean numbered, Phrase after) {
+        super(0, 0, 0, 0);
+        setBorder(TOP + BOTTOM);
+        setBorderWidth(1);
+
+        this.numbered = numbered;
+        this.after = after;
+    }
+
+/**
+ * Constructs a <CODE>Header</CODE>-object with only a pagenumber.
+ *
+ * @param numbered <CODE>true</CODE> if the page has to be numbered
+ */
+
+    public HeaderFooter(boolean numbered) {
+        this(null, true);
+        this.numbered = numbered;
+    }
+
     // methods
     
 /**
@@ -178,16 +205,38 @@ public class HeaderFooter extends Rectangle {
  */
     
     public Paragraph paragraph() {
-        Paragraph paragraph = new Paragraph(before.getLeading());
-        paragraph.add(before);
+        Paragraph paragraph;
+        if (before != null) {
+            paragraph = new Paragraph(before.getLeading());
+            paragraph.add(before);
+        } else {
+            paragraph = new Paragraph();
+        }
+
         if (numbered) {
-            paragraph.addSpecial(new Chunk(String.valueOf(pageN), before.getFont()));
+            Font font = getFont();
+            if (font != null) {
+                paragraph.addSpecial(new Chunk(String.valueOf(pageN), font));
+            } else {
+                paragraph.addSpecial(new Chunk(String.valueOf(pageN)));
+            }
         }
         if (after != null) {
             paragraph.addSpecial(after);
         }
         paragraph.setAlignment(alignment);
         return paragraph;
+    }
+
+    private Font getFont() {
+        if (before != null) {
+            return before.getFont();
+        }
+        if (after != null) {
+            return after.getFont();
+        }
+
+        return null;
     }
 
     /**

--- a/pdf-toolbox/src/test/java/com/lowagie/examples/footer/Footer.java
+++ b/pdf-toolbox/src/test/java/com/lowagie/examples/footer/Footer.java
@@ -1,0 +1,43 @@
+package com.lowagie.examples.footer;
+
+import com.lowagie.text.Document;
+import com.lowagie.text.Element;
+import com.lowagie.text.HeaderFooter;
+import com.lowagie.text.PageSize;
+import com.lowagie.text.Paragraph;
+import com.lowagie.text.Phrase;
+import com.lowagie.text.pdf.PdfWriter;
+
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+
+public class Footer {
+
+/**
+ * Create a document with 2 empty pages and custom numbered footer without before part.
+  * @param args
+ */
+
+    public static void main(String []args) {
+        Document document = new Document(PageSize.A4, 10f, 10f, 10f, 10f);
+
+        try {
+            PdfWriter.getInstance(document,
+                    new FileOutputStream("footer.pdf"));
+            HeaderFooter footer = new HeaderFooter(true, new Phrase(" page"));
+            footer.setAlignment(Element.ALIGN_CENTER);
+            footer.setBorderWidthBottom(0);
+            document.setFooter(footer);
+
+            document.open();
+            document.add(new Paragraph(" "));
+            document.newPage();
+            document.add(new Paragraph(" "));
+            document.newPage();
+            document.add(new Paragraph(" "));
+        } catch (FileNotFoundException e) {
+            System.err.println(e.getMessage());
+        }
+        document.close();
+    }
+}


### PR DESCRIPTION
## Description of the new Feature/Bugfix
HeaderFooter functionality was extended. I added ability to skip before Phrase at all. Also only numbering constructor was added.

## Unit-Tests for the new Feature/Bugfix
New feature doesn't affect any other functionality and I add only working example.

## Compatibilities Issues
Not found.

## Testing details
Working example was added (in package com.lowagie.examples.footer).
