### PR TITLE
set FLAGS_PRINT flag in annotation for action chunks

### DIFF
--- a/openpdf/src/main/java/com/lowagie/text/pdf/PdfDocument.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/PdfDocument.java
@@ -1578,7 +1578,9 @@ public class PdfDocument extends Document {
                             subtract = 0;
                         if (nextChunk == null)
                             subtract += hangingCorrection;
-                        text.addAnnotation(new PdfAnnotation(writer, xMarker, yMarker, xMarker + width - subtract, yMarker + chunk.font().size(), (PdfAction)chunk.getAttribute(Chunk.ACTION)));
+                        PdfAnnotation annotation = new PdfAnnotation(writer, xMarker, yMarker, xMarker + width - subtract, yMarker + chunk.font().size(), (PdfAction)chunk.getAttribute(Chunk.ACTION));
+                        annotation.setFlags(PdfAnnotation.FLAGS_PRINT);
+                        text.addAnnotation(annotation);
                     }
                     if (chunk.isAttribute(Chunk.REMOTEGOTO)) {
                         float subtract = lastBaseFactor;


### PR DESCRIPTION
## Description of the new Feature/Bugfix
Set `PdfAnnotation.FLAGS_PRINT` when writing the document line for a Chunk object with `ACTION` attribute to make the PDF conform to the [ISO 19005-2:2011, ISO 19005-3:2012 PDFA/3a specifications](https://github.com/veraPDF/veraPDF-validation-profiles/wiki/PDFA-Parts-2-and-3-rules#rule-632-1). Rule description by PDFA GreenField validation parser 1.22.3: 

> Except for annotation dictionaries whose Subtype value is Popup, all annotation dictionaries shall contain the F key.

Until this issue I was able to make PDFs created by this lib conform to PDFA/3a by using the API provided by this lib. However, I couldn't find a way of conforming to this particular rule without altering the implementation of this library. This motivated me to make this pull request.

## Unit-Tests for the new Feature/Bugfix
- [ ] Unit-Tests added to reproduce the bug
- [ ] Unit-Tests added to the added feature

## Compatibilities Issues
This change doesn't brake anything. No changes in any method signatures.

## Testing details
Run the [veraPDF](https://github.com/veraPDF/veraPDF-validation) validator on a PDF which contains an Anchor object with an external reference. It should not complain about violation of the PDFA-Validator rule mentioned in the description above.