### PR TITLE
Update Bouncy Castle dependency to version 1.71.  

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,9 +131,9 @@ See: [wiki](https://github.com/LibrePDF/OpenPDF/wiki/Accents,-DIN-91379,-non-Lat
 
 - [BouncyCastle](https://www.bouncycastle.org/) (BouncyCastle is used to sign PDF files, so it's a recommended
   dependency)
-    - Provider (`org.bouncycastle:bcprov-jdk15on` or `org.bouncycastle:bcprov-ext-jdk15on` depending
+    - Provider (`org.bouncycastle:bcprov-jdk18on` or `org.bouncycastle:bcprov-ext-jdk18on` depending
       on which algorithm you are using)
-    - PKIX/CMS (`org.bouncycastle:bcpkix-jdk15on`)
+    - PKIX/CMS (`org.bouncycastle:bcpkix-jdk18on`)
 - Apache FOP (`org.apache.xmlgraphics:fop`)
 - Please refer to our [pom.xml](pom.xml) to see what version is needed.
 

--- a/openpdf/pom.xml
+++ b/openpdf/pom.xml
@@ -27,12 +27,12 @@
         </dependency>
         <dependency>
             <groupId>org.bouncycastle</groupId>
-            <artifactId>bcprov-jdk15on</artifactId>
+            <artifactId>bcprov-jdk18on</artifactId>
             <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>org.bouncycastle</groupId>
-            <artifactId>bcpkix-jdk15on</artifactId>
+            <artifactId>bcpkix-jdk18on</artifactId>
             <optional>true</optional>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@
         <pitmp-maven-plugin.version>1.3.7</pitmp-maven-plugin.version>
 
         <!-- dependencies -->
-        <bouncycastle.version>1.70</bouncycastle.version>
+        <bouncycastle.version>1.71</bouncycastle.version>
         <commons-io.version>2.11.0</commons-io.version>
         <dom4j.version>2.1.3</dom4j.version>
         <fop.version>2.7</fop.version>
@@ -99,12 +99,12 @@
         <dependencies>
             <dependency>
                 <groupId>org.bouncycastle</groupId>
-                <artifactId>bcprov-jdk15on</artifactId>
+                <artifactId>bcprov-jdk18on</artifactId>
                 <version>${bouncycastle.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.bouncycastle</groupId>
-                <artifactId>bcpkix-jdk15on</artifactId>
+                <artifactId>bcpkix-jdk18on</artifactId>
                 <version>${bouncycastle.version}</version>
             </dependency>
             <dependency>
@@ -374,7 +374,7 @@
                     <!--Need this because dep is optional and pitest can't find classes-->
                     <dependency>
                         <groupId>org.bouncycastle</groupId>
-                        <artifactId>bcprov-jdk15on</artifactId>
+                        <artifactId>bcprov-jdk18on</artifactId>
                         <version>${bouncycastle.version}</version>
                     </dependency>
                 </dependencies>


### PR DESCRIPTION
Update Bouncy Castle dependency to version 1.71.  
Use version of Bouncy Castle for JDK 1.8 and later, instead of JDK 1.5 and later.

https://www.bouncycastle.org/releasenotes.html#r1rv71