### PR TITLE
Issue 720: Fixed Null Pointer Exception

### DIFF
--- a/openpdf/src/main/java/com/lowagie/text/pdf/PdfReader.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/PdfReader.java
@@ -3730,6 +3730,8 @@ public class PdfReader implements PdfViewerPreferences, Closeable {
 
     private void iteratePages(PRIndirectReference rpage) {
       PdfDictionary page = (PdfDictionary) getPdfObject(rpage);
+      if (page == null)
+        return;
       PdfArray kidsPR = page.getAsArray(PdfName.KIDS);
       // reference to a leaf
       if (kidsPR == null) {


### PR DESCRIPTION
## Description of the new Feature/Bugfix
Prevents NullPointerException on some PDFs

Related Issue: #720 

## Unit-Tests for the new Feature/Bugfix
- [ ] Unit-Tests added to reproduce the bug
- [ ] Unit-Tests added to the added feature

## Compatibilities Issues
I don't think so. I created breakpoint at `PdfArray kidsPR = page.getAsArray(PdfName.KIDS);`
and when `PdfDictionary page` was null I forced a return, so that the programm wouldn't hit the NullPointerException.
Then the PDF could be read and was processed by my application.

## Testing details
Sorry for not providing a test file here, but the PDF contains some sensitive data which I'm not allowed to share.

