### PR TITLE
Balancing market content operators when using without properties

### DIFF
--- a/openpdf/src/main/java/com/lowagie/text/pdf/PdfContentByte.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/PdfContentByte.java
@@ -3292,28 +3292,27 @@ public class PdfContentByte {
     public void beginMarkedContentSequence(PdfName tag, PdfDictionary property, boolean inline) {
         if (property == null) {
             content.append(tag.getBytes()).append(" BMC").append_i(separator);
-            return;
-        }
-        content.append(tag.getBytes()).append(' ');
-        if (inline)
-            try {
-                property.toPdf(writer, content);
+        } else {
+            content.append(tag.getBytes()).append(' ');
+            if (inline) {
+                try {
+                    property.toPdf(writer, content);
+                } catch (Exception e) {
+                    throw new ExceptionConverter(e);
+                }
+            } else {
+                PdfObject[] objs;
+                if (writer.propertyExists(property))
+                    objs = writer.addSimpleProperty(property, null);
+                else
+                    objs = writer.addSimpleProperty(property, writer.getPdfIndirectReference());
+                PdfName name = (PdfName) objs[0];
+                PageResources prs = getPageResources();
+                name = prs.addProperty(name, (PdfIndirectReference) objs[1]);
+                content.append(name.getBytes());
             }
-            catch (Exception e) {
-                throw new ExceptionConverter(e);
-            }
-        else {
-            PdfObject[] objs;
-            if (writer.propertyExists(property))
-                objs = writer.addSimpleProperty(property, null);
-            else
-                objs = writer.addSimpleProperty(property, writer.getPdfIndirectReference());
-            PdfName name = (PdfName)objs[0];
-            PageResources prs = getPageResources();
-            name = prs.addProperty(name, (PdfIndirectReference)objs[1]);
-            content.append(name.getBytes());
+            content.append(" BDC").append_i(separator);
         }
-        content.append(" BDC").append_i(separator);
         ++mcDepth;
     }
 

--- a/openpdf/src/main/java/com/lowagie/text/pdf/PdfName.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/PdfName.java
@@ -172,6 +172,8 @@ public class PdfName extends PdfObject implements Comparable<PdfName> {
     /** A name */
     public static final PdfName ARTBOX = new PdfName("ArtBox");
     /** A name */
+    public static final PdfName ARTIFACT = new PdfName("Artifact");
+    /** A name */
     public static final PdfName ASCENT = new PdfName("Ascent");
     /** A name */
     public static final PdfName AS = new PdfName("AS");


### PR DESCRIPTION
## Description of the new Feature/Bugfix
To produce PDF/UA compatible documents artifacts needs to be marked. This can be achieved by encapsulating it with a marked content sequence under the "Artifact" tag. There are no further properties associated with it. When using `beginMarkedContentSequence` without a property this will result in an unbalanced market content counter `mcDepth`, whereupon an `IllegalPdfSyntaxException` will be thrown when calling `endMarkedContentSequence`.
I also added the artifact tag in the PdfName class.

Related Issue: # none

## Unit-Tests for the new Feature/Bugfix
- [ ] Unit-Tests added to reproduce the bug
- [ ] Unit-Tests added to the added feature

## Compatibilities Issues
Not as far as i know. Internally there are no marked content sequences without properties used. As there should should always be a EMC tag following the BDC tag there are probally no use cases where this change is conflicting.