### PR TITLE
Errors in indentation and tab positions

### DIFF
--- a/openpdf/src/main/java/com/lowagie/text/pdf/PdfChunk.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/PdfChunk.java
@@ -537,6 +537,8 @@ public class PdfChunk {
  */
     
     float width() {
+        if (isAttribute(Chunk.TAB))
+            return 0.0f;
         if (isAttribute(Chunk.CHAR_SPACING)) {
             Float cs = (Float) getAttribute(Chunk.CHAR_SPACING);
             return font.width(value) + value.length() * cs;

--- a/openpdf/src/main/java/com/lowagie/text/pdf/PdfDocument.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/PdfDocument.java
@@ -457,6 +457,7 @@ public class PdfDocument extends Document {
                     // we cast the element to a chunk
                     PdfChunk chunk = new PdfChunk((Chunk) element, anchorAction);
                     // we try to add the chunk to the line, until we succeed
+                    if (!chunk.isTab())
                     {
                         PdfChunk overflow;
                         while ((overflow = line.add(chunk)) != null) {
@@ -465,6 +466,8 @@ public class PdfDocument extends Document {
                             chunk.trimFirstSpace();
                         }
                     }
+                    else
+                        line.add(chunk);
                     pageEmpty = false;
                     if (chunk.isAttribute(Chunk.NEWPAGE)) {
                         newPage();
@@ -3159,7 +3162,7 @@ public class PdfDocument extends Document {
                 // if there is still text to render we render it
                 if (lines != null && !lines.isEmpty()) {
                     // we write the text
-                    float cellTop = cell.getTop(ctx.pagetop - ctx.oldHeight);
+                    float cellTop = cell.getTop(ctx.pagetop - ctx.oldHeight - 5f/*adjust for decent size*/);
                     text.moveText(0, cellTop);
                     float cellDisplacement = flushLines() - cellTop;
 

--- a/openpdf/src/main/java/com/lowagie/text/pdf/PdfLine.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/PdfLine.java
@@ -292,6 +292,8 @@ public class PdfLine {
     void setExtraIndent(float extra) {
         left += extra;
         width -= extra;
+        if (extra < 0.0f)
+            originalWidth -= extra;
     }
     
     /**


### PR DESCRIPTION
The widt() method of a TAB PdfChunk must return 0.0f to avoid it from advancing the position away from the given tab-position. It used to move to the right the width of the placeholder character in the chunk.

When using a negative value for setFirstLineIndent, the original width of the PdfLine must be adjusted.  If not, the calculation of the remaining width after inserting a TAB will be wrong. The result will be that the line may be broken at the wrong position, making both the first and second line too short.

Related Issue: #790
Related Issue: #791

## Compatibilities Issues
Existing code using TAB may have their position moved slightly to the left.

