### PR TITLE
Issue747: fix wrong layout of generating a table with alignment setting

### DIFF
--- a/openpdf/src/main/java/com/lowagie/text/pdf/PdfCell.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/PdfCell.java
@@ -384,6 +384,7 @@ public class PdfCell extends Rectangle {
         extraHeight += getBorderWidthInside(TOP);
         if (firstLine != null) {
             firstLine.height = firstLineRealHeight + extraHeight;
+            contentHeight += extraHeight;
         }
     }
 

--- a/openpdf/src/test/java/com/lowagie/text/pdf/table/TableEndlessTest.java
+++ b/openpdf/src/test/java/com/lowagie/text/pdf/table/TableEndlessTest.java
@@ -1,0 +1,62 @@
+package com.lowagie.text.pdf.table;
+
+import com.lowagie.text.*;
+import com.lowagie.text.alignment.VerticalAlignment;
+import com.lowagie.text.pdf.PdfWriter;
+import org.junit.jupiter.api.Test;
+
+import java.io.FileOutputStream;
+
+import static java.time.Duration.*;
+import static org.junit.jupiter.api.Assertions.assertTimeout;
+
+public class TableEndlessTest {
+
+    /**
+     * Bug fix scenario: a table with setting alignment as bottom enters endless loop
+     */
+    @Test
+    void testNoEndlessLoopWithBottom() {
+        assertTimeout(ofSeconds(10), () -> {
+            Document document = new Document(PageSize.A4);
+            PdfWriter writer = PdfWriter.getInstance(document, new FileOutputStream("test.pdf"));
+            Table table = new Table(2);
+            Cell cell1 = new Cell("any text");
+            cell1.setVerticalAlignment(VerticalAlignment.BOTTOM);
+            table.addCell(cell1);
+            StringBuilder largeStr = new StringBuilder();
+            for (int i = 0; i < 45; i++) {
+                largeStr.append(String.format("this is to test-> row %d\n", i));
+            }
+            Cell cell2 = new Cell(new Phrase(largeStr.toString()));
+            table.addCell(cell2);
+            document.open();
+            document.add(table);
+            document.close();
+        });
+    }
+
+    /**
+     * Bug fix scenario: a table with setting alignment as center enters endless loop
+     */
+    @Test
+    void testNoEndlessLoopWithCenter() {
+        assertTimeout(ofSeconds(10), () -> {
+            Document document = new Document(PageSize.A4);
+            PdfWriter writer = PdfWriter.getInstance(document, new FileOutputStream("test.pdf"));
+            Table table = new Table(2);
+            Cell cell1 = new Cell("any text\nany text\nany text");
+            cell1.setVerticalAlignment(VerticalAlignment.CENTER);
+            table.addCell(cell1);
+            StringBuilder largeStr = new StringBuilder();
+            for (int i = 0; i < 86; i++) {
+                largeStr.append(String.format("this is to test-> row %d\n", i));
+            }
+            Cell cell2 = new Cell(new Phrase(largeStr.toString()));
+            table.addCell(cell2);
+            document.open();
+            document.add(table);
+            document.close();
+        });
+    }
+}


### PR DESCRIPTION
## Description of the new Feature/Bugfix
The strange layout or endless loop is caused by wrong position of the first line in cell which sets alignment not as TOP.  After searching the codes deeper, I find it forgets to change contentHeight after modifying line.height with adding correct alignment space. In this way, I just add the missing part on contentHeight for the first line and it works perfectly!

Related Issue: #747

## Unit-Tests for the new Feature/Bugfix
```
public static void test() throws FileNotFoundException {
	Document document = new Document(PageSize.A4);
	PdfWriter writer = PdfWriter.getInstance(document, new FileOutputStream("test.pdf"));
	Table table = new Table(2);
	Cell cell = new Cell("any text\nany text\nany text\nany text\nany text\nany text");
	cell.setVerticalAlignment(VerticalAlignment.BOTTOM);
	table.addCell(cell);
	StringBuilder largeStr = new StringBuilder();
	for (int i = 0; i < 45; i++) {
		largeStr.append(String.format("this is to test-> row %d\n", i));
	}
	Cell cell2 = new Cell(new Phrase(largeStr.toString()));
	table.addCell(cell2);
	document.open();
	document.add(table);
	document.close();
}
```
### Before fixing:
<img width="234" alt="image" src="https://user-images.githubusercontent.com/75869809/170850955-c22f962a-ef97-44a8-8259-8f4471ef6141.png">

### After fixing:
<img width="210" alt="Screen Shot 2022-05-29 at 11 39 02 AM" src="https://user-images.githubusercontent.com/75869809/170850972-c06fe073-7f88-4393-a15a-539349e2a717.png">

## Compatibilities Issues
There are no compatibility problems with the new code so far.

## Testing details
I create two Junit tests to examine.