### PR TITLE
Issue619: add support for rowspan

### DIFF
--- a/openpdf/src/main/java/com/lowagie/text/html/simpleparser/IncCell.java
+++ b/openpdf/src/main/java/com/lowagie/text/html/simpleparser/IncCell.java
@@ -78,6 +78,10 @@ public class IncCell implements TextElementArray {
                 .flatMap(NumberUtilities::parseInt)
                 .ifPresent(cell::setColspan);
 
+        props.findProperty("rowspan").
+                flatMap(NumberUtilities::parseInt)
+                .ifPresent(cell::setRowspan);
+
         if (tag.equals("th")) {
             cell.setHorizontalAlignment(Element.ALIGN_CENTER);
         }

--- a/openpdf/src/test/java/com/lowagie/text/html/HTMLTableTest.java
+++ b/openpdf/src/test/java/com/lowagie/text/html/HTMLTableTest.java
@@ -1,0 +1,49 @@
+package com.lowagie.text.html;
+
+import com.lowagie.text.Document;
+import com.lowagie.text.html.simpleparser.HTMLWorker;
+import org.junit.jupiter.api.Test;
+import java.io.StringReader;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.fail;
+
+public class HTMLTableTest {
+    /**
+     * Bug fix scenario: a table with rowspan doesn't work
+     */
+    @Test
+    void testRolspan() {
+        String code = "<td rowspan=\"4\">line 1</td>";
+        String html = String.format(code);
+        testParse(html);
+    }
+
+    /**
+     * Bug fix scenario: a table with colspan doesn't work
+     */
+    @Test
+    void testColspan() {
+        String code = "<td colspan=\"2\">line 1</td>";
+        String html = String.format(code);
+        testParse(html);
+    }
+
+    /**
+     * parse an html string to convert to pdf
+     *
+     * @param html input html string for conversion
+     */
+    void testParse(String html) {
+        try {
+            Document doc = new Document();
+            doc.open();
+            HTMLWorker worker = new HTMLWorker(doc);
+            worker.parse(new StringReader(html));
+            assertNotNull(doc, () -> html + " was not parsed successfully");
+        } catch (Exception e) {
+            e.printStackTrace();
+            fail(() -> html + " resulted in " + e);
+        }
+    }
+}

--- a/pdf-toolbox/src/test/java/com/lowagie/examples/html/SpanTableHtml.java
+++ b/pdf-toolbox/src/test/java/com/lowagie/examples/html/SpanTableHtml.java
@@ -1,0 +1,63 @@
+package com.lowagie.examples.html;
+
+import com.lowagie.text.Document;
+import com.lowagie.text.PageSize;
+import com.lowagie.text.html.simpleparser.HTMLWorker;
+import com.lowagie.text.pdf.PdfWriter;
+
+import java.io.*;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+
+public class SpanTableHtml {
+    public static void main(String[] args) throws IOException {
+        testRowspan();
+        testColspan();
+    }
+
+    /**
+     * Converts an HTML page to pdf with the table containing rolspan tags
+     */
+    public static void testRowspan() {
+        Document doc = new Document(PageSize.A4);
+        PdfWriter writer = null;
+        try {
+            writer = PdfWriter.getInstance(doc, Files.newOutputStream(Paths.get("testRowspanOut.pdf")));
+            doc.open();
+            InputStream stream = SpanTableHtml.class.getResourceAsStream("example1forHTMLWorker.html");
+            HTMLWorker worker = new HTMLWorker(doc);
+            worker.parse(new InputStreamReader(stream,"UTF-8"));
+            assert(true);
+        } catch (IOException e) {
+            e.printStackTrace();
+        } finally {
+            doc.close();
+            if (writer != null) {
+                writer.close();
+            }
+        }
+    }
+
+    /**
+     * Converts an HTML page to pdf with the table containing colspan tags
+     */
+    public static void testColspan() {
+        Document doc = new Document(PageSize.A4);
+        PdfWriter writer = null;
+        try {
+            writer = PdfWriter.getInstance(doc, Files.newOutputStream(Paths.get("testColspanOut.pdf")));
+            doc.open();
+            InputStream stream = SpanTableHtml.class.getResourceAsStream("example2forHTMLWorker.html");
+            HTMLWorker worker = new HTMLWorker(doc);
+            worker.parse(new InputStreamReader(stream,"UTF-8"));
+            assert(true);
+        } catch (IOException e) {
+            e.printStackTrace();
+        } finally {
+            doc.close();
+            if (writer != null) {
+                writer.close();
+            }
+        }
+    }
+}

--- a/pdf-toolbox/src/test/resources/com/lowagie/examples/html/example1forHTMLWorker.html
+++ b/pdf-toolbox/src/test/resources/com/lowagie/examples/html/example1forHTMLWorker.html
@@ -1,0 +1,45 @@
+<html>
+<head>
+  <title>Test</title>
+</head>
+<body>
+<b>Test</b>
+<br/>
+<table>
+  <tr>
+    <td rowspan="4" valign="top" align="right">line 1</td>
+    <td rowspan="4" valign="top" align="right">line 2</td>
+    <td valign="top" align="right">line 3</td>
+    <td valign="top" align="right">line 4</td>
+    <td valign="top" align="right">line 5</td>
+    <td valign="top" align="right">line 6</td>
+    <td valign="top" align="right">line 7</td>
+    <td valign="top" align="right">line 8</td>
+  </tr>
+  <tr>
+    <td valign="top" align="right">line 3</td>
+    <td valign="top" align="right">line 4</td>
+    <td valign="top" align="right">line 5</td>
+    <td valign="top" align="right">line 6</td>
+    <td valign="top" align="right">line 7</td>
+    <td valign="top" align="right">line 8</td>
+  </tr>
+  <tr>
+    <td valign="top" align="right">line 3</td>
+    <td valign="top" align="right">line 4</td>
+    <td valign="top" align="right">line 5</td>
+    <td valign="top" align="right">line 6</td>
+    <td valign="top" align="right">line 7</td>
+    <td valign="top" align="right">line 8</td>
+  </tr>
+  <tr>
+    <td valign="top" align="right">line 3</td>
+    <td valign="top" align="right">line 4</td>
+    <td valign="top" align="right">line 5</td>
+    <td valign="top" align="right">line 6</td>
+    <td valign="top" align="right">line 7</td>
+    <td valign="top" align="right">line 8</td>
+  </tr>
+</table>
+</body>
+</html>

--- a/pdf-toolbox/src/test/resources/com/lowagie/examples/html/example2forHTMLWorker.html
+++ b/pdf-toolbox/src/test/resources/com/lowagie/examples/html/example2forHTMLWorker.html
@@ -1,0 +1,42 @@
+<html>
+<head>
+  <title>Test</title>
+</head>
+<body>
+<b>Test</b>
+<br/>
+<table>
+  <tr>
+    <td colspan="2" valign="top" align="right">line 1</td>
+    <td valign="top" align="right">line 2</td>
+    <td valign="top" align="right">line 3</td>
+    <td valign="top" align="right">line 4</td>
+    <td valign="top" align="right">line 5</td>
+  </tr>
+  <tr>
+    <td valign="top" align="right">line 1</td>
+    <td valign="top" align="right">line 2</td>
+    <td valign="top" align="right">line 3</td>
+    <td valign="top" align="right">line 4</td>
+    <td valign="top" align="right">line 5</td>
+    <td valign="top" align="right">line 6</td>
+  </tr>
+  <tr>
+    <td valign="top" align="right">line 1</td>
+    <td valign="top" align="right">line 2</td>
+    <td valign="top" align="right">line 3</td>
+    <td valign="top" align="right">line 4</td>
+    <td valign="top" align="right">line 5</td>
+    <td valign="top" align="right">line 6</td>
+  </tr>
+  <tr>
+    <td valign="top" align="right">line 1</td>
+    <td valign="top" align="right">line 2</td>
+    <td valign="top" align="right">line 3</td>
+    <td valign="top" align="right">line 4</td>
+    <td valign="top" align="right">line 5</td>
+    <td valign="top" align="right">line 6</td>
+  </tr>
+</table>
+</body>
+</html>


### PR DESCRIPTION
## Description of the new Feature/Bugfix
Describe here how you fixed the bug, or implemented the new feature.
Digging into the endElement method of HTMLworker class, I find there is something wrong with IncCell, which only adds the support for colspan of tr. In this way, I add one line of code in constructor of IncCell to imitate the setting of colspan to enable rowspan.

Related Issue: #619 

### Expected Result:
<img width="980" alt="Screen Shot 2022-04-26 at 9 17 04 PM" src="https://user-images.githubusercontent.com/75869809/165308544-797f1a1c-55fe-4e54-9323-c54c59804534.png">

### Wrong Result:
<img width="974" alt="Screen Shot 2022-04-26 at 9 15 40 PM" src="https://user-images.githubusercontent.com/75869809/165308872-a2cec4d4-ad22-4116-8a1d-8be3e3f77189.png">

## Unit-Tests for the new Feature/Bugfix
- [Y] Unit-Tests added to reproduce the bug

## Compatibilities Issues
Is anything broken because of the new code? Any changes in method signatures?
No, there is nothing broken because of the new code. No, there is no change in method signatures

## Testing details
Any other details about how to test the new feature or bugfix?
I reproduce the broken steps of nonsupport of rowspan.