### PR TITLE
Skipping eliminateSharedStreams() method call.

### DIFF
--- a/openpdf/src/main/java/com/lowagie/text/pdf/PdfReader.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/PdfReader.java
@@ -625,7 +625,7 @@ public class PdfReader implements PdfViewerPreferences, Closeable {
 
       strings.clear();
       readPages();
-      eliminateSharedStreams();
+      //eliminateSharedStreams();
       removeUnusedObjects();
     } finally {
       try {


### PR DESCRIPTION
## Description of the new Feature/Bugfix
The change is that creating a PdfReader does not mean that the eliminateSharedStreams() method is called. This solves #763 which breaks certain PDF documents by doing this. Instead if elimination of shared streams is needed in some case the public method can be called explicitly.

Related Issue: #763

## Unit-Tests for the new Feature/Bugfix
- [ ] Unit-Tests added to reproduce the bug
- [ ] Unit-Tests added to the added feature

## Compatibilities Issues
Is anything broken because of the new code? Any changes in method signatures?
Method signatures are the same but if elimination of shared streams are required for some use case then this method needs to be called explicitly from now.

## Testing details
Any other details about how to test the new feature or bugfix?
Tested with PDF documents having this issue. See link to document in the ticket.