### PR TITLE
update FOP dependency to 2.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,7 +79,7 @@
         <bouncycastle.version>1.70</bouncycastle.version>
         <commons-io.version>2.11.0</commons-io.version>
         <dom4j.version>2.1.3</dom4j.version>
-        <fop.version>2.6</fop.version>
+        <fop.version>2.7</fop.version>
         <jakarta.servlet-api.version>5.0.0</jakarta.servlet-api.version>
         <jcommon.version>1.0.24</jcommon.version>
         <jfreechart.version>1.5.3</jfreechart.version>


### PR DESCRIPTION
## Description of the new Feature/Bugfix
Minor version update to Apache FOP.

The changes from 2.6 to 2.7 are identified at https://xmlgraphics.apache.org/fop/2.7/changes_2.7.html

Related Issue: N/A

## Unit-Tests for the new Feature/Bugfix
- [N/A] Unit-Tests added to reproduce the bug
- [N/A] Unit-Tests added to the added feature

## Compatibilities Issues
Nil known.

## Testing details
N/A.
