### PR TITLE
Add linebreak after Content Stream

### DIFF
--- a/openpdf/src/main/java/com/lowagie/text/pdf/parser/PdfContentReaderTool.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/parser/PdfContentReaderTool.java
@@ -153,7 +153,7 @@ public class PdfContentReaderTool {
             out.print((char) ch);
         }
 
-        out.println("- - - - - Text Extraction - - - - - -");
+        out.println("\n- - - - - Text Extraction - - - - - -");
         PdfTextExtractor extractor = new PdfTextExtractor(reader,
                 new MarkedUpTextAssembler(reader));
         String extractedText = extractor.getTextFromPage(pageNum);


### PR DESCRIPTION
This adds a linebreak after the Stream Content so that the "Text Exctraction" heading stands in a new line.

In its current state, the heading for "Text Extraction" would directly be appended to the same line where the Content Stream ends.

## Description of the new Feature/Bugfix
I just added a new line before the "Text Extraction" Heading

## Compatibilities Issues
I do not assume there to be any compatibility issues
