### PR TITLE
Fix bug in setBottom method with alignment setting

### DIFF
--- a/openpdf/src/main/java/com/lowagie/text/html/simpleparser/IncCell.java
+++ b/openpdf/src/main/java/com/lowagie/text/html/simpleparser/IncCell.java
@@ -78,6 +78,10 @@ public class IncCell implements TextElementArray {
                 .flatMap(NumberUtilities::parseInt)
                 .ifPresent(cell::setColspan);
 
+        props.findProperty("rowspan").
+                flatMap(NumberUtilities::parseInt)
+                .ifPresent(cell::setRowspan);
+
         if (tag.equals("th")) {
             cell.setHorizontalAlignment(Element.ALIGN_CENTER);
         }

--- a/openpdf/src/main/java/com/lowagie/text/pdf/PdfCell.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/PdfCell.java
@@ -384,6 +384,7 @@ public class PdfCell extends Rectangle {
         extraHeight += getBorderWidthInside(TOP);
         if (firstLine != null) {
             firstLine.height = firstLineRealHeight + extraHeight;
+            contentHeight += extraHeight;
         }
     }
 

--- a/openpdf/src/test/java/com/lowagie/text/html/HtmlTableTest.java
+++ b/openpdf/src/test/java/com/lowagie/text/html/HtmlTableTest.java
@@ -1,0 +1,50 @@
+package com.lowagie.text.html;
+
+import com.lowagie.text.Document;
+import com.lowagie.text.html.simpleparser.HTMLWorker;
+import org.junit.jupiter.api.Test;
+import java.io.StringReader;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.fail;
+
+public class HtmlTableTest {
+    /**
+     * Bug fix scenario: a table with rowspan doesn't work
+     */
+    @Test
+    void testRolspan() {
+        String code = "<td rowspan=\"4\">line 1</td>";
+        String html = String.format(code);
+        testParse(html);
+    }
+
+    /**
+     * Bug fix scenario: a table with colspan doesn't work
+     */
+    @Test
+    void testColspan() {
+        String code = "<td colspan=\"2\">line 1</td>";
+        String html = String.format(code);
+        testParse(html);
+    }
+
+    /**
+     * parse an html string to convert to pdf
+     *
+     * @param html input html string for conversion
+     */
+    void testParse(String html) {
+        try {
+            Document doc = new Document();
+            doc.open();
+            HTMLWorker worker = new HTMLWorker(doc);
+            worker.parse(new StringReader(html));
+            assertNotNull(doc, () -> html + " was not parsed successfully");
+        } catch (Exception e) {
+            e.printStackTrace();
+            fail(() -> html + " resulted in " + e);
+        }
+    }
+}
+

--- a/pdf-toolbox/src/test/java/com/lowagie/examples/html/SpanTableHtml.java
+++ b/pdf-toolbox/src/test/java/com/lowagie/examples/html/SpanTableHtml.java
@@ -1,0 +1,55 @@
+package com.lowagie.examples.html;
+
+import com.lowagie.text.Document;
+import com.lowagie.text.PageSize;
+import com.lowagie.text.html.simpleparser.HTMLWorker;
+import com.lowagie.text.pdf.PdfWriter;
+
+import java.io.*;
+
+public class SpanTableHtml {
+    public static void main(String[] args) {
+        testRowspan(args);
+        testColspan(args);
+    }
+
+    public static void testRowspan(String[] args) {
+        Document doc = new Document(PageSize.A4);
+        PdfWriter writer = null;
+        try {
+            File out = new File("testOut1.pdf");
+            writer = PdfWriter.getInstance(doc, new FileOutputStream(out));
+            doc.open();
+            InputStream stream = SpanTableHtml.class.getResourceAsStream("example1forHTMLWorker.html");
+            HTMLWorker worker = new HTMLWorker(doc);
+            worker.parse(new InputStreamReader(stream));
+        } catch (IOException e) {
+            e.printStackTrace();
+        } finally {
+            doc.close();
+            if (writer != null) {
+                writer.close();
+            }
+        }
+    }
+
+    public static void testColspan(String[] args) {
+        Document doc = new Document(PageSize.A4);
+        PdfWriter writer = null;
+        try {
+            File out = new File("testOut2.pdf");
+            writer = PdfWriter.getInstance(doc, new FileOutputStream(out));
+            doc.open();
+            InputStream stream = SpanTableHtml.class.getResourceAsStream("example2forHTMLWorker.html");
+            HTMLWorker worker = new HTMLWorker(doc);
+            worker.parse(new InputStreamReader(stream));
+        } catch (IOException e) {
+            e.printStackTrace();
+        } finally {
+            doc.close();
+            if (writer != null) {
+                writer.close();
+            }
+        }
+    }
+}

--- a/pdf-toolbox/src/test/java/com/lowagie/examples/html/SpanTableHtml.java
+++ b/pdf-toolbox/src/test/java/com/lowagie/examples/html/SpanTableHtml.java
@@ -6,23 +6,28 @@ import com.lowagie.text.html.simpleparser.HTMLWorker;
 import com.lowagie.text.pdf.PdfWriter;
 
 import java.io.*;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 
 public class SpanTableHtml {
-    public static void main(String[] args) {
-        testRowspan(args);
-        testColspan(args);
+    public static void main(String[] args) throws IOException {
+        testRowspan();
+        testColspan();
     }
 
-    public static void testRowspan(String[] args) {
+    /**
+     * Converts an HTML page to pdf with the table containing rolspan tags
+     */
+    public static void testRowspan() {
         Document doc = new Document(PageSize.A4);
         PdfWriter writer = null;
         try {
-            File out = new File("testOut1.pdf");
-            writer = PdfWriter.getInstance(doc, new FileOutputStream(out));
+            writer = PdfWriter.getInstance(doc, Files.newOutputStream(Paths.get("testRowspanOut.pdf")));
             doc.open();
             InputStream stream = SpanTableHtml.class.getResourceAsStream("example1forHTMLWorker.html");
             HTMLWorker worker = new HTMLWorker(doc);
-            worker.parse(new InputStreamReader(stream));
+            worker.parse(new InputStreamReader(stream,"UTF-8"));
+            assert(true);
         } catch (IOException e) {
             e.printStackTrace();
         } finally {
@@ -33,16 +38,19 @@ public class SpanTableHtml {
         }
     }
 
-    public static void testColspan(String[] args) {
+    /**
+     * Converts an HTML page to pdf with the table containing colspan tags
+     */
+    public static void testColspan() {
         Document doc = new Document(PageSize.A4);
         PdfWriter writer = null;
         try {
-            File out = new File("testOut2.pdf");
-            writer = PdfWriter.getInstance(doc, new FileOutputStream(out));
+            writer = PdfWriter.getInstance(doc, Files.newOutputStream(Paths.get("testColspanOut.pdf")));
             doc.open();
             InputStream stream = SpanTableHtml.class.getResourceAsStream("example2forHTMLWorker.html");
             HTMLWorker worker = new HTMLWorker(doc);
-            worker.parse(new InputStreamReader(stream));
+            worker.parse(new InputStreamReader(stream,"UTF-8"));
+            assert(true);
         } catch (IOException e) {
             e.printStackTrace();
         } finally {

--- a/pdf-toolbox/src/test/resources/com/lowagie/examples/html/example1forHTMLWorker.html
+++ b/pdf-toolbox/src/test/resources/com/lowagie/examples/html/example1forHTMLWorker.html
@@ -1,0 +1,45 @@
+<html>
+<head>
+    <title>Test</title>
+</head>
+<body>
+<b>Test</b>
+<br/>
+<table>
+    <tr>
+        <td rowspan="4" valign="top" align="right">line 1</td>
+        <td rowspan="4" valign="top" align="right">line 2</td>
+        <td valign="top" align="right">line 3</td>
+        <td valign="top" align="right">line 4</td>
+        <td valign="top" align="right">line 5</td>
+        <td valign="top" align="right">line 6</td>
+        <td valign="top" align="right">line 7</td>
+        <td valign="top" align="right">line 8</td>
+    </tr>
+    <tr>
+        <td valign="top" align="right">line 3</td>
+        <td valign="top" align="right">line 4</td>
+        <td valign="top" align="right">line 5</td>
+        <td valign="top" align="right">line 6</td>
+        <td valign="top" align="right">line 7</td>
+        <td valign="top" align="right">line 8</td>
+    </tr>
+    <tr>
+        <td valign="top" align="right">line 3</td>
+        <td valign="top" align="right">line 4</td>
+        <td valign="top" align="right">line 5</td>
+        <td valign="top" align="right">line 6</td>
+        <td valign="top" align="right">line 7</td>
+        <td valign="top" align="right">line 8</td>
+    </tr>
+    <tr>
+        <td valign="top" align="right">line 3</td>
+        <td valign="top" align="right">line 4</td>
+        <td valign="top" align="right">line 5</td>
+        <td valign="top" align="right">line 6</td>
+        <td valign="top" align="right">line 7</td>
+        <td valign="top" align="right">line 8</td>
+    </tr>
+</table>
+</body>
+</html>

--- a/pdf-toolbox/src/test/resources/com/lowagie/examples/html/example2forHTMLWorker.html
+++ b/pdf-toolbox/src/test/resources/com/lowagie/examples/html/example2forHTMLWorker.html
@@ -1,0 +1,43 @@
+<html>
+<head>
+    <title>Test</title>
+</head>
+<body>
+<b>Test</b>
+<br/>
+<table>
+    <tr>
+        <td colspan="2" valign="top" align="right">line 1</td>
+        <td valign="top" align="right">line 2</td>
+        <td valign="top" align="right">line 3</td>
+        <td valign="top" align="right">line 4</td>
+        <td valign="top" align="right">line 5</td>
+    </tr>
+    <tr>
+        <td valign="top" align="right">line 1</td>
+        <td valign="top" align="right">line 2</td>
+        <td valign="top" align="right">line 3</td>
+        <td valign="top" align="right">line 4</td>
+        <td valign="top" align="right">line 5</td>
+        <td valign="top" align="right">line 6</td>
+    </tr>
+    <tr>
+        <td valign="top" align="right">line 1</td>
+        <td valign="top" align="right">line 2</td>
+        <td valign="top" align="right">line 3</td>
+        <td valign="top" align="right">line 4</td>
+        <td valign="top" align="right">line 5</td>
+        <td valign="top" align="right">line 6</td>
+    </tr>
+    <tr>
+        <td valign="top" align="right">line 1</td>
+        <td valign="top" align="right">line 2</td>
+        <td valign="top" align="right">line 3</td>
+        <td valign="top" align="right">line 4</td>
+        <td valign="top" align="right">line 5</td>
+        <td valign="top" align="right">line 6</td>
+    </tr>
+</table>
+</body>
+</html>
+


### PR DESCRIPTION
## Description of the new Feature/Bugfix
The strange layout or endless loop is caused by wrong position of the first line in cell which sets alignment not as TOP.  After searching the codes deeper, I find it forgets to change contentHeight after modifying line.height with adding correct alignment space. In this way, I just add the missing part on contentHeight for the first line and it works perfectly!

Related Issue: #747

## Unit-Tests for the new Feature/Bugfix
```
public static void test() throws FileNotFoundException {
	Document document = new Document(PageSize.A4);
	PdfWriter writer = PdfWriter.getInstance(document, new FileOutputStream("test.pdf"));
	Table table = new Table(2);
	Cell cell = new Cell("any text\nany text\nany text\nany text\nany text\nany text");
	cell.setVerticalAlignment(VerticalAlignment.BOTTOM);
	table.addCell(cell);
	StringBuilder largeStr = new StringBuilder();
	for (int i = 0; i < 45; i++) {
		largeStr.append(String.format("this is to test-> row %d\n", i));
	}
	Cell cell2 = new Cell(new Phrase(largeStr.toString()));
	table.addCell(cell2);
	document.open();
	document.add(table);
	document.close();
}
```
### Before fixing:
<img width="234" alt="image" src="https://user-images.githubusercontent.com/75869809/170850955-c22f962a-ef97-44a8-8259-8f4471ef6141.png">
### After fixing:
<img width="210" alt="Screen Shot 2022-05-29 at 11 39 02 AM" src="https://user-images.githubusercontent.com/75869809/170850972-c06fe073-7f88-4393-a15a-539349e2a717.png">

## Compatibilities Issues
There are no compatibility problems with the new code so far.

## Testing details
I create two test scenario tests to reproduce scenario of the bug.
