### PR TITLE
Fix bug about SAXiTextHandler

### DIFF
--- a/openpdf/src/main/java/com/lowagie/text/html/SAXmyHtmlHandler.java
+++ b/openpdf/src/main/java/com/lowagie/text/html/SAXmyHtmlHandler.java
@@ -233,6 +233,7 @@ public class SAXmyHtmlHandler extends SAXiTextHandler<HtmlPeer> // SAXmyHandler
         if (HtmlTagMap.isTitle(lowerCaseName)) {
             if (currentChunk != null) {
                 bodyAttributes.put(ElementTags.TITLE, currentChunk.getContent());
+                currentChunk = null;
             }
             return;
         }

--- a/openpdf/src/main/java/com/lowagie/text/xml/SAXiTextHandler.java
+++ b/openpdf/src/main/java/com/lowagie/text/xml/SAXiTextHandler.java
@@ -226,21 +226,21 @@ public class SAXiTextHandler<T extends XmlPeer> extends DefaultHandler {
         }
 
         // maybe there is some meaningful data that wasn't between tags
-//        if (currentChunk != null && isNotBlank(currentChunk.getContent())) {
-//            TextElementArray current;
-//            try {
-//                current = (TextElementArray) stack.pop();
-//            } catch (EmptyStackException ese) {
-//                if (bf == null) {
-//                    current = new Paragraph("", new Font());
-//                } else {
-//                    current = new Paragraph("", new Font(this.bf));
-//                }
-//            }
-//            current.add(currentChunk);
-//            stack.push(current);
-//            currentChunk = null;
-//        }
+        if (currentChunk != null && isNotBlank(currentChunk.getContent())) {
+            TextElementArray current;
+            try {
+                current = (TextElementArray) stack.pop();
+            } catch (EmptyStackException ese) {
+                if (bf == null) {
+                    current = new Paragraph("", new Font());
+                } else {
+                    current = new Paragraph("", new Font(this.bf));
+                }
+            }
+            current.add(currentChunk);
+            stack.push(current);
+            currentChunk = null;
+        }
 
         // chunks
         if (ElementTags.CHUNK.equals(name)) {
@@ -525,7 +525,7 @@ public class SAXiTextHandler<T extends XmlPeer> extends DefaultHandler {
         }
 
         String content = new String(ch, start, length);
-        if (content.trim().isEmpty() && content.indexOf(' ') < 0) {
+        if (content.trim().isEmpty()) {
             return;
         }
 

--- a/openpdf/src/main/java/com/lowagie/text/xml/SAXiTextHandler.java
+++ b/openpdf/src/main/java/com/lowagie/text/xml/SAXiTextHandler.java
@@ -226,21 +226,21 @@ public class SAXiTextHandler<T extends XmlPeer> extends DefaultHandler {
         }
 
         // maybe there is some meaningful data that wasn't between tags
-        if (currentChunk != null && isNotBlank(currentChunk.getContent())) {
-            TextElementArray current;
-            try {
-                current = (TextElementArray) stack.pop();
-            } catch (EmptyStackException ese) {
-                if (bf == null) {
-                    current = new Paragraph("", new Font());
-                } else {
-                    current = new Paragraph("", new Font(this.bf));
-                }
-            }
-            current.add(currentChunk);
-            stack.push(current);
-            currentChunk = null;
-        }
+//        if (currentChunk != null && isNotBlank(currentChunk.getContent())) {
+//            TextElementArray current;
+//            try {
+//                current = (TextElementArray) stack.pop();
+//            } catch (EmptyStackException ese) {
+//                if (bf == null) {
+//                    current = new Paragraph("", new Font());
+//                } else {
+//                    current = new Paragraph("", new Font(this.bf));
+//                }
+//            }
+//            current.add(currentChunk);
+//            stack.push(current);
+//            currentChunk = null;
+//        }
 
         // chunks
         if (ElementTags.CHUNK.equals(name)) {

--- a/openpdf/src/test/java/com/lowagie/text/html/SAXmyHtmlHandlerTest.java
+++ b/openpdf/src/test/java/com/lowagie/text/html/SAXmyHtmlHandlerTest.java
@@ -1,0 +1,50 @@
+package com.lowagie.text.html;
+import java.io.InputStream;
+
+import com.lowagie.text.Document;
+import org.junit.jupiter.api.Test;
+
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.fail;
+
+/**
+ * This test class contains a series of smoke tests. The goal of these tests is not validate the generated document,
+ * but to ensure no exception is thrown.
+ */
+public class SAXmyHtmlHandlerTest {
+
+    /**
+     * Test scenario: a html file with a title will not generate.
+     */
+    @Test
+    void testTitle_generate() {
+        InputStream is = SAXmyHtmlHandlerTest.class.getClassLoader().getResourceAsStream("parseTitle.html");
+        parseHtml(is);
+    }
+
+
+    /**
+     * Test scenario: a html file with a table will generate like html webpage.
+     */
+    @Test
+    void testTable_generate() {
+        InputStream is = SAXmyHtmlHandlerTest.class.getClassLoader().getResourceAsStream("parseTable.html");
+        parseHtml(is);
+    }
+
+    /**
+     * Parse the input HTML file to PDF file.
+     * @param is The input stream of the HTML file.
+     */
+    void parseHtml(InputStream is) {
+        try {
+            Document doc1 = new Document();
+            doc1.open();
+            HtmlParser.parse(doc1,is);
+            assertNotNull(doc1, () -> is + " was not parsed successfully");
+        } catch (Exception e) {
+            fail(() -> is + " resulted in " + e);
+        }
+    }
+}

--- a/openpdf/src/test/resources/parseTable.html
+++ b/openpdf/src/test/resources/parseTable.html
@@ -1,0 +1,44 @@
+<html>
+<head>
+  <title>Test</title>
+</head>
+<body>
+<br/>
+<table>
+  <tr>  <!--test-->
+    <td rowspan="4">line 1</td>
+    <td rowspan="4">line 2</td>
+    <td>line 3</td>
+    <td>line 4</td>
+    <td>line 5</td>
+    <td>line 6</td>
+    <td>line 7</td>
+    <td>line 8</td>
+  </tr>
+  <tr>
+    <td>line 3</td>
+    <td>line 4</td>
+    <td>line 5</td>
+    <td>line 6</td>
+    <td>line 7</td>
+    <td>line 8</td>
+  </tr>
+  <tr>
+    <td>line 3</td>
+    <td>line 4</td>
+    <td>line 5</td>
+    <td>line 6</td>
+    <td>line 7</td>
+    <td>line 8</td>
+  </tr>
+  <tr>
+    <td>line 3</td>
+    <td>line 4</td>
+    <td>line 5</td>
+    <td>line 6</td>
+    <td>line 7</td>
+    <td>line 8</td>
+  </tr>
+</table>
+</body>
+</html>

--- a/openpdf/src/test/resources/parseTitle.html
+++ b/openpdf/src/test/resources/parseTitle.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8"/>
+    <title>Title</title>
+</head>
+<body>
+    <p>This is a test</p>
+    <p>This is a test2</p>
+</body>
+</html>

--- a/pdf-toolbox/src/test/java/com/lowagie/examples/html/ParseTableHtml.java
+++ b/pdf-toolbox/src/test/java/com/lowagie/examples/html/ParseTableHtml.java
@@ -1,0 +1,53 @@
+/*
+ * $Id: HelloHtml.java 3373 2008-05-12 16:21:24Z xlv $
+ *
+ * This code is part of the 'OpenPDF Tutorial'.
+ * You can find the complete tutorial at the following address:
+ * https://github.com/LibrePDF/OpenPDF/wiki/Tutorial
+ *
+ * This code is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ *
+ */
+
+package com.lowagie.examples.html;
+
+import com.lowagie.text.Document;
+import com.lowagie.text.DocumentException;
+import com.lowagie.text.html.HtmlParser;
+import com.lowagie.text.pdf.PdfWriter;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+
+/**
+ * Generates a simple table HTML page.
+ *
+ * @author chappyer
+ */
+
+public class ParseTableHtml {
+
+    /**
+     * Generates an HTML page with a table
+     *
+     * @param args no arguments needed here
+     */
+    public static void main(String[] args) {
+        System.out.println("Parse ParseTable");
+
+        // step 1: creation of a document-object
+        try (Document document = new Document()) {
+            PdfWriter.getInstance(document, Files.newOutputStream(Paths.get("parseTable.pdf")));
+            // step 2: we open the document
+            document.open();
+            // step 3: parsing the HTML document to convert it in PDF
+            HtmlParser.parse(document, ParseHelloHtml.class.getClassLoader().getResourceAsStream("com/lowagie/examples/html/parseTable.html"));
+        } catch (DocumentException | IOException de) {
+            System.err.println(de.getMessage());
+        }
+    }
+}

--- a/pdf-toolbox/src/test/java/com/lowagie/examples/html/ParseTitleHtml.java
+++ b/pdf-toolbox/src/test/java/com/lowagie/examples/html/ParseTitleHtml.java
@@ -1,0 +1,52 @@
+/*
+ * $Id: HelloHtml.java 3373 2008-05-12 16:21:24Z xlv $
+ *
+ * This code is part of the 'OpenPDF Tutorial'.
+ * You can find the complete tutorial at the following address:
+ * https://github.com/LibrePDF/OpenPDF/wiki/Tutorial
+ *
+ * This code is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ *
+ */
+
+package com.lowagie.examples.html;
+
+import com.lowagie.text.Document;
+import com.lowagie.text.DocumentException;
+import com.lowagie.text.html.HtmlParser;
+import com.lowagie.text.pdf.PdfWriter;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+
+/**
+ * Generates a simple HTML page which contains a title.
+ *
+ * @author chappyer
+ */
+
+public class ParseTitleHtml {
+
+    /**
+     * Generates an HTML page which contains a title
+     *
+     * @param args no arguments needed here
+     */
+    public static void main(String[] args) {
+
+        // step 1: creation of a document-object
+        try (Document document = new Document()) {
+            PdfWriter.getInstance(document, Files.newOutputStream(Paths.get("parseTitle.pdf")));
+            // step 2: we open the document
+            document.open();
+            // step 3: parsing the HTML document to convert it in PDF
+            HtmlParser.parse(document, ParseHelloHtml.class.getClassLoader().getResourceAsStream("com/lowagie/examples/html/parseTitle.html"));
+        } catch (DocumentException | IOException de) {
+            de.printStackTrace();
+        }
+    }
+}

--- a/pdf-toolbox/src/test/resources/com/lowagie/examples/html/parseTable.html
+++ b/pdf-toolbox/src/test/resources/com/lowagie/examples/html/parseTable.html
@@ -1,0 +1,16 @@
+<html>
+<head>
+  <title>Test</title>
+</head>
+<body>
+<table>
+  <tr>
+    <td>line 3</td>
+    <td>line 4</td>
+    <td>line 4</td>
+    <td>line 4</td>
+    <td>line 4</td>
+  </tr>
+</table>
+</body>
+</html>

--- a/pdf-toolbox/src/test/resources/com/lowagie/examples/html/parseTitle.html
+++ b/pdf-toolbox/src/test/resources/com/lowagie/examples/html/parseTitle.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8"/>
+    <title>Title</title>
+</head>
+<body>
+    <p>This is a test</p>
+    <p>This is a test2</p>
+</body>
+</html>


### PR DESCRIPTION
## Description of the Bugfix
This pull request mainly solves two problems
- Problem1
When converting a html file to a pdf file, the layout of the generated file should be the same as the layout of the html file, so the content between title tag in html file should not write in pdf file. 
- Problem2
There are some unnecessary spaces in the generated pdf file, which causes the layout of the generated pdf file wrong.

Related Issue: #706

## Unit-Tests for the new Feature/Bugfix
- [ ] Unit-Tests added to reproduce the bug

## Compatibilities Issues
There are no compatibility problems with the new code so far

## Testing details
- Two scenario test to reproduce scenario of the bug
- Two junit smoke test to test whether PDF documents can be generated correctly