### PR TITLE
Add optional metadata/info update in a sequential revision

### DIFF
--- a/openpdf/src/main/java/com/lowagie/text/pdf/PdfStamper.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/PdfStamper.java
@@ -884,4 +884,44 @@ public class PdfStamper
         this.stamper.setModificationDate(modificationDate);
     }
 
+    /**
+     * Returns whether the /Metadata dictionary should be updated in the new sequential PDF revision update
+     *
+     * @return if the /Metadata should be updated
+     */
+    public boolean isUpdateMetadata() {
+        return this.stamper.isUpdateMetadata();
+    }
+
+    /**
+     * Sets whether the /Metadata dictionary should be updated in a new sequential PDF revision update.
+     * The condition is applied only when a new revision is being appended (e.g. on a new signature addition).
+     * Default : TRUE (/Metadata dictionary is updated in a sequential revision update)
+     *
+     * @param updateMetadata if the /Metadata should be updated
+     */
+    public void setUpdateMetadata(boolean updateMetadata) {
+        this.stamper.setUpdateMetadata(updateMetadata);
+    }
+
+    /**
+     * Returns whether the document /Info dictionary should be updated in a sequential PDF revision update
+     *
+     * @return if the document /Info should be updated
+     */
+    public boolean isUpdateDocInfo() {
+        return this.stamper.isUpdateDocInfo();
+    }
+
+    /**
+     * Sets whether the document /Info dictionary should be updated in a sequential PDF revision update.
+     * The condition is applied only when a new revision is being appended (e.g. on a new signature addition).
+     * Default : TRUE (/Info dictionary is updated in a sequential revision update)
+     *
+     * @param updateDocInfo if the document /Info should be updated
+     */
+    public void setUpdateDocInfo(boolean updateDocInfo) {
+        this.stamper.setUpdateDocInfo(updateDocInfo);
+    }
+
 }

--- a/openpdf/src/test/java/com/lowagie/text/pdf/metadata/CleanMetaDataTest.java
+++ b/openpdf/src/test/java/com/lowagie/text/pdf/metadata/CleanMetaDataTest.java
@@ -9,12 +9,13 @@ import com.lowagie.text.pdf.PdfReader;
 import com.lowagie.text.pdf.PdfStamper;
 import com.lowagie.text.pdf.PdfWriter;
 import com.lowagie.text.xml.xmp.XmpWriter;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.util.HashMap;
 import java.util.Map;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
 
 public class CleanMetaDataTest {
   
@@ -132,6 +133,80 @@ public class CleanMetaDataTest {
     r.close();
     String dataString = new String(data);
     Assertions.assertFalse(dataString.contains("This example explains how to add metadata."));
+	}
+
+	@Test
+	public void skipMetaDataUpdateTest() throws Exception {
+		ByteArrayOutputStream baos = new ByteArrayOutputStream();
+		PdfReader reader = new PdfReader(new File("src/test/resources/HelloWorldMeta.pdf").getAbsolutePath());
+		PdfStamper stamp = new PdfStamper(reader, baos, '\0', true);
+		stamp.setUpdateMetadata(false);
+		stamp.cleanMetadata();
+		stamp.close();
+
+		String dataString = baos.toString();
+		Assertions.assertTrue(dataString.contains("This example explains how to add metadata."));
+	}
+
+	@Test
+	public void skipMetaDataUpdateFirstRevisionTest() throws Exception {
+		ByteArrayOutputStream baos = new ByteArrayOutputStream();
+		PdfReader reader = new PdfReader(new File("src/test/resources/HelloWorldMeta.pdf").getAbsolutePath());
+		PdfStamper stamp = new PdfStamper(reader, baos, '\0', false);
+		stamp.setUpdateMetadata(false);
+		stamp.cleanMetadata();
+		stamp.close();
+
+		String dataString = baos.toString();
+		Assertions.assertFalse(dataString.contains("This example explains how to add metadata."));
+	}
+
+	@Test
+	public void skipInfoUpdateTest() throws Exception {
+		ByteArrayOutputStream baos = new ByteArrayOutputStream();
+		PdfReader reader = new PdfReader(new File("src/test/resources/HelloWorldMeta.pdf").getAbsolutePath());
+		PdfStamper stamp = new PdfStamper(reader, baos, '\0', true);
+
+		HashMap<String, String> moreInfo = createCleanerMoreInfo();
+		moreInfo.put("Producer", Document.getVersion());
+		moreInfo.put("Author", "Author1");
+		moreInfo.put("Title", "Title2");
+		moreInfo.put("Subject", "Subject3");
+		stamp.setInfoDictionary(moreInfo);
+
+		stamp.setUpdateDocInfo(false);
+		stamp.close();
+
+		PdfReader r = new PdfReader(baos.toByteArray());
+		Assertions.assertNull(r.getInfo().get("Producer"));
+		Assertions.assertNull(r.getInfo().get("Author"));
+		Assertions.assertNull(r.getInfo().get("Title"));
+		Assertions.assertNull(r.getInfo().get("Subject"));
+		r.close();
+	}
+
+	@Test
+	public void skipInfoUpdateFirstRevisionTest() throws Exception {
+		ByteArrayOutputStream baos = new ByteArrayOutputStream();
+		PdfReader reader = new PdfReader(new File("src/test/resources/HelloWorldMeta.pdf").getAbsolutePath());
+		PdfStamper stamp = new PdfStamper(reader, baos, '\0', false);
+
+		HashMap<String, String> moreInfo = createCleanerMoreInfo();
+		moreInfo.put("Producer", Document.getVersion());
+		moreInfo.put("Author", "Author1");
+		moreInfo.put("Title", "Title2");
+		moreInfo.put("Subject", "Subject3");
+		stamp.setInfoDictionary(moreInfo);
+
+		stamp.setUpdateDocInfo(false);
+		stamp.close();
+
+		PdfReader r = new PdfReader(baos.toByteArray());
+		Assertions.assertNotNull(r.getInfo().get("Producer"));
+		Assertions.assertNotNull(r.getInfo().get("Author"));
+		Assertions.assertNotNull(r.getInfo().get("Title"));
+		Assertions.assertNotNull(r.getInfo().get("Subject"));
+		r.close();
 	}
 	
 	@Test


### PR DESCRIPTION
## Description of the new Feature/Bugfix
When changing a document using sequential update (_append=true_), a new /Metadata and /Info dictionaries are being included to the new revision overriding the original values. This change breaks compliance of original PDF/A documents.
Both of the properties are optional by ISO 32000-1/2, therefore their inclusion or update is not mandatory.

Therefore, I have added two setters to the PdfStamper, namely _#setUpdateMetadata_ and _#setUpdateDocInfo_ allowing to configure the inclusion of /Metadata and /Info dictionaries to the added sequential revision, respectively.

The change does not modify the default behavior of OpenPdf and requires the added parameters to be set to false (false = no update).
Moreover, the new variables are handled only during the new sequential update, and does not impact a new PDF creation or change within the first revision.

## Unit-Tests for the new Feature/Bugfix
- [ ] Unit-Tests added to reproduce the bug
- [X] Unit-Tests added to the added feature

## Compatibilities Issues
The original behavior is not impacted by the change.

## Testing details
Added unit tests for both new setter methods, including PDF non-sequential and sequential update.