### PR TITLE
Fix height calculation for table rows with rowspan

### DIFF
--- a/openpdf/src/test/java/com/lowagie/text/pdf/TableRowSpanEvenSplitTest.java
+++ b/openpdf/src/test/java/com/lowagie/text/pdf/TableRowSpanEvenSplitTest.java
@@ -55,4 +55,53 @@ public class TableRowSpanEvenSplitTest {
         Assertions.assertEquals(0, heightRow2 - heightRow3);
         Assertions.assertNotEquals(0, heightRow1 - heightRow2);
     }
+
+    @Test
+    public void threeWithLargeRowspanCellTest() {
+        Document document = new Document(PageSize.A4);
+        ByteArrayOutputStream pdfOut = new ByteArrayOutputStream();
+        PdfWriter.getInstance(document, pdfOut);
+        PdfPTable table = new PdfPTable(2);
+        PdfPCell cell = new PdfPCell();
+        cell.setRowspan(3);
+        cell.addElement(new Chunk("rowspan\nrowspan\nrowspan\nrowspan\nrowspan\nrowspan\nrowspan"));
+        table.addCell(cell);
+
+        table.addCell("row1");
+        table.addCell("row2");
+        table.addCell("row3");
+        document.open();
+        document.add(table);
+        float heightRow1 = table.getRows().get(0).getMaxHeights();
+        float heightRow2 = table.getRows().get(1).getMaxHeights();
+        float heightRow3 = table.getRows().get(2).getMaxHeights();
+        document.close();
+        Assertions.assertEquals(0, heightRow2 - heightRow3);
+        Assertions.assertEquals(0, heightRow1 - heightRow2);
+    }
+
+    @Test
+    public void threeWithLargeRowspanCellTestUnevenDistribution() {
+        Document document = new Document(PageSize.A4);
+        ByteArrayOutputStream pdfOut = new ByteArrayOutputStream();
+        PdfWriter.getInstance(document, pdfOut);
+        PdfPTable table = new PdfPTable(2);
+        PdfPCell cell = new PdfPCell();
+        cell.setRowspan(3);
+        cell.addElement(new Chunk("rowspan\nrowspan\nrowspan\nrowspan\nrowspan\nrowspan\nrowspan"));
+        table.addCell(cell);
+
+        table.addCell("row1\nrow1\nrow1\nrow1\nrow1\nrow1");
+        table.addCell("row2");
+        table.addCell("row3");
+        document.open();
+        document.add(table);
+        float heightRow1 = table.getRows().get(0).getMaxHeights();
+        float heightRow2 = table.getRows().get(1).getMaxHeights();
+        float heightRow3 = table.getRows().get(2).getMaxHeights();
+        document.close();
+        Assertions.assertEquals(0, heightRow2 - heightRow3);
+        Assertions.assertNotEquals(0, heightRow1 - heightRow2);
+        Assertions.assertTrue(heightRow1 > heightRow2);
+    }
 }


### PR DESCRIPTION
## Description of the new Feature/Bugfix
Fixes https://github.com/LibrePDF/OpenPDF/issues/864

- Fix calculation of row heights when using rowspan
- Row heights for tables that contain cells with rowspan > 1 are calculated on first access to row heights.
- Additional space necessary to fit the contents of the rowspanning cell is distributed as evenly as possible among all rows.

Bug was introduced with https://github.com/LibrePDF/OpenPDF/pull/693

## Unit-Tests for the new Feature/Bugfix
- [x] Unit-Tests added to reproduce the bug
- [ ] Unit-Tests added to the added feature

## Compatibilities Issues
No changes should be visible to the user.

## Testing details
Any other details about how to test the new feature or bugfix?
