### PR TITLE
Issue 629 fix: Throw exception if an xref PREV points to the startxref

### DIFF
--- a/openpdf/src/main/java/com/lowagie/text/error_messages/en.lng
+++ b/openpdf/src/main/java/com/lowagie/text/error_messages/en.lng
@@ -385,6 +385,7 @@ while.removing.wmf.placeable.header=while removing wmf placeable header
 writelength.can.only.be.called.after.output.of.the.stream.body=writeLength() can only be called after output of the stream body.
 writelength.can.only.be.called.in.a.contructed.pdfstream.inputstream.pdfwriter=writeLength() can only be called in a contructed PdfStream(InputStream,PdfWriter).
 wrong.number.of.columns=Wrong number of columns.
+xref.infinite.loop=An infinite loop was detected in the xref table.
 xref.subsection.not.found=xref subsection not found
 xstep.or.ystep.can.not.be.zero=XStep or YStep can not be ZERO.
 you.can.only.add.a.writer.to.a.pdfdocument.once=You can only add a writer to a PdfDocument once.

--- a/openpdf/src/main/java/com/lowagie/text/error_messages/nl.lng
+++ b/openpdf/src/main/java/com/lowagie/text/error_messages/nl.lng
@@ -385,6 +385,7 @@ while.removing.wmf.placeable.header=tijdens het verwijderen van een wmf position
 writelength.can.only.be.called.after.output.of.the.stream.body=writeLength() kan alleen opgeroepen worden na output van de stream body.
 writelength.can.only.be.called.in.a.contructed.pdfstream.inputstream.pdfwriter=writeLength() kan alleen opgeroepen worden in een aldus aangemaakte stream: PdfStream(InputStream,PdfWriter).
 wrong.number.of.columns=Verkeerd aantal kolommen.
+xref.infinite.loop=Er is een eindeloos lus gedetecteerd in de xref-tabel.
 xref.subsection.not.found=xref subsectie niet gevonden
 xstep.or.ystep.can.not.be.zero=XStep of YStep kan niet nul zijn.
 you.can.only.add.a.writer.to.a.pdfdocument.once=Je kan een writer slecht een enkele keer toevoegen aan een PdfDocument.

--- a/openpdf/src/main/java/com/lowagie/text/error_messages/pt.lng
+++ b/openpdf/src/main/java/com/lowagie/text/error_messages/pt.lng
@@ -5,3 +5,4 @@ fdf.header.not.found=Início de FDF não encontrado.
 greaterthan.not.expected='>' inesperado
 pdf.header.not.found=Início de PDF não encontrado.
 pdf.startxref.not.found=startxref de PDF não encontrado.
+xref.infinite.loop=Um loop infinito foi detectado na tabela xref.

--- a/openpdf/src/main/java/com/lowagie/text/pdf/PdfReader.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/PdfReader.java
@@ -1394,6 +1394,10 @@ public class PdfReader implements PdfViewerPreferences, Closeable {
       PdfNumber prev = (PdfNumber) trailer2.get(PdfName.PREV);
       if (prev == null)
         break;
+      if (prev.intValue() == startxref)
+        throw new InvalidPdfException(
+            MessageLocalization
+                .getComposedMessage("xref.infinite.loop"));
       tokens.seek(prev.intValue());
       trailer2 = readXrefSection();
     }


### PR DESCRIPTION
Fix for https://github.com/LibrePDF/OpenPDF/issues/629 

Simple check during readXref: if prev.intValue() refers to the same value as startXref, then throw exception and rebuild the xref.

Added translations for the exception message as well.