### PR TITLE
#373 - fix table rendering in footers

### DIFF
--- a/openpdf/src/main/java/com/lowagie/text/HeaderFooter.java
+++ b/openpdf/src/main/java/com/lowagie/text/HeaderFooter.java
@@ -52,6 +52,8 @@ package com.lowagie.text;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.lowagie.text.pdf.PdfPTable;
+
 /**
  * A <CODE>HeaderFooter</CODE>-object is a <CODE>Rectangle</CODe> with text that can be put above and/or below every
  * page.

--- a/openpdf/src/test/java/com/lowagie/text/FooterTableTest.java
+++ b/openpdf/src/test/java/com/lowagie/text/FooterTableTest.java
@@ -1,7 +1,6 @@
 package com.lowagie.text;
 
 import java.io.ByteArrayOutputStream;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.util.Objects;
 

--- a/openpdf/src/test/java/com/lowagie/text/FooterTableTest.java
+++ b/openpdf/src/test/java/com/lowagie/text/FooterTableTest.java
@@ -1,0 +1,59 @@
+package com.lowagie.text;
+
+import java.io.ByteArrayOutputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.util.Objects;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import com.lowagie.text.pdf.PdfPTable;
+import com.lowagie.text.pdf.PdfWriter;
+
+public class FooterTableTest {
+    @Test
+    public void imageLeftAlignmentPositionTest() throws IOException {
+        Document document = new Document(PageSize.A4);
+        PdfWriter.getInstance(document, new ByteArrayOutputStream());
+
+        Image jpg = Image.getInstance(Objects.requireNonNull(getClass().getClassLoader().getResource("GitHub-Mark-32px.png")));
+        jpg.setAlignment(Image.RIGHT);
+
+        PdfPTable table = new PdfPTable(3);
+        table.getDefaultCell().setBorder(Table.NO_BORDER);
+        table.addCell("1.1");
+        table.addCell("1.2");
+        table.addCell("1.3");
+        table.addCell("2.1");
+        table.addCell(new Phrase("center"));
+        table.addCell("2.3");
+        table.addCell("3.1");
+        table.addCell("3.2");
+        table.addCell("3.3");
+
+        Paragraph footerParagraph = new Paragraph();
+        ;
+        footerParagraph.add(jpg);
+        footerParagraph.add(table);
+
+        HeaderFooter footer = new HeaderFooter(footerParagraph, false);
+        document.setFooter(footer);
+
+        document.open();
+        document.add(new Paragraph("This is a test line."));
+        document.add(new Paragraph("Second line"));
+        document.newPage();
+        document.add(new Paragraph("second"));
+        document.newPage();
+        document.add(new Paragraph("third"));
+        document.close();
+
+        float tableHeight = table.getTotalHeight();
+        float footerTop = footer.getTop();
+        float tableBottom = footerTop - table.getTotalHeight();
+        Assertions.assertEquals(48.0, tableHeight);
+        Assertions.assertEquals(76.0, footerTop);
+        Assertions.assertEquals(28.0, tableBottom);
+    }
+}


### PR DESCRIPTION
## Description of the new Feature/Bugfix
As a follow-up of https://github.com/LibrePDF/OpenPDF/pull/697, extend the newly added logic to also work with `PdfPTable`s to completely fix https://github.com/LibrePDF/OpenPDF/issues/373.  
Actual implementation analogous to the existing stuff:

* adding new switch cases for the `PdfPTable` when
** (pre-)rendering the footer
** adding the actual table to the document

Related Issue: #373 

## Unit-Tests for the new Feature/Bugfix
New unit test in `FooterTableTest.java`.

## Compatibilities Issues
No changes.

## Testing details
Test class can be used to see created PDF by changing the PDF writer instance to:

```
PdfWriter.getInstance(document, new FileOutputStream("test.pdf"));
```

First page of output file:
![image](https://user-images.githubusercontent.com/1199637/192136489-f1ff5a51-f8ea-4401-a76d-43cb21296463.png)

Full PDF:
[ticket373.pdf](https://github.com/LibrePDF/OpenPDF/files/9640401/ticket373.pdf)



