### PR TITLE
Throw InvalidPdfException in PdfReader.rebuildXref if no trailer is found

### DIFF
--- a/openpdf/src/main/java/com/lowagie/text/pdf/PdfReader.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/PdfReader.java
@@ -1722,6 +1722,8 @@ public class PdfReader implements PdfViewerPreferences, Closeable {
         }
       }
     }
+    if (trailer == null)
+      throw new InvalidPdfException(MessageLocalization.getComposedMessage("trailer.not.found"));
     xref = new int[top * 2];
     for (int k = 0; k < top; ++k) {
       int[] obj = xr[k];


### PR DESCRIPTION
In PdfReader.rebuildXref reintroduce check for if trailer is null and throw a InvalidPdfException, to prevent a Nullpointer exception later when reading invalid PDF documents without a trailer.

This problem is described in issue #725. Currently a NullPointerException is thrown when reading a PDF file with an invalid trailer. This is what such a NullPointerException looks like in the system I'm working on:
```
java.lang.NullPointerException
	at com.lowagie.text.pdf.PdfReader.readPages(PdfReader.java:1164)
	at com.lowagie.text.pdf.PdfReader.readPdf(PdfReader.java:627)
	at com.lowagie.text.pdf.PdfReader.<init>(PdfReader.java:212)
	at com.lowagie.text.pdf.PdfReader.<init>(PdfReader.java:196)
	at no.foo.bar.split(PdfDocument.java:91)
```

This check was present in https://github.com/ymasory but removed at a later time here: https://github.com/daviddurand/iText-4.2.0/commit/d61051c9bef5c139a0a1c746eaafd29ae47507f4
https://github.com/ymasory/iText-4.2.0/blob/master/src/core/com/lowagie/text/pdf/PdfReader.java#L1524

iText 5 and 7 will also throw a InvalidPdfException in PdfReader.rebuildXref in this case.

