### PR TITLE
Document 3rd party lib dep for getTiffImage

### DIFF
--- a/openpdf/src/main/java/com/lowagie/text/ImageLoader.java
+++ b/openpdf/src/main/java/com/lowagie/text/ImageLoader.java
@@ -160,6 +160,18 @@ public class ImageLoader {
         }
     }
 
+    /**
+     * Creates an Image from an array of tiff image bytes.
+     * For JRE < 9, `ImageIO.read()` requires a supporting library in the classpath to read tiffs.
+     * Options are:
+     * - https://github.com/jai-imageio/jai-imageio-core
+     * - https://github.com/haraldk/TwelveMonkeys 
+     *
+     * see: https://openjdk.java.net/jeps/262
+     * 
+     * @param imageData bytes of the tiff image
+     * @return an objet of type <code>Image</code>
+     */
     public static Image getTiffImage(byte[] imageData) {
         try (InputStream is = new ByteArrayInputStream(imageData)) {
             BufferedImage bufferedImage = ImageIO.read(is);


### PR DESCRIPTION
## Description of the new Feature/Bugfix

Using Java < 9 tiff images will fail to load with a NullPointerException unless a supporting lib is present in the classpath, ie
jai-imageio-core. This PR documents the dependency.

## Compatibilities Issues

documentation only

## Testing details

documentation only
