### PR TITLE
fix nonsupport of rowspan

### DIFF
--- a/openpdf/src/main/java/com/lowagie/text/html/simpleparser/IncCell.java
+++ b/openpdf/src/main/java/com/lowagie/text/html/simpleparser/IncCell.java
@@ -78,6 +78,10 @@ public class IncCell implements TextElementArray {
                 .flatMap(NumberUtilities::parseInt)
                 .ifPresent(cell::setColspan);
 
+        props.findProperty("rowspan").
+                flatMap(NumberUtilities::parseInt)
+                .ifPresent(cell::setRowspan);
+
         if (tag.equals("th")) {
             cell.setHorizontalAlignment(Element.ALIGN_CENTER);
         }


### PR DESCRIPTION
## Description of the new Feature/Bugfix
Describe here how you fixed the bug, or implemented the new feature.
Digging into the endElement method of HTMLworker class, I find there is something wrong with IncCell, which only adds the support for colspan of tr. In this way, I add one line of code in constructor of IncCell to imitate the setting of colspan to enable rowspan.

Related Issue: #619 

## Unit-Tests for the new Feature/Bugfix
- [Y] Unit-Tests added to reproduce the bug
- [ ] Unit-Tests added to the added feature

## Compatibilities Issues
Is anything broken because of the new code? Any changes in method signatures?
No, there is nothing broken because of the new code. No, there is no change in method signatures

## Testing details
Any other details about how to test the new feature or bugfix?
I reproduce the broken steps of nonsupport of rowspan.