### PR TITLE
AutoCloseable interface for classes that already implement it

### DIFF
--- a/openpdf/src/main/java/com/lowagie/text/DocListener.java
+++ b/openpdf/src/main/java/com/lowagie/text/DocListener.java
@@ -58,7 +58,7 @@ package com.lowagie.text;
  * @see        DocWriter
  */
 
-public interface DocListener extends ElementListener {
+public interface DocListener extends ElementListener, AutoCloseable {
 
     // methods
 

--- a/openpdf/src/main/java/com/lowagie/text/Document.java
+++ b/openpdf/src/main/java/com/lowagie/text/Document.java
@@ -103,7 +103,7 @@ import java.util.Properties;
  * </BLOCKQUOTE>
  */
 
-public class Document implements AutoCloseable, DocListener {
+public class Document implements DocListener {
     
     // membervariables
     private static final String VERSION_PROPERTIES = "com/lowagie/text/version.properties";

--- a/openpdf/src/main/java/com/lowagie/text/pdf/MappedRandomAccessFile.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/MappedRandomAccessFile.java
@@ -66,7 +66,7 @@ import java.security.PrivilegedAction;
  * @author Joakim Sandstroem
  * Created on 6.9.2006
  */
-public class MappedRandomAccessFile {
+public class MappedRandomAccessFile implements AutoCloseable {
     
     private MappedByteBuffer mappedByteBuffer = null;
     private FileChannel channel = null;

--- a/openpdf/src/main/java/com/lowagie/text/pdf/PRTokeniser.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/PRTokeniser.java
@@ -56,7 +56,7 @@ import com.lowagie.text.error_messages.MessageLocalization;
  *
  * @author  Paulo Soares (psoares@consiste.pt)
  */
-public class PRTokeniser {
+public class PRTokeniser implements AutoCloseable {
     
     public static final int TK_NUMBER = 1;
     public static final int TK_STRING = 2;

--- a/openpdf/src/main/java/com/lowagie/text/pdf/PdfCopyFields.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/PdfCopyFields.java
@@ -63,7 +63,7 @@ import com.lowagie.text.pdf.interfaces.PdfViewerPreferences;
  * @author  Paulo Soares (psoares@consiste.pt)
  */
 public class PdfCopyFields
-    implements PdfViewerPreferences, PdfEncryptionSettings {
+    implements PdfViewerPreferences, PdfEncryptionSettings, AutoCloseable {
     
     private PdfCopyFieldsImp fc;
     

--- a/openpdf/src/main/java/com/lowagie/text/pdf/PdfCopyForms.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/PdfCopyForms.java
@@ -66,7 +66,7 @@ import com.lowagie.text.pdf.interfaces.PdfViewerPreferences;
  * @since 2.1.5
  */
 public class PdfCopyForms
-    implements PdfViewerPreferences, PdfEncryptionSettings {
+    implements PdfViewerPreferences, PdfEncryptionSettings, AutoCloseable {
     
     /** The class with the actual implementations. */
     private PdfCopyFormsImp fc;

--- a/openpdf/src/main/java/com/lowagie/text/pdf/PdfStamper.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/PdfStamper.java
@@ -79,7 +79,7 @@ import java.util.Map;
  * @author Paulo Soares (psoares@consiste.pt)
  */
 public class PdfStamper
-    implements PdfViewerPreferences, PdfEncryptionSettings {
+    implements PdfViewerPreferences, PdfEncryptionSettings, AutoCloseable {
     /**
      * The writer
      */    

--- a/openpdf/src/main/java/com/lowagie/text/xml/xmp/XmpWriter.java
+++ b/openpdf/src/main/java/com/lowagie/text/xml/xmp/XmpWriter.java
@@ -66,7 +66,7 @@ import java.util.Map;
  * Metadata to a PDF Dictionary. Remark that this class doesn't cover the
  * complete XMP specification. 
  */
-public class XmpWriter {
+public class XmpWriter implements AutoCloseable {
 
     /** A possible charset for the XMP. */
     public static final String UTF8 = "UTF-8";


### PR DESCRIPTION
## Description of the new Feature/Bugfix
I added the AutoCloseable interface on those classes which already implement it. Most of them seem to use it to close files or streams in their implementation, so it is recommended to give them this interface.

Related Issue: Problem/enhancement mentioned in #812 

## Unit-Tests for the new Feature/Bugfix
No new tests needed, because it does not introduce a new feature or fix a bug or change.

## Compatibilities Issues
No issues to be expected, but linters will suggest the dev to use try-with-resources.

## Testing details
--
