### PR TITLE
Improve monospaced font mapping on Windows and Linux

### DIFF
--- a/openpdf/src/main/java/com/lowagie/text/pdf/DefaultFontMapper.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/DefaultFontMapper.java
@@ -127,10 +127,9 @@ public class DefaultFontMapper implements FontMapper {
         return BaseFont.createFont(p.fontName, p.encoding, p.embedded, p.cached, p.ttfAfm, p.pfb);
       }
       final String fontKey;
-      final String logicalName = font.getName();
+      final String logicalName = font.getName().toLowerCase();
 
-      if (logicalName.equalsIgnoreCase("DialogInput") || logicalName.equalsIgnoreCase("Monospaced") || logicalName
-          .equalsIgnoreCase("Courier")) {
+      if (logicalName.equals("dialoginput") || logicalName.contains("mono") || logicalName.startsWith("courier")) {
 
         if (font.isItalic()) {
           if (font.isBold()) {
@@ -149,7 +148,7 @@ public class DefaultFontMapper implements FontMapper {
           }
         }
 
-      } else if (logicalName.equalsIgnoreCase("Serif") || logicalName.equalsIgnoreCase("TimesRoman")) {
+      } else if (logicalName.equals("serif") || logicalName.equals("timesroman")) {
 
         if (font.isItalic()) {
           if (font.isBold()) {


### PR DESCRIPTION
## Description of the new Feature/Bugfix
The `DefaultFontMapper` attempts to map awt font to PDF fonts. Even if the `Graphics2D` code explicitly sets the font to `Font.MONOSPACED` the font might get converted to a different font family in the `CompositeFontDrawer`.

On Windows it was converted to `Courier New`.
On Linux it was converted to `DejaVu San Mono`

In those cases the `HELVETICA` was used rather than `COURIER` which causes the font spacing to be incorrect on the PDF.

This PR changes to logic to catch those additional monospaced fonts out of the box without the need to create a new `FontMapper`.

## Unit-Tests for the new Feature/Bugfix
- [ ] Unit-Tests added to reproduce the bug
- [ ] Unit-Tests added to the added feature

## Compatibilities Issues
Is anything broken because of the new code? Any changes in method signatures?

The logic changes does not affect any previous font name matches. 

## Testing details
Any other details about how to test the new feature or bugfix?
