### PR TITLE
Adding Paragraphs with different run directions to same ColumnText ob…

### DIFF
--- a/openpdf/src/main/java/com/lowagie/text/Paragraph.java
+++ b/openpdf/src/main/java/com/lowagie/text/Paragraph.java
@@ -49,6 +49,8 @@
 
 package com.lowagie.text;
 
+import com.lowagie.text.pdf.PdfWriter;
+
 /**
  * A <CODE>Paragraph</CODE> is a series of <CODE>Chunk</CODE>s and/or <CODE>Phrases</CODE>.
  * <P>
@@ -79,6 +81,9 @@ public class Paragraph extends Phrase {
     
     /** The alignment of the text. */
     protected int alignment = Element.ALIGN_UNDEFINED;
+
+    /** The base run direction of paragraph */
+    protected int runDirection = PdfWriter.RUN_DIRECTION_DEFAULT;
     
     /** The text leading that is multiplied by the biggest font size in the line. */
     protected float multipliedLeading = 0;
@@ -499,4 +504,11 @@ public class Paragraph extends Phrase {
         return spacingAfter;
     }
 
+    public int getRunDirection() {
+        return runDirection;
+    }
+
+    public void setRunDirection(int runDirection) {
+        this.runDirection = runDirection;
+    }
 }

--- a/openpdf/src/main/java/com/lowagie/text/pdf/ColumnText.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/ColumnText.java
@@ -1176,7 +1176,7 @@ public class ColumnText {
                         compositeColumn.setFollowingIndent(para.getIndentationLeft());
                         compositeColumn.setRightIndent(para.getIndentationRight());
                         compositeColumn.setLeading(para.getLeading(), para.getMultipliedLeading());
-                        compositeColumn.setRunDirection(runDirection);
+                        compositeColumn.setRunDirection(para.getRunDirection() == PdfWriter.RUN_DIRECTION_DEFAULT ? runDirection : para.getRunDirection());
                         compositeColumn.setArabicOptions(arabicOptions);
                         compositeColumn.setSpaceCharRatio(spaceCharRatio);
                         compositeColumn.addText(para);


### PR DESCRIPTION
A base direction attribute has been added at Paragraph level so that when two different paragraphs with different layouts (LTR/RTL) are added to the same ColumnText object, we can set the run direction of composite column based on the paragraphs itself.
Related Issue: https://github.com/LibrePDF/OpenPDF/issues/691

