### PR TITLE
Issue676: references in tag structure tree are incorrect

### DIFF
--- a/openpdf/src/main/java/com/lowagie/text/pdf/PdfStructureTreeRoot.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/PdfStructureTreeRoot.java
@@ -50,7 +50,6 @@ package com.lowagie.text.pdf;
 
 import java.io.IOException;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
 /**
@@ -122,10 +121,9 @@ public class PdfStructureTreeRoot extends PdfDictionary {
         PdfObject obj = dictionary.get(PdfName.K);
         if (obj != null && obj.isArray() && !((PdfArray) obj).getElements().get(0).isNumber()) {
             PdfArray ar = (PdfArray) obj;
-            List<PdfObject> a = ar.getElements();
-            for (int k = 0; k < a.size(); ++k) {
-                PdfStructureElement e = (PdfStructureElement) a.get(k);
-                a.set(k, e.getReference());
+            for (int k = 0; k < ar.size(); ++k) {
+                PdfStructureElement e = (PdfStructureElement) ar.getDirectObject(k);
+                ar.set(k, e.getReference());
                 nodeProcess(e, e.getReference());
             }
         }


### PR DESCRIPTION
## Description of the new Feature/Bugfix
The code to create indirect references in the tag structure tree was modifying a copy of the arrays rather than the arrays themselves.

Related Issue: #676

## Unit-Tests for the new Feature/Bugfix
None

## Compatibilities Issues
None

## Testing details
The Acrobat syntax checker no longer reports an error
