### PR TITLE
Adding Constructor Code for Footer in Table 

### DIFF
--- a/openpdf/src/main/java/com/lowagie/text/Font.java
+++ b/openpdf/src/main/java/com/lowagie/text/Font.java
@@ -331,7 +331,7 @@ public class Font implements Comparable {
             return 4;
         } catch (ClassCastException cce) {
             return -3;
-            
+
         }
     }
 

--- a/openpdf/src/main/java/com/lowagie/text/Font.java
+++ b/openpdf/src/main/java/com/lowagie/text/Font.java
@@ -331,6 +331,7 @@ public class Font implements Comparable {
             return 4;
         } catch (ClassCastException cce) {
             return -3;
+            
         }
     }
 

--- a/openpdf/src/main/java/com/lowagie/text/HeaderFooter.java
+++ b/openpdf/src/main/java/com/lowagie/text/HeaderFooter.java
@@ -109,7 +109,7 @@ public class HeaderFooter extends Rectangle {
 
     /**
      * Constructs a <CODE>Footer</CODE></CODE>-object for adding a PdfPTable
-     *
+     *Written by Cesia Bulnes for CS 427 https://github.com/LibrePDF/OpenPDF/compare/master...cesiabulnes:cesiab2_branch?expand=1
      * @param    beforePDF        the <CODE>Table</CODE>
      *
      */

--- a/openpdf/src/main/java/com/lowagie/text/HeaderFooter.java
+++ b/openpdf/src/main/java/com/lowagie/text/HeaderFooter.java
@@ -50,6 +50,9 @@
 package com.lowagie.text;
 
 
+import com.lowagie.text.pdf.PdfPTable;
+import com.lowagie.text.pdf.PdfTable;
+
 /**
  * A <CODE>HeaderFooter</CODE>-object is a <CODE>Rectangle</CODe> with text
  * that can be put above and/or below every page.
@@ -72,7 +75,10 @@ public class HeaderFooter extends Rectangle {
     
 /** This is the <CODE>Phrase</CODE> that comes before the pagenumber. */
     private Phrase before = null;
-    
+
+    /** This is the <CODE>PDFTable</CODE> */ //line written by Cesia Bulnes
+    private PdfPTable beforeP = null;
+
 /** This is number of the page. */
     private int pageN;
     
@@ -100,22 +106,40 @@ public class HeaderFooter extends Rectangle {
         this.before = before;
         this.after = after;
     }
-    
-/**
- * Constructs a <CODE>Header</CODE>-object with a pagenumber at the end.
- *
- * @param    before        the <CODE>Phrase</CODE> before the pagenumber
- * @param    numbered      page will be numbered if <CODE>true</CODE>
- */
-    
+
+    /**
+     * Constructs a <CODE>Footer</CODE></CODE>-object for adding a PdfPTable
+     *
+     * @param    beforePDF        the <CODE>Table</CODE>
+     *
+     */
+    //written by Cesia Bulnes
+    public HeaderFooter(PdfPTable beforePDF) {
+        super(0, 0, 0, 0);
+        setBorder(TOP + BOTTOM);
+        setBorderWidth(1);
+        //this.numbered = numbered;
+        this.beforeP = beforePDF;
+    }
+
+
+    /**
+     * Constructs a <CODE>Footer</CODE>-object with a pagenumber at the end.
+     *
+     * @param    before        the <CODE>Phrase</CODE> before the pagenumber
+     * @param    numbered      page will be numbered if <CODE>true</CODE>
+     */
+
     public HeaderFooter(Phrase before, boolean numbered) {
         super(0, 0, 0, 0);
         setBorder(TOP + BOTTOM);
         setBorderWidth(1);
-        
+
         this.numbered = numbered;
         this.before = before;
     }
+
+
 
 /**
  * Constructs a <CODE>Header</CODE>-object with a pagenumber at the beginning.
@@ -144,6 +168,8 @@ public class HeaderFooter extends Rectangle {
         this.numbered = numbered;
     }
 
+
+
     // methods
     
 /**
@@ -165,8 +191,19 @@ public class HeaderFooter extends Rectangle {
     public Phrase getBefore() {
         return before;
     }
-    
-/**
+
+
+    /**
+            * Gets the pdfptable
+            *
+            * @return  a pdfptable
+ */
+
+    public PdfPTable getBeforeP() {
+        return beforeP;
+    }
+
+    /**
  * Gets the part that comes after the pageNumber.
  *
  * @return  a Phrase

--- a/openpdf/src/main/java/com/lowagie/text/Paragraph.java
+++ b/openpdf/src/main/java/com/lowagie/text/Paragraph.java
@@ -161,6 +161,28 @@ public class Paragraph extends Phrase {
     public Paragraph(String string, Font font) {
         super(string, font);
     }
+    /**
+     * Constructs a <CODE>Paragraph</CODE> with a certain <CODE>String</CODE>
+     * and a certain leading.
+     *
+     * @param    strings       a list <CODE>String</CODE>
+     * @param    fonts        a list <CODE>Fonts</CODE>
+     *  By going through each string in the strings array,  match the font for
+     *  the string. If there are less fonts than strings,  do the mod for the font where
+     *  the currentIndex mod font size, will give the correct font in a loop
+     */
+    public Paragraph(java.util.List<String> strings, java.util.List<Font> fonts) {
+        super();
+        int currentIndex = 0;
+
+        for (String string: strings) {
+            //for every string in strings, get the font in the index( mod the index in case there are more strings than fonts
+            this.add(new Chunk(string, fonts.get(Math.floorMod(currentIndex, fonts.size()))));
+
+            currentIndex += 1;
+        }
+
+    }
     
     /**
      * Constructs a <CODE>Paragraph</CODE> with a certain <CODE>String</CODE>

--- a/openpdf/src/main/java/com/lowagie/text/Paragraph.java
+++ b/openpdf/src/main/java/com/lowagie/text/Paragraph.java
@@ -162,6 +162,7 @@ public class Paragraph extends Phrase {
         super(string, font);
     }
     /**
+     * Implemented by Cesia Bulnes for CS 472: https://github.com/LibrePDF/OpenPDF/compare/master...cesiabulnes:cesiab_branch?expand=1
      * Constructs a <CODE>Paragraph</CODE> with a certain <CODE>String</CODE>
      * and a certain leading.
      *

--- a/openpdf/src/main/java/com/lowagie/text/Phrase.java
+++ b/openpdf/src/main/java/com/lowagie/text/Phrase.java
@@ -55,6 +55,7 @@ import java.util.Collection;
 import com.lowagie.text.error_messages.MessageLocalization;
 
 import com.lowagie.text.pdf.HyphenationEvent;
+import com.lowagie.text.pdf.PdfPTable;
 
 /**
  * A <CODE>Phrase</CODE> is a series of <CODE>Chunk</CODE>s.
@@ -91,7 +92,8 @@ public class Phrase extends ArrayList<Element> implements TextElementArray {
     // membervariables
     /** This is the leading of this phrase. */
     protected float leading = Float.NaN;
-
+    /** This is the table in this phrase. */
+    protected PdfPTable table;
     /** This is the font of this phrase. */
     protected Font font;
 
@@ -130,6 +132,18 @@ public class Phrase extends ArrayList<Element> implements TextElementArray {
     public Phrase(float leading) {
         this.leading = leading;
         font = new Font();
+    }
+
+    /**
+     * Constructs a <CODE>Phrase</CODE> with a certain table.
+     *
+     * @param    table        the table
+     */
+    public Phrase(PdfPTable table) {
+        this.table = table;
+        super.add(table);
+        //this.add(table);
+
     }
 
     /**
@@ -290,6 +304,7 @@ public class Phrase extends ArrayList<Element> implements TextElementArray {
             element.type() == Element.ANNOTATION ||
             element.type() == Element.TABLE || // line added by David Freels
             element.type() == Element.YMARK ||
+            element.type() == Element.PTABLE ||      //line added by Cesia bulnes
             element.type() == Element.MARKED) {
                 super.add(index, element);
             }

--- a/openpdf/src/main/java/com/lowagie/text/Phrase.java
+++ b/openpdf/src/main/java/com/lowagie/text/Phrase.java
@@ -136,6 +136,7 @@ public class Phrase extends ArrayList<Element> implements TextElementArray {
 
     /**
      * Constructs a <CODE>Phrase</CODE> with a certain table.
+     * Written by Cesia Bulnes CS 427 https://github.com/LibrePDF/OpenPDF/compare/master...cesiabulnes:cesiab2_branch?expand=1
      *
      * @param    table        the table
      */

--- a/openpdf/src/main/java/com/lowagie/text/pdf/PdfContentByte.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/PdfContentByte.java
@@ -81,7 +81,7 @@ import java.util.Map;
  * font encoding.
  */
 
-public class PdfContentByte {
+public class    PdfContentByte {
 
     /**
      * This class keeps the graphic state of the current page

--- a/openpdf/src/test/java/com/lowagie/text/pdf/DifferentiatingWords571Test.java
+++ b/openpdf/src/test/java/com/lowagie/text/pdf/DifferentiatingWords571Test.java
@@ -25,6 +25,7 @@ public class DifferentiatingWords571Test {
      * Using the paragraph constructor created for this issue, use both fontArrayList and textArrayList
      * parameters.This will return the matching font for the string.
      * From there a user may choose to align using column text, and finish by adding the paragraph into the doc.
+     * Implemented by Cesia Bulnes for CS 427 https://github.com/LibrePDF/OpenPDF/compare/master...cesiabulnes:cesiab_branch?expand=1
      */
     @Test
     void testFontsInDiffWords() throws IOException {

--- a/openpdf/src/test/java/com/lowagie/text/pdf/DifferentiatingWords571Test.java
+++ b/openpdf/src/test/java/com/lowagie/text/pdf/DifferentiatingWords571Test.java
@@ -1,0 +1,68 @@
+package com.lowagie.text.pdf;
+
+import com.lowagie.text.Font;
+import org.junit.jupiter.api.Test;
+import com.lowagie.text.Chunk;
+import com.lowagie.text.Document;
+import com.lowagie.text.Element;
+import com.lowagie.text.PageSize;
+import com.lowagie.text.Paragraph;
+import com.lowagie.text.pdf.parser.PdfTextExtractor;
+import java.io.ByteArrayOutputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import java.awt.*;
+import java.util.ArrayList;
+
+public class DifferentiatingWords571Test {
+    /**
+     * The following creates a new document.
+     * From there, fonts are initialized and placed in fontArrayList.
+     * For testing purposes, add new text  into textArrayList
+     *
+     * Using the paragraph constructor created for this issue, use both fontArrayList and textArrayList
+     * parameters.This will return the matching font for the string.
+     * From there a user may choose to align using column text, and finish by adding the paragraph into the doc.
+     */
+    @Test
+    void testFontsInDiffWords() throws IOException {
+
+        final Document document = new Document();
+        final PdfWriter writer = PdfWriter.getInstance(document, new FileOutputStream("./src/test/resources/TestDiffFonts.pdf"));
+
+        document.open();
+        LayoutProcessor.enable(java.awt.Font.LAYOUT_RIGHT_TO_LEFT);
+
+        Font timesNormal = new Font(Font.TIMES_ROMAN, Font.DEFAULTSIZE, Font.NORMAL);
+        Font customFont = new Font(Font.COURIER, 12, Font.BOLD, Color.BLUE);
+        Font customFont2 = new Font(Font.COURIER, 19, Font.BOLD, Color.BLUE);
+        ArrayList<Font> fontArrayList = new ArrayList<>();
+
+        fontArrayList.add(timesNormal);
+        fontArrayList.add(customFont);
+        fontArrayList.add(customFont2);
+        ArrayList<String> textArrayList = new ArrayList<>();
+        textArrayList.add("Testing string1");
+        textArrayList.add("Testing string2");
+        textArrayList.add("Testing string3");
+        textArrayList.add("Testing string4");
+
+        Paragraph paragraph = new Paragraph(textArrayList,fontArrayList);
+        paragraph.setAlignment(Element.ALIGN_JUSTIFIED);
+
+        PdfContentByte canvas = writer.getDirectContent();
+        ColumnText ct = new ColumnText(canvas);
+        ct.setSimpleColumn(100, 500, 200, 750);
+        ct.addElement(paragraph); // add the paragraph as element
+        ct.go();
+
+        document.add(paragraph);
+        document.close();
+
+
+    }
+
+
+}

--- a/openpdf/src/test/java/com/lowagie/text/pdf/LayoutProcessor534Test.java
+++ b/openpdf/src/test/java/com/lowagie/text/pdf/LayoutProcessor534Test.java
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.Test;
 
 class LayoutProcessor534Test {
 
+
     @Test
     public void whenLayoutRightToLeftLatin_thenRevertCharOrder() throws IOException {
         // given

--- a/openpdf/src/test/java/com/lowagie/text/pdf/TablePdfTest.java
+++ b/openpdf/src/test/java/com/lowagie/text/pdf/TablePdfTest.java
@@ -126,6 +126,11 @@ public class TablePdfTest {
         return table;
     }
 
+    /**
+     * Junit test for the footer
+     *Written by Cesia Bulnes CS 427 https://github.com/LibrePDF/OpenPDF/compare/master...cesiabulnes:cesiab2_branch?expand=1
+     **/
+
 
     @Test
     void testTableFooter() throws Exception{

--- a/openpdf/src/test/java/com/lowagie/text/pdf/TablePdfTest.java
+++ b/openpdf/src/test/java/com/lowagie/text/pdf/TablePdfTest.java
@@ -1,9 +1,9 @@
 package com.lowagie.text.pdf;
 
-import com.lowagie.text.Document;
-import com.lowagie.text.DocumentException;
-import com.lowagie.text.Phrase;
+import com.lowagie.text.*;
 import org.junit.jupiter.api.Test;
+
+import java.io.FileOutputStream;
 
 public class TablePdfTest {
 
@@ -125,5 +125,42 @@ public class TablePdfTest {
 
         return table;
     }
+
+
+    @Test
+    void testTableFooter() throws Exception{
+    try {
+        Document document = new Document(PageSize.A4);
+
+        PdfWriter writer = PdfWriter.getInstance(document, new FileOutputStream("fail.pdf"));
+
+        PdfPTable table = new PdfPTable(2);
+        table.setWidthPercentage(100);
+        table.addCell(new PdfPCell(new Paragraph("CONTENT")));
+        table.addCell(new PdfPCell(new Paragraph("CONTENT")));
+
+
+        //HeaderFooter footer2 = new HeaderFooter(new Phrase("This is page "), new Phrase("."));
+        //Phrase footerParagraph = new Phrase();
+
+        Phrase footerParagraph = new Phrase();
+        footerParagraph.add(table);
+
+        //HeaderFooter footer = new HeaderFooter(new PdfPTable(table));
+        HeaderFooter footer = new HeaderFooter(new Phrase(table),true);
+        footer.setAlignment(Element.ALIGN_CENTER);
+        //footer2.setAlignment(Element.ALIGN_CENTER);
+        System.out.print(table);
+        document.setFooter(footer);
+        //document.setFooter(footer2);
+        document.open();
+        //document.add(footer);
+
+
+        document.add(new Paragraph("Hello World"));
+        document.close();
+    } catch (Exception ex) {
+        System.out.println(ex);
+    }}
 
 }

--- a/openpdf/src/test/java/com/lowagie/text/pdf/fonts/FontTest.java
+++ b/openpdf/src/test/java/com/lowagie/text/pdf/fonts/FontTest.java
@@ -44,6 +44,7 @@ class FontTest {
         put(Font.STRIKETHRU, Font::isStrikethru);
         put(Font.BOLDITALIC, f -> f.isBold() && f.isItalic());
         put(Font.UNDERLINE | Font.BOLD, f -> f.isUnderlined() && f.isBold());
+
     }};
 
     private static final String FONT_NAME_WITHOUT_STYLES = "non-existing-font";
@@ -162,5 +163,6 @@ class FontTest {
         File current = new File("target/resultSimulatedBold.pdf");
         assertTrue(FileUtils.contentEquals(original, current));
     }
+
 
 }

--- a/openpdf/src/test/resources/TestDiffFonts.pdf
+++ b/openpdf/src/test/resources/TestDiffFonts.pdf
@@ -24,7 +24,7 @@ endobj
 <</Type/Catalog/Pages 4 0 R>>
 endobj
 7 0 obj
-<</ModDate(D:20211119002515-08'00')/CreationDate(D:20211119002515-08'00')/Producer(OpenPDF 1.3.27-SNAPSHOT)>>
+<</ModDate(D:20211119012650-08'00')/CreationDate(D:20211119012650-08'00')/Producer(OpenPDF 1.3.27-SNAPSHOT)>>
 endobj
 xref
 0 8
@@ -37,7 +37,7 @@ xref
 0000000667 00000 n 
 0000000712 00000 n 
 trailer
-<</Info 7 0 R/ID [<be8620fde342deacc4b08c1ee41e97a2><03525c992b2bd2a7b70cbc9560249f47>]/Root 6 0 R/Size 8>>
+<</Info 7 0 R/ID [<86c1c0abd11bfcfeedd97592a97a198b><d593b162e43f4a92721444ba890eeb9c>]/Root 6 0 R/Size 8>>
 startxref
 837
 %%EOF

--- a/openpdf/src/test/resources/TestDiffFonts.pdf
+++ b/openpdf/src/test/resources/TestDiffFonts.pdf
@@ -1,0 +1,43 @@
+%PDF-1.5
+%âãÏÓ
+3 0 obj
+<</Filter/FlateDecode/Length 232>>stream
+xœ’Ë
+Â@E÷óYêÂ1™´óØ
+ºæ|Û‚¿ï<¨¶ÂT7m '÷Ş$}ˆ¬Á¢+J…s’0–ë)ğçğÕ?ãã şÔõ—{]ß†-ı5pêÍ!´Í7¦"†ĞdÔÍ¡üA÷/¢ÊÄsØ­û8AV&D0\¿””–ÚÄNÂT|æ™jNDÈF–Ä©Sª:5ş·€aš‚6ª¨ıî¢DÉjdğsuóÚê‰ƒU)ÿS°’.Ùü©N$PgŒÉQ™Ñ(ná|åõê:İ¨
+±ù’ıòNÿeE¨ı
+endstream
+endobj
+5 0 obj
+<</Contents 3 0 R/Type/Page/Resources<</Font<</F1 1 0 R/F2 2 0 R>>>>/Parent 4 0 R/MediaBox[0 0 595 842]>>
+endobj
+1 0 obj
+<</Subtype/Type1/Type/Font/BaseFont/Times-Roman/Encoding/WinAnsiEncoding>>
+endobj
+2 0 obj
+<</Subtype/Type1/Type/Font/BaseFont/Courier-Bold/Encoding/WinAnsiEncoding>>
+endobj
+4 0 obj
+<</Kids[5 0 R]/Type/Pages/Count 1>>
+endobj
+6 0 obj
+<</Type/Catalog/Pages 4 0 R>>
+endobj
+7 0 obj
+<</ModDate(D:20211119002515-08'00')/CreationDate(D:20211119002515-08'00')/Producer(OpenPDF 1.3.27-SNAPSHOT)>>
+endobj
+xref
+0 8
+0000000000 65535 f 
+0000000435 00000 n 
+0000000525 00000 n 
+0000000015 00000 n 
+0000000616 00000 n 
+0000000314 00000 n 
+0000000667 00000 n 
+0000000712 00000 n 
+trailer
+<</Info 7 0 R/ID [<be8620fde342deacc4b08c1ee41e97a2><03525c992b2bd2a7b70cbc9560249f47>]/Root 6 0 R/Size 8>>
+startxref
+837
+%%EOF


### PR DESCRIPTION
## Description of the new Feature/Bugfix
Describe here how you fixed the bug, or implemented the new feature.
The HeaderFooter class did not have constructors for implementing Phrase with a parameter of a table or a header footer with a table as a parameter. Constructors were added.

Related Issue: #373 

## Unit-Tests for the new Feature/Bugfix
- [1 ] Unit-Tests added to the added feature

## Compatibilities Issues
Is anything broken because of the new code? Any changes in method signatures? No

