### PR TITLE
Issue 623 : Make BaseFont subset prefix generation deterministic

### DIFF
--- a/openpdf/src/main/java/com/lowagie/text/pdf/BaseFont.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/BaseFont.java
@@ -54,6 +54,7 @@ import com.lowagie.text.error_messages.MessageLocalization;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.security.SecureRandom;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.StringTokenizer;
@@ -335,6 +336,11 @@ public abstract class BaseFont {
      * byte code.
      */
     protected IntHashtable specialMap;
+
+    /**
+     * Used to build a randomized prefix for a subset name
+     */
+    protected SecureRandom secureRandom;
 
     static {
         BuiltinFonts14.put(COURIER, PdfName.COURIER);
@@ -1353,12 +1359,35 @@ public abstract class BaseFont {
      * 
      * @return the subset prefix
      */
-    public static String createSubsetPrefix() {
+    protected String createSubsetPrefix() {
         String s = "";
+        SecureRandom secureRandom = getSecureRandom();
         for (int k = 0; k < 6; ++k) {
-            s += (char) (Math.random() * 26 + 'A');
+            s += (char) (secureRandom.nextDouble() * 26 + 'A');
         }
         return s + "+";
+    }
+
+    /**
+     * Returns a defined SecureRandom implementation.
+     * If nothing is set, returns a new
+     *
+     * @return {@link SecureRandom}
+     */
+    protected SecureRandom getSecureRandom() {
+        if (secureRandom != null) {
+            return secureRandom;
+        }
+        return new SecureRandom();
+    }
+
+    /**
+     * Sets the SecureRandom instance to be used for a subset's prefix generation
+     *
+     * @param secureRandom {@link SecureRandom}
+     */
+    public void setSecureRandom(SecureRandom secureRandom) {
+        this.secureRandom = secureRandom;
     }
 
     /**

--- a/openpdf/src/main/java/com/lowagie/text/pdf/PdfReader.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/PdfReader.java
@@ -2650,7 +2650,7 @@ public class PdfReader implements PdfViewerPreferences, Closeable {
         String s = getSubsetPrefix(dic);
         if (s == null)
           continue;
-        String ns = BaseFont.createSubsetPrefix() + s.substring(7);
+        String ns = createRandomSubsetPrefix() + s.substring(7);
         PdfName newName = new PdfName(ns);
         dic.put(PdfName.BASEFONT, newName);
         setXrefPartialObject(k, dic);
@@ -2670,7 +2670,7 @@ public class PdfReader implements PdfViewerPreferences, Closeable {
         String sde = getSubsetPrefix(desc);
         if (sde == null)
           continue;
-        String ns = BaseFont.createSubsetPrefix();
+        String ns = createRandomSubsetPrefix();
         if (s != null)
           dic.put(PdfName.BASEFONT, new PdfName(ns + s.substring(7)));
         setXrefPartialObject(k, dic);
@@ -2684,6 +2684,20 @@ public class PdfReader implements PdfViewerPreferences, Closeable {
       }
     }
     return total;
+  }
+
+  /**
+   * Creates a unique subset prefix to be added to the font name when the font
+   * is embedded and subset.
+   *
+   * @return the subset prefix
+   */
+  private String createRandomSubsetPrefix() {
+    String s = "";
+    for (int k = 0; k < 6; ++k) {
+      s += (char) (Math.random() * 26 + 'A');
+    }
+    return s + "+";
   }
 
   /**
@@ -2709,7 +2723,7 @@ public class PdfReader implements PdfViewerPreferences, Closeable {
         s = getFontName(dic);
         if (s == null)
           continue;
-        String ns = BaseFont.createSubsetPrefix() + s;
+        String ns = createRandomSubsetPrefix() + s;
         PdfDictionary fd = (PdfDictionary) getPdfObjectRelease(dic
             .get(PdfName.FONTDESCRIPTOR));
         if (fd == null)

--- a/openpdf/src/test/java/com/lowagie/text/pdf/SubsetPrefixCreationTest.java
+++ b/openpdf/src/test/java/com/lowagie/text/pdf/SubsetPrefixCreationTest.java
@@ -1,0 +1,50 @@
+package com.lowagie.text.pdf;
+
+import org.apache.commons.io.IOUtils;
+import org.bouncycastle.crypto.prng.FixedSecureRandom;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.security.SecureRandom;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+/**
+ * See : https://github.com/LibrePDF/OpenPDF/issues/623
+ */
+public class SubsetPrefixCreationTest {
+
+    @Test
+    public void createSubsetPrefixTest() throws Exception {
+        BaseFont font = BaseFont.createFont("LiberationSerif-Regular.ttf", BaseFont.IDENTITY_H,
+                BaseFont.EMBEDDED,true, getFontByte("LiberationSerif-Regular.ttf"), null);
+        assertNotEquals(font.createSubsetPrefix(), font.createSubsetPrefix());
+
+        byte[] baseSeed = new SecureRandom().generateSeed(512);
+        // init deterministic SecureRandom with a custom base seed
+        SecureRandom secureRandom = new FixedSecureRandom(baseSeed);
+        font.setSecureRandom(secureRandom);
+        assertNotEquals(font.createSubsetPrefix(), font.createSubsetPrefix()); // still different, as FixedSecureRandom generates a new random on each step
+
+        SecureRandom secureRandomOne = new FixedSecureRandom(baseSeed);
+        font.setSecureRandom(secureRandomOne);
+
+        String subsetPrefixOne = font.createSubsetPrefix();
+
+        // re-init FixedSecureRandom for deterministic generation
+        SecureRandom secureRandomTwo = new FixedSecureRandom(baseSeed);
+        font.setSecureRandom(secureRandomTwo);
+
+        String subsetPrefixTwo = font.createSubsetPrefix();
+        assertEquals(subsetPrefixOne, subsetPrefixTwo); // the desired deterministic behavior
+    }
+
+    private byte[] getFontByte(String fileName) throws IOException {
+        try (InputStream stream = BaseFont.getResourceStream(fileName, null)) {
+            return IOUtils.toByteArray(stream);
+        }
+    }
+
+}


### PR DESCRIPTION
Added a configurable SecureRandom to BaseFont class to make a possibility to generate a deterministic subset prefix.
By default the generated String is still random.

Related Issue: #623 

Unit test is provided within the commit. Tested within our implementation using a FixedSecureRandom from BC, and the generated subset prefix is deterministic, as expected.

Some comments:

I do not understand a reason for the method PdfReader.shuffleSubsetNames(). To my opinion, it could be removed, as if you remove it from code, it does not brake any unit tests. Nevertheless, I left this method with the  old behavior for backward compatibility.

My solution is pretty simple and straight-forward, so if you have better ideas how it could be implemented, please feel free to make the changes in my original PR.

Best regards,
Aleksandr.