### PR TITLE
toolbox: fix compile warning in JFreeChartExample

### DIFF
--- a/pdf-toolbox/src/test/java/com/lowagie/examples/directcontent/graphics2d/JFreeChartExample.java
+++ b/pdf-toolbox/src/test/java/com/lowagie/examples/directcontent/graphics2d/JFreeChartExample.java
@@ -108,7 +108,7 @@ public class JFreeChartExample {
      * @return a piechart
      */
     public static JFreeChart getPieChart() {
-        DefaultPieDataset dataset = new DefaultPieDataset();
+        DefaultPieDataset<String> dataset = new DefaultPieDataset<>();
         dataset.setValue("iText", 60);
         dataset.setValue("cinema.lowagie.com", 10);
         dataset.setValue("tutorial", 30);


### PR DESCRIPTION
## Description of the new Feature/Bugfix
Fixes compile time warnings in JFreeChartExample of the form:
```
unchecked call to setValue(K,double) as a member of the raw type org.jfree.data.general.DefaultPieDataset
```

I've just provided the appropriate type.

Related Issue: N/A

## Unit-Tests for the new Feature/Bugfix
- [N/A] Unit-Tests added to reproduce the bug
- [N/A] Unit-Tests added to the added feature

## Compatibilities Issues
N/A

## Testing details
Build-time warning.
