### PR TITLE
fix dictionary casting for issue #729

### DIFF
--- a/openpdf/src/main/java/com/lowagie/text/pdf/PdfWriter.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/PdfWriter.java
@@ -2489,7 +2489,7 @@ public class PdfWriter extends DocWriter implements
         PdfArray arr = new PdfArray();
         for (PdfOCG o : documentOCG) {
             PdfLayer layer = (PdfLayer) o;
-            PdfDictionary usage = (PdfDictionary) layer.get(PdfName.USAGE);
+            PdfDictionary usage = layer.getAsDict(PdfName.USAGE);
             if (usage != null && usage.get(category) != null)
                 arr.add(layer.getRef());
         }


### PR DESCRIPTION
## Description of the new Feature/Bugfix

Used another way to cast the PdfLayer info to a dictonary 
using the getasdictionary method.

Related Issue: #729

## Unit-Tests for the new Feature/Bugfix
- [ ] Unit-Tests added to reproduce the bug
- [ ] Unit-Tests added to the added feature

## Compatibilities Issues
Is anything broken because of the new code? Any changes in method signatures?

## Testing details
Any other details about how to test the new feature or bugfix?
