### PR TITLE
Remove dependency on javax.annotation

### DIFF
--- a/openpdf/pom.xml
+++ b/openpdf/pom.xml
@@ -89,7 +89,7 @@
                         <!-- All com.lowagie.text.* packages are 'public' -->
                         <Export-Package>com.lowagie.text.*;version="${project.version}"</Export-Package>
                         <!-- Declare the Bouncycastle dependencies as optional -->
-                        <Import-Package>org.bouncycastle.*;resolution:=optional,!com.lowagie.*,javax.annotation.*;version="[1,4)",*</Import-Package>
+                        <Import-Package>org.bouncycastle.*;resolution:=optional,!com.lowagie.*,*</Import-Package>
                     </instructions>
                 </configuration>
             </plugin>

--- a/openpdf/src/main/java/com/lowagie/text/Chunk.java
+++ b/openpdf/src/main/java/com/lowagie/text/Chunk.java
@@ -63,8 +63,6 @@ import com.lowagie.text.pdf.PdfAnnotation;
 import com.lowagie.text.pdf.PdfContentByte;
 import com.lowagie.text.pdf.draw.DrawInterface;
 
-import javax.annotation.Nullable;
-
 /**
  * This is the smallest significant part of text that can be added to a
  * document.
@@ -356,7 +354,6 @@ public class Chunk implements Element {
      * 
      * @return a <CODE>Font</CODE>
      */
-    @Nullable
     public Font getFont() {
         return font;
     }

--- a/openpdf/src/main/java/com/lowagie/text/Font.java
+++ b/openpdf/src/main/java/com/lowagie/text/Font.java
@@ -53,7 +53,6 @@ import com.lowagie.text.html.Markup;
 import com.lowagie.text.pdf.BaseFont;
 import java.awt.Color;
 import java.util.Locale;
-import javax.annotation.Nullable;
 
 
 /**
@@ -195,7 +194,7 @@ public class Font implements Comparable {
      * @param color  the <CODE>Color</CODE> of this font.
      */
 
-    public Font(int family, float size, int style, @Nullable Color color) {
+    public Font(int family, float size, int style, Color color) {
         this.family = family;
         this.size = size;
         this.style = style;

--- a/openpdf/src/main/java/com/lowagie/text/FontFactoryImp.java
+++ b/openpdf/src/main/java/com/lowagie/text/FontFactoryImp.java
@@ -64,7 +64,6 @@ import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
-import javax.annotation.Nullable;
 
 
 /**
@@ -166,7 +165,7 @@ public class FontFactoryImp implements FontProvider {
      * @param    color        the <CODE>Color</CODE> of this font.
      * @return the Font constructed based on the parameters
      */
-    public Font getFont(@Nullable String fontName, String encoding, boolean embedded, float size, int style, @Nullable Color color) {
+    public Font getFont(String fontName, String encoding, boolean embedded, float size, int style, Color color) {
         return getFont(fontName, encoding, embedded, size, style, color, true);
     }
     
@@ -185,8 +184,8 @@ public class FontFactoryImp implements FontProvider {
      *                 the cache if new, false if the font is always created new
      * @return the Font constructed based on the parameters
      */
-    public Font getFont(@Nullable String fontname, String encoding, boolean embedded, float size, int style,
-            @Nullable Color color, boolean cached) {
+    public Font getFont(String fontname, String encoding, boolean embedded, float size, int style,
+            Color color, boolean cached) {
         if (fontname == null) {
             return new Font(Font.UNDEFINED, size, style, color);
         }

--- a/openpdf/src/main/java/com/lowagie/text/FontProvider.java
+++ b/openpdf/src/main/java/com/lowagie/text/FontProvider.java
@@ -47,7 +47,6 @@
 
 package com.lowagie.text;
 
-import javax.annotation.Nullable;
 import java.awt.Color;
 
 /**
@@ -76,5 +75,5 @@ public interface FontProvider {
      * @param color    the <CODE>Color</CODE> of this font.
      * @return the Font constructed based on the parameters
      */
-    Font getFont(@Nullable String fontName, String encoding, boolean embedded, float size, int style, @Nullable Color color);
+    Font getFont(String fontName, String encoding, boolean embedded, float size, int style, Color color);
 }

--- a/openpdf/src/main/java/com/lowagie/text/html/HtmlWriter.java
+++ b/openpdf/src/main/java/com/lowagie/text/html/HtmlWriter.java
@@ -77,7 +77,6 @@ import com.lowagie.text.SimpleTable;
 import com.lowagie.text.Table;
 import com.lowagie.text.pdf.BaseFont;
 
-import javax.annotation.Nullable;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.util.Date;
@@ -530,7 +529,7 @@ public class HtmlWriter extends DocWriter {
      * @param font the font of an object
      * @return true if the font differs
      */
-    public boolean isOtherFont(@Nullable Font font) {
+    public boolean isOtherFont(Font font) {
         try {
             Font cFont = currentfont.peek();
             return cFont.compareTo(font) != 0;
@@ -1026,7 +1025,7 @@ public class HtmlWriter extends DocWriter {
      * @param styleAttributes the style of the font
      * @throws IOException thrown when an I/O operation fails
      */
-    protected void write(@Nullable Font font, @Nullable Properties styleAttributes) throws IOException {
+    protected void write(Font font, Properties styleAttributes) throws IOException {
         if (font == null || !isOtherFont(font)) {
             return;
         }

--- a/openpdf/src/main/java/com/lowagie/text/html/Markup.java
+++ b/openpdf/src/main/java/com/lowagie/text/html/Markup.java
@@ -52,8 +52,6 @@
 
 package com.lowagie.text.html;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import java.awt.Color;
 import java.util.Locale;
 import java.util.Properties;
@@ -351,7 +349,7 @@ public class Markup {
      * @return a <code>float</code> number
      * @since 2.1.3
      */
-    public static float parseLength(@Nullable String string, float actualFontSize) {
+    public static float parseLength(String string, float actualFontSize) {
         if (string == null)
             return 0f;
         int pos = 0;
@@ -419,8 +417,7 @@ public class Markup {
      * @param color the <CODE>Color</CODE> that has to be converted.
      * @return the HTML representation of this <CODE>Color</CODE>
      */
-    @Nullable
-    public static Color decodeColor(@Nullable String color) {
+    public static Color decodeColor(String color) {
         if (color == null) {
             return null;
         }
@@ -442,8 +439,7 @@ public class Markup {
      *            keyN="valueN" '
      * @return a Properties object
      */
-    @Nonnull
-    public static Properties parseAttributes(@Nullable String string) {
+    public static Properties parseAttributes(String string) {
         Properties result = new Properties();
         if (string == null) {
             return result;

--- a/openpdf/src/main/java/com/lowagie/text/html/SAXmyHtmlHandler.java
+++ b/openpdf/src/main/java/com/lowagie/text/html/SAXmyHtmlHandler.java
@@ -50,7 +50,6 @@
 package com.lowagie.text.html;
 
 import java.util.Properties;
-import javax.annotation.Nullable;
 
 import com.lowagie.text.DocListener;
 import com.lowagie.text.DocumentException;
@@ -123,7 +122,7 @@ public class SAXmyHtmlHandler extends SAXiTextHandler<HtmlPeer> // SAXmyHandler
      * @param attrs     the list of attributes
      */
     @Override
-    public void startElement(String uri, String localName, String name, @Nullable Attributes attrs) {
+    public void startElement(String uri, String localName, String name, Attributes attrs) {
         // super.handleStartingTags is replaced with handleStartingTags
         // suggestion by Vu Ngoc Tan/Hop
         String lowerCaseName = name.toLowerCase();

--- a/openpdf/src/main/java/com/lowagie/text/html/package-info.java
+++ b/openpdf/src/main/java/com/lowagie/text/html/package-info.java
@@ -1,4 +1,3 @@
-@ParametersAreNonnullByDefault
 package com.lowagie.text.html;
 
-import javax.annotation.ParametersAreNonnullByDefault;
+

--- a/openpdf/src/main/java/com/lowagie/text/html/simpleparser/ChainedProperties.java
+++ b/openpdf/src/main/java/com/lowagie/text/html/simpleparser/ChainedProperties.java
@@ -55,8 +55,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 
 public class ChainedProperties {
 
@@ -74,7 +72,6 @@ public class ChainedProperties {
     public ChainedProperties() {
     }
 
-    @Nullable
     public String getProperty(String key) {
         return findProperty(key).orElse(null);
     }
@@ -86,7 +83,6 @@ public class ChainedProperties {
      * @return {@link Optional} containing the value or {@link Optional#empty()} if there is no value or
      * it equals {@code null}
      */
-    @Nonnull
     public Optional<String> findProperty(String key) {
         for (int k = chain.size() - 1; k >= 0; --k) {
             Object[] obj = (Object[]) chain.get(k);
@@ -106,7 +102,6 @@ public class ChainedProperties {
      * @param defaultValue default property value
      * @return property or default value if it's null
      */
-    @Nonnull
     public String getOrDefault(String key, String defaultValue) {
         return findProperty(key).orElse(defaultValue);
     }

--- a/openpdf/src/main/java/com/lowagie/text/html/simpleparser/FactoryProperties.java
+++ b/openpdf/src/main/java/com/lowagie/text/html/simpleparser/FactoryProperties.java
@@ -71,7 +71,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
 import java.util.StringTokenizer;
-import javax.annotation.Nullable;
 
 /**
  * @author psoares
@@ -97,7 +96,7 @@ public class FactoryProperties {
      */
     private FontProvider fontImp = FontFactory.getFontImp();
 
-    private static void setParagraphLeading(Paragraph paragraph, @Nullable String leading) {
+    private static void setParagraphLeading(Paragraph paragraph, String leading) {
         if (leading == null) {
             paragraph.setLeading(0, 1.5f);
             return;
@@ -189,8 +188,7 @@ public class FactoryProperties {
      * @return a HyphenationEvent
      * @since 2.1.2
      */
-    @Nullable
-    public static HyphenationEvent getHyphenation(@Nullable String s) {
+    public static HyphenationEvent getHyphenation(String s) {
         if (s == null || s.length() == 0) {
             return null;
         }

--- a/openpdf/src/main/java/com/lowagie/text/html/simpleparser/HTMLWorker.java
+++ b/openpdf/src/main/java/com/lowagie/text/html/simpleparser/HTMLWorker.java
@@ -83,7 +83,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Stack;
 import java.util.StringTokenizer;
-import javax.annotation.Nullable;
 
 public class HTMLWorker implements SimpleXMLDocHandler, DocListener {
 
@@ -136,12 +135,12 @@ public class HTMLWorker implements SimpleXMLDocHandler, DocListener {
      */
     @Deprecated
     @SuppressWarnings("unchecked")
-    public static ArrayList<Element> parseToList(Reader reader, @Nullable StyleSheet style, HashMap interfaceProps)
+    public static ArrayList<Element> parseToList(Reader reader, StyleSheet style, HashMap interfaceProps)
             throws IOException {
         return parseToList(reader, style, (Map<String, Object>) interfaceProps);
     }
 
-    public static ArrayList<Element> parseToList(Reader reader, @Nullable StyleSheet style, Map<String, Object> interfaceProps)
+    public static ArrayList<Element> parseToList(Reader reader, StyleSheet style, Map<String, Object> interfaceProps)
             throws IOException {
         HTMLWorker worker = new HTMLWorker(null);
         if (style != null) {

--- a/openpdf/src/main/java/com/lowagie/text/html/simpleparser/package-info.java
+++ b/openpdf/src/main/java/com/lowagie/text/html/simpleparser/package-info.java
@@ -1,4 +1,2 @@
-@ParametersAreNonnullByDefault
 package com.lowagie.text.html.simpleparser;
 
-import javax.annotation.ParametersAreNonnullByDefault;

--- a/openpdf/src/main/java/com/lowagie/text/pdf/PdfPCell.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/PdfPCell.java
@@ -62,8 +62,6 @@ import com.lowagie.text.Rectangle;
 import com.lowagie.text.ExceptionConverter;
 import com.lowagie.text.pdf.events.PdfPCellEventForwarder;
 
-import javax.annotation.Nullable;
-
 /**
  * A cell in a PdfPTable.
  */
@@ -146,7 +144,7 @@ public class PdfPCell extends Rectangle{
      * 
      * @param phrase the text
      */
-    public PdfPCell(@Nullable Phrase phrase) {
+    public PdfPCell(Phrase phrase) {
         super(0, 0, 0, 0);
         borderWidth = 0.5f;
         border = BOX;

--- a/openpdf/src/main/java/com/lowagie/text/pdf/PdfPKCS7.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/PdfPKCS7.java
@@ -80,8 +80,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import org.bouncycastle.asn1.ASN1Encodable;
 import org.bouncycastle.asn1.ASN1EncodableVector;
 import org.bouncycastle.asn1.ASN1Encoding;
@@ -300,7 +298,6 @@ public class PdfPKCS7 {
      * @return a date
      * @since 2.1.6
      */
-    @Nullable
     public Calendar getTimeStampDate() {
         if (timeStampToken == null)
             return null;
@@ -1076,7 +1073,6 @@ public class PdfPKCS7 {
         return false;
     }
 
-    @Nullable
     private static ASN1Primitive getExtensionValue(X509Certificate cert,
                                                    String oid) throws IOException {
         byte[] bytes = cert.getExtensionValue(oid);
@@ -1089,7 +1085,6 @@ public class PdfPKCS7 {
         return aIn.readObject();
     }
 
-    @Nonnull
     private static String getStringFromGeneralName(ASN1Primitive names) {
        	ASN1TaggedObject taggedObject = (ASN1TaggedObject) names ;
         return new String(ASN1OctetString.getInstance(taggedObject, false)
@@ -1765,7 +1760,6 @@ public class PdfPKCS7 {
 
         }
 
-        @Nullable
         public String getField(String name) {
             List<String> vs = valuesMap.get(name);
             return vs == null ? null : vs.get(0);

--- a/openpdf/src/main/java/com/lowagie/text/pdf/TextField.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/TextField.java
@@ -59,8 +59,6 @@ import com.lowagie.text.Font;
 import com.lowagie.text.Phrase;
 import com.lowagie.text.Rectangle;
 
-import javax.annotation.Nullable;
-
 /**
  * Supports text, combo and list fields generating the correct appearances.
  * All the option in the Acrobat GUI are supported in an easy to use API.
@@ -719,7 +717,7 @@ public class TextField extends BaseField {
      */
     @Deprecated
     @SuppressWarnings("unchecked")
-    public void setChoiceSelections(@Nullable ArrayList selections ) {
+    public void setChoiceSelections(ArrayList selections ) {
         setChoiceSelections((List<Integer>) selections);
     }
     
@@ -728,7 +726,7 @@ public class TextField extends BaseField {
      * list, all but the first element will be removed.
      * @param selections new selections.  If null, it clear()s the underlying ArrayList.
      */
-    public void setChoiceSelections(@Nullable List<Integer> selections ) {
+    public void setChoiceSelections(List<Integer> selections ) {
         if (selections != null) {
             choiceSelections = new ArrayList<>( selections );
             if (choiceSelections.size() > 1 && (options & BaseField.MULTISELECT) == 0 ) {

--- a/openpdf/src/main/java/com/lowagie/text/pdf/XfaForm.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/XfaForm.java
@@ -63,7 +63,6 @@ import java.util.EmptyStackException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import javax.annotation.Nullable;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
@@ -305,7 +304,7 @@ public class XfaForm {
      * @param name the complete or partial name
      * @return the <CODE>Node</CODE> or <CODE>null</CODE> if not found
      */
-    public Node findDatasetsNode(@Nullable String name) {
+    public Node findDatasetsNode(String name) {
         if (name == null)
             return null;
         name = findDatasetsName(name);
@@ -319,7 +318,7 @@ public class XfaForm {
      * @param n the <CODE>Node</CODE>
      * @return the text found or "" if no text was found
      */
-    public static String getNodeText(@Nullable Node n) {
+    public static String getNodeText(Node n) {
         if (n == null)
             return "";
         return getNodeText(n, "");
@@ -346,7 +345,7 @@ public class XfaForm {
      * @param n the <CODE>Node</CODE> to add the text to
      * @param text the text to add
      */
-    public void setNodeText(@Nullable Node n, String text) {
+    public void setNodeText(Node n, String text) {
         if (n == null)
             return;
         Node nc;
@@ -1061,7 +1060,7 @@ public class XfaForm {
             return null;
         }
 
-        private void processTemplate(Node n, @Nullable Map<String, Integer> ff) {
+        private void processTemplate(Node n, Map<String, Integer> ff) {
             if (ff == null)
                 ff = new HashMap<>();
             Map<String, Integer> ss = new HashMap<>();

--- a/openpdf/src/main/java/com/lowagie/text/pdf/parser/ContentOperator.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/parser/ContentOperator.java
@@ -49,7 +49,6 @@ package com.lowagie.text.pdf.parser;
 import com.lowagie.text.pdf.PdfDictionary;
 import com.lowagie.text.pdf.PdfObject;
 
-import javax.annotation.Nonnull;
 import java.util.List;
 
 /**
@@ -71,6 +70,5 @@ public interface ContentOperator {
      * @return the name of the operator as it will be recognized in the pdf
      * stream
      */
-    @Nonnull
     String getOperatorName();
 }

--- a/openpdf/src/main/java/com/lowagie/text/pdf/parser/FinalText.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/parser/FinalText.java
@@ -5,7 +5,6 @@ package com.lowagie.text.pdf.parser;
 
 import com.lowagie.text.pdf.PdfReader;
 
-import javax.annotation.Nullable;
 
 /**
  * @author dgd
@@ -23,7 +22,6 @@ public class FinalText implements TextAssemblyBuffer {
      *
      * @see com.lowagie.text.pdf.parser.TextAssemblyBuffer#getText()
      */
-    @Nullable
     @Override
     public String getText() {
         return content;

--- a/openpdf/src/main/java/com/lowagie/text/pdf/parser/MarkedUpTextAssembler.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/parser/MarkedUpTextAssembler.java
@@ -43,7 +43,6 @@ package com.lowagie.text.pdf.parser;
 
 import com.lowagie.text.pdf.PdfReader;
 
-import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -62,7 +61,6 @@ public class MarkedUpTextAssembler implements TextAssembler {
      */
     List<FinalText> result = new ArrayList<>();
     private PdfReader reader;
-    @Nullable
     private ParsedTextImpl inProgress = null;
     private int page;
     private int wordIdCounter = 1;
@@ -135,7 +133,7 @@ public class MarkedUpTextAssembler implements TextAssembler {
         }
     }
 
-    private FinalText concatenateResult(@Nullable String containingElementName) {
+    private FinalText concatenateResult(String containingElementName) {
         // null element means that this is a formatting artifact, not content.
         if (containingElementName == null) {
             // at some point, we may want to extract alternate text for some
@@ -167,7 +165,7 @@ public class MarkedUpTextAssembler implements TextAssembler {
      * @see com.lowagie.text.pdf.parser.TextAssembler#endParsingContext(String)
      */
     @Override
-    public FinalText endParsingContext(@Nullable String containingElementName) {
+    public FinalText endParsingContext(String containingElementName) {
         clearAccumulator();
         return concatenateResult(containingElementName);
     }

--- a/openpdf/src/main/java/com/lowagie/text/pdf/parser/ParsedText.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/parser/ParsedText.java
@@ -52,8 +52,6 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 
 /**
  * @author dgd
@@ -413,7 +411,6 @@ public class ParsedText extends ParsedTextImpl {
      *
      * @see com.lowagie.text.pdf.parser.ParsedTextImpl#getText()
      */
-    @Nullable
     @Override
     public String getText() {
         String text = super.getText();
@@ -426,7 +423,6 @@ public class ParsedText extends ParsedTextImpl {
     /**
      * @return a string whose characters represent code points in a possibly two-byte font
      */
-    @Nonnull
     public String getFontCodes() {
         return Optional.ofNullable(pdfText)
                 .map(PdfString::toString)

--- a/openpdf/src/main/java/com/lowagie/text/pdf/parser/ParsedTextImpl.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/parser/ParsedTextImpl.java
@@ -41,7 +41,6 @@
  */
 package com.lowagie.text.pdf.parser;
 
-import javax.annotation.Nullable;
 
 /**
  * @author dgd
@@ -76,7 +75,7 @@ public abstract class ParsedTextImpl implements TextAssemblyBuffer {
      * @param spaceWidth
      *            What is the width of the space in this font....
      */
-    ParsedTextImpl(@Nullable String text,
+    ParsedTextImpl(String text,
                    Vector startPoint,
                    Vector endPoint,
                    Vector baseline,
@@ -96,7 +95,6 @@ public abstract class ParsedTextImpl implements TextAssemblyBuffer {
      * {@inheritDoc}
      * @see com.lowagie.text.pdf.parser.ParsedText#getText()
      */
-    @Nullable
     @Override
     public String getText() {
         return text;

--- a/openpdf/src/main/java/com/lowagie/text/pdf/parser/PdfContentStreamHandler.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/parser/PdfContentStreamHandler.java
@@ -50,8 +50,6 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Stack;
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 
 import com.lowagie.text.ExceptionConverter;
 import com.lowagie.text.error_messages.MessageLocalization;
@@ -107,7 +105,6 @@ public class PdfContentStreamHandler {
         reset();
     }
 
-    @Nonnull
     private static Matrix getMatrix(List<PdfObject> operands) {
         float a = ((PdfNumber) operands.get(0)).floatValue();
         float b = ((PdfNumber) operands.get(1)).floatValue();
@@ -192,7 +189,6 @@ public class PdfContentStreamHandler {
      * @param operatorName name of the operator that we might need to call
      * @return the operator or null if none present
      */
-    @Nonnull
     public Optional<ContentOperator> lookupOperator(String operatorName) {
         return Optional.ofNullable(operators.get(operatorName));
     }
@@ -227,7 +223,7 @@ public class PdfContentStreamHandler {
         textFragments = newBuffer;
     }
 
-    void pushContext(@Nullable String newContextName) {
+    void pushContext(String newContextName) {
         contextNames.push(newContextName);
         textFragmentStreams.push(textFragments);
         textFragments = new ArrayList<>();
@@ -238,7 +234,6 @@ public class PdfContentStreamHandler {
      *
      * @return the graphics state
      */
-    @Nonnull
     GraphicsState graphicsState() {
         return gsStack.peek();
     }
@@ -307,7 +302,6 @@ public class PdfContentStreamHandler {
     /**
      * @return result text
      */
-    @Nonnull
     public String getResultantText() {
         if (contextNames.size() > 0) {
             throw new RuntimeException("can't get text with unprocessed stack items");
@@ -326,7 +320,6 @@ public class PdfContentStreamHandler {
         /**
          * @see com.lowagie.text.pdf.parser.ContentOperator#getOperatorName()
          */
-        @Nonnull
         @Override
         public String getOperatorName() {
             return "TJ";
@@ -354,7 +347,6 @@ public class PdfContentStreamHandler {
         /**
          * @see com.lowagie.text.pdf.parser.ContentOperator#getOperatorName()
          */
-        @Nonnull
         @Override
         public String getOperatorName() {
             return "BT";
@@ -374,7 +366,6 @@ public class PdfContentStreamHandler {
         /**
          * @see com.lowagie.text.pdf.parser.ContentOperator#getOperatorName()
          */
-        @Nonnull
         @Override
         public String getOperatorName() {
             return "ET";
@@ -394,7 +385,6 @@ public class PdfContentStreamHandler {
         /**
          * @see com.lowagie.text.pdf.parser.ContentOperator#getOperatorName()
          */
-        @Nonnull
         @Override
         public String getOperatorName() {
             return "cm";
@@ -425,7 +415,6 @@ public class PdfContentStreamHandler {
         /**
          * @see com.lowagie.text.pdf.parser.ContentOperator#getOperatorName()
          */
-        @Nonnull
         @Override
         public String getOperatorName() {
             return "'";
@@ -458,7 +447,6 @@ public class PdfContentStreamHandler {
         /**
          * @see com.lowagie.text.pdf.parser.ContentOperator#getOperatorName()
          */
-        @Nonnull
         @Override
         public String getOperatorName() {
             return "\"";
@@ -491,7 +479,6 @@ public class PdfContentStreamHandler {
         /**
          * @see com.lowagie.text.pdf.parser.ContentOperator#getOperatorName()
          */
-        @Nonnull
         @Override
         public String getOperatorName() {
             return "Q";
@@ -510,7 +497,6 @@ public class PdfContentStreamHandler {
         /**
          * @see com.lowagie.text.pdf.parser.ContentOperator#getOperatorName()
          */
-        @Nonnull
         @Override
         public String getOperatorName() {
             return "gs";
@@ -553,7 +539,6 @@ public class PdfContentStreamHandler {
         /**
          * @see com.lowagie.text.pdf.parser.ContentOperator#getOperatorName()
          */
-        @Nonnull
         @Override
         public String getOperatorName() {
             return "q";
@@ -574,7 +559,6 @@ public class PdfContentStreamHandler {
         /**
          * @see com.lowagie.text.pdf.parser.ContentOperator#getOperatorName()
          */
-        @Nonnull
         @Override
         public String getOperatorName() {
             return "Tc";
@@ -594,7 +578,6 @@ public class PdfContentStreamHandler {
         /**
          * @see com.lowagie.text.pdf.parser.ContentOperator#getOperatorName()
          */
-        @Nonnull
         @Override
         public String getOperatorName() {
             return "Tf";
@@ -621,7 +604,6 @@ public class PdfContentStreamHandler {
         /**
          * @see com.lowagie.text.pdf.parser.ContentOperator#getOperatorName()
          */
-        @Nonnull
         @Override
         public String getOperatorName() {
             return "Tm";
@@ -652,7 +634,6 @@ public class PdfContentStreamHandler {
         /**
          * @see com.lowagie.text.pdf.parser.ContentOperator#getOperatorName()
          */
-        @Nonnull
         @Override
         public String getOperatorName() {
             return "TD";
@@ -676,7 +657,6 @@ public class PdfContentStreamHandler {
         /**
          * @see com.lowagie.text.pdf.parser.ContentOperator#getOperatorName()
          */
-        @Nonnull
         @Override
         public String getOperatorName() {
             return "Tj";
@@ -702,7 +682,6 @@ public class PdfContentStreamHandler {
         /**
          * @see com.lowagie.text.pdf.parser.ContentOperator#getOperatorName()
          */
-        @Nonnull
         @Override
         public String getOperatorName() {
             return "T*";
@@ -724,7 +703,6 @@ public class PdfContentStreamHandler {
         /**
          * @see com.lowagie.text.pdf.parser.ContentOperator#getOperatorName()
          */
-        @Nonnull
         @Override
         public String getOperatorName() {
             return "Td";
@@ -748,7 +726,6 @@ public class PdfContentStreamHandler {
         /**
          * @see com.lowagie.text.pdf.parser.ContentOperator#getOperatorName()
          */
-        @Nonnull
         @Override
         public String getOperatorName() {
             return "Tr";
@@ -768,7 +745,6 @@ public class PdfContentStreamHandler {
         /**
          * @see com.lowagie.text.pdf.parser.ContentOperator#getOperatorName()
          */
-        @Nonnull
         @Override
         public String getOperatorName() {
             return "Ts";
@@ -788,7 +764,6 @@ public class PdfContentStreamHandler {
         /**
          * @see com.lowagie.text.pdf.parser.ContentOperator#getOperatorName()
          */
-        @Nonnull
         @Override
         public String getOperatorName() {
             return "TL";
@@ -808,7 +783,6 @@ public class PdfContentStreamHandler {
         /**
          * @see com.lowagie.text.pdf.parser.ContentOperator#getOperatorName()
          */
-        @Nonnull
         @Override
         public String getOperatorName() {
             return "Tz";
@@ -828,7 +802,6 @@ public class PdfContentStreamHandler {
         /**
          * @see com.lowagie.text.pdf.parser.ContentOperator#getOperatorName()
          */
-        @Nonnull
         @Override
         public String getOperatorName() {
             return "Tw";
@@ -848,7 +821,6 @@ public class PdfContentStreamHandler {
         /**
          * @see com.lowagie.text.pdf.parser.ContentOperator#getOperatorName()
          */
-        @Nonnull
         @Override
         public String getOperatorName() {
             return "BMC";
@@ -874,7 +846,6 @@ public class PdfContentStreamHandler {
         /**
          * @see com.lowagie.text.pdf.parser.ContentOperator#getOperatorName()
          */
-        @Nonnull
         @Override
         public String getOperatorName() {
             return "BDC";
@@ -937,7 +908,6 @@ public class PdfContentStreamHandler {
         /**
          * @see com.lowagie.text.pdf.parser.ContentOperator#getOperatorName()
          */
-        @Nonnull
         @Override
         public String getOperatorName() {
             return "EMC";
@@ -953,7 +923,6 @@ public class PdfContentStreamHandler {
         /**
          * @see com.lowagie.text.pdf.parser.ContentOperator#getOperatorName()
          */
-        @Nonnull
         @Override
         public String getOperatorName() {
             return "Do";

--- a/openpdf/src/main/java/com/lowagie/text/pdf/parser/PdfTextExtractor.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/parser/PdfTextExtractor.java
@@ -62,7 +62,6 @@ import com.lowagie.text.pdf.PdfObject;
 import com.lowagie.text.pdf.PdfReader;
 import com.lowagie.text.pdf.RandomAccessFileOrArray;
 
-import javax.annotation.Nonnull;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -180,7 +179,6 @@ public class PdfTextExtractor {
      * @return a String with the content as plain text (without PDF syntax)
      * @throws IOException on error
      */
-    @Nonnull
     public String getTextFromPage(int page) throws IOException {
         return getTextFromPage(page, false);
     }
@@ -194,7 +192,6 @@ public class PdfTextExtractor {
      * @return result of extracting the text, with tags as requested.
      * @throws IOException on error
      */
-    @Nonnull
     public String getTextFromPage(int page, boolean useContainerMarkup) throws IOException {
         PdfDictionary pageDict = reader.getPageN(page);
         if (pageDict == null) {

--- a/openpdf/src/main/java/com/lowagie/text/pdf/parser/TextAssemblyBuffer.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/parser/TextAssemblyBuffer.java
@@ -5,7 +5,6 @@ package com.lowagie.text.pdf.parser;
 
 import com.lowagie.text.pdf.PdfReader;
 
-import javax.annotation.Nullable;
 
 /**
  * @author dgd
@@ -16,7 +15,6 @@ public interface TextAssemblyBuffer {
     /**
      * @return the text to render
      */
-    @Nullable
     String getText();
 
     /**

--- a/openpdf/src/main/java/com/lowagie/text/pdf/parser/Word.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/parser/Word.java
@@ -43,8 +43,6 @@
  */
 package com.lowagie.text.pdf.parser;
 
-import javax.annotation.Nullable;
-
 import com.lowagie.text.Rectangle;
 import com.lowagie.text.pdf.PdfReader;
 
@@ -126,7 +124,7 @@ public class Word extends ParsedTextImpl {
      *            page.
      * @return markup to represent this one word.
      */
-    private String wordMarkup(@Nullable String text, PdfReader reader, int page, TextAssembler assembler) {
+    private String wordMarkup(String text, PdfReader reader, int page, TextAssembler assembler) {
         if (text == null) {
             return "";
         }

--- a/openpdf/src/main/java/com/lowagie/text/pdf/parser/package-info.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/parser/package-info.java
@@ -1,4 +1,1 @@
-@ParametersAreNonnullByDefault
 package com.lowagie.text.pdf.parser;
-
-import javax.annotation.ParametersAreNonnullByDefault;

--- a/openpdf/src/main/java/com/lowagie/text/utils/NumberUtilities.java
+++ b/openpdf/src/main/java/com/lowagie/text/utils/NumberUtilities.java
@@ -1,7 +1,6 @@
 package com.lowagie.text.utils;
 
 import java.util.Optional;
-import javax.annotation.Nonnull;
 
 public final class NumberUtilities {
 
@@ -14,7 +13,6 @@ public final class NumberUtilities {
      * @param value string value
      * @return {@link Optional} containing parsed value or empty
      */
-    @Nonnull
     public static Optional<Float> parseFloat(String value) {
         try {
             return Optional.of(Float.parseFloat(value));
@@ -29,7 +27,6 @@ public final class NumberUtilities {
      * @param value string value
      * @return {@link Optional} containing parsed value or empty
      */
-    @Nonnull
     public static Optional<Integer> parseInt(String value) {
         try {
             return Optional.of(Integer.parseInt(value));

--- a/openpdf/src/main/java/com/lowagie/text/utils/package-info.java
+++ b/openpdf/src/main/java/com/lowagie/text/utils/package-info.java
@@ -1,4 +1,2 @@
-@ParametersAreNonnullByDefault
 package com.lowagie.text.utils;
 
-import javax.annotation.ParametersAreNonnullByDefault;

--- a/openpdf/src/main/java/com/lowagie/text/xml/SAXiTextHandler.java
+++ b/openpdf/src/main/java/com/lowagie/text/xml/SAXiTextHandler.java
@@ -56,7 +56,6 @@ import java.util.EmptyStackException;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Stack;
-import javax.annotation.Nullable;
 
 import com.lowagie.text.Anchor;
 import com.lowagie.text.Annotation;
@@ -201,7 +200,7 @@ public class SAXiTextHandler<T extends XmlPeer> extends DefaultHandler {
      * @param attributes the list of attributes
      */
 
-    public void startElement(String uri, String localName, String name, @Nullable Attributes attributes) {
+    public void startElement(String uri, String localName, String name, Attributes attributes) {
 
         Properties properties = new Properties();
         if (attributes != null) {


### PR DESCRIPTION
Remove javax.annotation dependency.

javax.annotation is replaced by jakarta.annotation. javax.annotation is no longer maintained.

https://github.com/LibrePDF/OpenPDF/issues/651