### PR TITLE
Prevent ClassCastExceptions for PdfNull object during signing PDF docs

### DIFF
--- a/openpdf/src/main/java/com/lowagie/text/pdf/AcroFields.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/AcroFields.java
@@ -152,7 +152,7 @@ public class AcroFields {
 
   void fill() {
     fields = new HashMap<>();
-    PdfDictionary top = (PdfDictionary) PdfReader.getPdfObjectRelease(reader.getCatalog().get(PdfName.ACROFORM));
+    PdfDictionary top = (PdfDictionary) PdfReader.getPdfObjectReleaseNullConverting(reader.getCatalog().get(PdfName.ACROFORM));
     if (top == null) {
       return;
     }

--- a/openpdf/src/main/java/com/lowagie/text/pdf/PdfReader.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/PdfReader.java
@@ -901,6 +901,26 @@ public class PdfReader implements PdfViewerPreferences, Closeable {
   }
 
   /**
+   * If given object is instance of {@link PdfNull}, then {@code null} is returned. The provided object otherwise.
+   *
+   * @param obj object to convert
+   * @return provided object or null
+   */
+  public static PdfObject convertPdfNull(PdfObject obj) {
+      if (obj == null || obj instanceof PdfNull) {
+          return null;
+      }
+      return obj;
+  }
+
+  /**
+   * Returns {@link #getPdfObjectRelease(PdfObject)} with applied {@link #convertPdfNull(PdfObject)}.
+   */
+  public static PdfObject getPdfObjectReleaseNullConverting(PdfObject obj) {
+      return convertPdfNull(getPdfObjectRelease(obj));
+  }
+
+  /**
    * Reads a <CODE>PdfObject</CODE> resolving an indirect reference if needed.
    * 
    * @param obj
@@ -984,6 +1004,13 @@ public class PdfReader implements PdfViewerPreferences, Closeable {
       return obj;
     }
     return getPdfObject(obj);
+  }
+
+  /**
+   * Returns {@link #getPdfObject(PdfObject, PdfObject)} with applied {@link #convertPdfNull(PdfObject)}.
+   */
+  public static PdfObject getPdfObjectNullConverting(PdfObject obj, PdfObject parent) {
+      return convertPdfNull(getPdfObject(obj, parent));
   }
 
   /**

--- a/openpdf/src/main/java/com/lowagie/text/pdf/PdfStamper.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/PdfStamper.java
@@ -720,7 +720,7 @@ public class PdfStamper
         stp.sigApp.setStamper(stp);
         stp.hasSignature = true;
         PdfDictionary catalog = reader.getCatalog();
-        PdfDictionary acroForm = (PdfDictionary)PdfReader.getPdfObject(catalog.get(PdfName.ACROFORM), catalog);
+        PdfDictionary acroForm = (PdfDictionary)PdfReader.getPdfObjectNullConverting(catalog.get(PdfName.ACROFORM), catalog);
         if (acroForm != null) {
             acroForm.remove(PdfName.NEEDAPPEARANCES);
             stp.stamper.markUsed(acroForm);

--- a/openpdf/src/main/java/com/lowagie/text/pdf/PdfStamperImp.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/PdfStamperImp.java
@@ -1099,13 +1099,13 @@ class PdfStamperImp extends PdfWriter {
 
     void addDocumentField(PdfIndirectReference ref) {
         PdfDictionary catalog = reader.getCatalog();
-        PdfDictionary acroForm = (PdfDictionary)PdfReader.getPdfObject(catalog.get(PdfName.ACROFORM), catalog);
+        PdfDictionary acroForm = (PdfDictionary)PdfReader.getPdfObjectNullConverting(catalog.get(PdfName.ACROFORM), catalog);
         if (acroForm == null) {
             acroForm = new PdfDictionary();
             catalog.put(PdfName.ACROFORM, acroForm);
             markUsed(catalog);
         }
-        PdfArray fields = (PdfArray)PdfReader.getPdfObject(acroForm.get(PdfName.FIELDS), acroForm);
+        PdfArray fields = (PdfArray)PdfReader.getPdfObjectNullConverting(acroForm.get(PdfName.FIELDS), acroForm);
         if (fields == null) {
             fields = new PdfArray();
             acroForm.put(PdfName.FIELDS, fields);

--- a/openpdf/src/main/java/com/lowagie/text/pdf/XfaForm.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/XfaForm.java
@@ -104,7 +104,7 @@ public class XfaForm {
      * @since    2.1.3
      */
     public static PdfObject getXfaObject(PdfReader reader) {
-        PdfDictionary af = (PdfDictionary)PdfReader.getPdfObjectRelease(reader.getCatalog().get(PdfName.ACROFORM));
+        PdfDictionary af = (PdfDictionary)PdfReader.getPdfObjectReleaseNullConverting(reader.getCatalog().get(PdfName.ACROFORM));
         if (af == null) {
             return null;
         }


### PR DESCRIPTION
This PR fixes `ClassCastException` which occurs during signing some PDF documents. Null values are not properly checked in the code.

E.g.
```
java.lang.ClassCastException: com.lowagie.text.pdf.PdfNull cannot be cast to com.lowagie.text.pdf.PdfDictionary
	at com.lowagie.text.pdf.XfaForm.getXfaObject(XfaForm.java:107)
	at com.lowagie.text.pdf.XfaForm.<init>(XfaForm.java:124)
	at com.lowagie.text.pdf.AcroFields.<init>(AcroFields.java:143)
	at com.lowagie.text.pdf.PdfStamperImp.getAcroFields(PdfStamperImp.java:802)
	at com.lowagie.text.pdf.PdfSignatureAppearance.getNewSigName(PdfSignatureAppearance.java:931)
	at com.lowagie.text.pdf.PdfSignatureAppearance.<init>(PdfSignatureAppearance.java:158)
	at com.lowagie.text.pdf.PdfStamper.createSignature(PdfStamper.java:708)
```

To keep the changes backward compatible I only added new helper methods (with `NullConverting` suffix) in `PdfReader` instead of changing the existing ones.