### PR TITLE
Remove jsr305/javax.annotation Maven dependency

### DIFF
--- a/openpdf/pom.xml
+++ b/openpdf/pom.xml
@@ -22,10 +22,6 @@
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>com.google.code.findbugs</groupId>
-            <artifactId>jsr305</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcprov-jdk18on</artifactId>
             <optional>true</optional>

--- a/pom.xml
+++ b/pom.xml
@@ -85,7 +85,6 @@
         <jakarta.servlet-api.version>5.0.0</jakarta.servlet-api.version>
         <jcommon.version>1.0.24</jcommon.version>
         <jfreechart.version>1.5.3</jfreechart.version>
-        <jsr305.version>3.0.2</jsr305.version>
         <pdf-renderer.version>1.0.5</pdf-renderer.version>
 
         <!-- test-dependencies -->
@@ -108,11 +107,6 @@
                 <groupId>org.bouncycastle</groupId>
                 <artifactId>bcpkix-jdk18on</artifactId>
                 <version>${bouncycastle.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.google.code.findbugs</groupId>
-                <artifactId>jsr305</artifactId>
-                <version>${jsr305.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.xmlgraphics</groupId>


### PR DESCRIPTION
## Description of the new Feature/Bugfix
javax.annotation is no longer used since https://github.com/LibrePDF/OpenPDF/commit/8e4109b16d1e0c73f1f3dcc332a71b28bb90db19, but jsr305 still comes as a mandatory transitive dependency (https://central.sonatype.dev/artifact/com.github.librepdf/openpdf/1.3.30)