### PR TITLE
Correct run direction for RTL fields

### DIFF
--- a/openpdf/pom.xml
+++ b/openpdf/pom.xml
@@ -16,6 +16,12 @@
 
     <dependencies>
         <dependency>
+            <groupId>com.ibm.icu</groupId>
+            <artifactId>icu4j</artifactId>
+            <version>70.1</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
             <groupId>com.google.code.findbugs</groupId>
             <artifactId>jsr305</artifactId>
         </dependency>

--- a/openpdf/src/main/java/com/lowagie/text/pdf/TextField.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/TextField.java
@@ -229,6 +229,23 @@ public class TextField extends BaseField {
     }
     
     /**
+     * Flip text alignment for RTL texts Not sure why but this is needed
+     */
+    private int getTextAlignment(int runDirection) {
+        if (runDirection == PdfWriter.RUN_DIRECTION_RTL) {
+            if (alignment == Element.ALIGN_LEFT) {
+                return Element.ALIGN_RIGHT;
+            } else if (alignment == Element.ALIGN_RIGHT) {
+                return Element.ALIGN_LEFT;
+            } else {
+                return alignment;
+            }
+        } else {
+            return alignment;
+        }
+    }
+
+    /**
      * Get the <code>PdfAppearance</code> of a text or combo field
      * @throws IOException on error
      * @throws DocumentException on error
@@ -278,7 +295,7 @@ public class TextField extends BaseField {
                         usize = 12;
                     float step = Math.max((usize - 4) / 10, 0.2f);
                     ct.setSimpleColumn(0, -h, width, 0);
-                    ct.setAlignment(alignment);
+                    ct.setAlignment(getTextAlignment(rtl));
                     ct.setRunDirection(rtl);
                     for (; usize > 4; usize -= step) {
                         ct.setYLine(0);
@@ -299,7 +316,7 @@ public class TextField extends BaseField {
             float offsetY = offsetX + h - ufont.getFontDescriptor(BaseFont.BBOXURY, usize);
             ct.setSimpleColumn(extraMarginLeft + 2 * offsetX, -20000, box.getWidth() - 2 * offsetX, offsetY + leading);
             ct.setLeading(leading);
-            ct.setAlignment(alignment);
+            ct.setAlignment(getTextAlignment(rtl));
             ct.setRunDirection(rtl);
             ct.setText(phrase);
             ct.go();


### PR DESCRIPTION
## Description of the new Feature/Bugfix

We're using OpenPDF to fill out PDF forms.
Some of our forms are in Hebrew (whici is an RTL language).
If the value of a field contains both LTR / RTL characters OpenPDF [always uses LTR](https://github.com/LibrePDF/OpenPDF/blob/1.3.26/openpdf/src/main/java/com/lowagie/text/pdf/TextField.java#L211) for it.
This causes rendering issues because a single LTR character will set the run direction to LTR even if there are more Hebrew characters.

This solution adds icu4j as an optional dependecy and uses their Unicode Bidi Algorithm to check if the text is only LTR/RTL or mixed.

It seems run direction to be:

* NO_BIDI in case of only LTR to preserve current behavior (not sure if this can result in different results than LTR)
* RTL in case of only RTL.
* In case of mixed text we choose the more abundant direction. Another approach would be to use the run direction propery of the field but I couldn't find any docs on how to find it using  OpenPDF/iText (even later versions)

Related Issue: #

## Unit-Tests for the new Feature/Bugfix
- [ ] Unit-Tests added to reproduce the bug
- [ ] Unit-Tests added to the added feature

## Compatibilities Issues
None.

## Testing details
Try inserting these texts onto a field:

```
אחת שתיים שלוש four five
One two שלוש ארבע חמש
```

In both case their should be RTL because the Hebrew is more abundant.

Note:

1. We aleady use this code in our production app since yesterday. We might want to let it run for a while before adidng this to OpenPDF.
2. Please keep in mind them I don't work with Java a lot :)