### PR TITLE
Add flag to inhibit FOP glyph substitution

### DIFF
--- a/openpdf/src/main/java/com/lowagie/text/Document.java
+++ b/openpdf/src/main/java/com/lowagie/text/Document.java
@@ -958,7 +958,7 @@ public class Document implements AutoCloseable, DocListener {
      * @param documentLanguage the wanted language
      */
     public void setDocumentLanguage(String documentLanguage) {
-    	textRenderingOptions = textRenderingOptions.withDocumentLanguage(documentLanguage);
+    	textRenderingOptions.setDocumentLanguage(documentLanguage);
     }
 
     /**
@@ -981,7 +981,7 @@ public class Document implements AutoCloseable, DocListener {
      * @see #setDocumentLanguage(String)
      */
 	public void setGlyphSubstitutionEnabled(boolean glyphSubstitutionEnabled) {
-		textRenderingOptions = textRenderingOptions.withGlyphSubstitutionsEnabled(glyphSubstitutionEnabled);
+		textRenderingOptions.setGlyphSubstitutionEnabled(glyphSubstitutionEnabled);
 	}
 
 	/**

--- a/openpdf/src/main/java/com/lowagie/text/Document.java
+++ b/openpdf/src/main/java/com/lowagie/text/Document.java
@@ -204,12 +204,12 @@ public class Document implements AutoCloseable, DocListener {
     protected int chapternumber = 0;
 
     /**
-     * The default language of the document. Can be set to values like "en_US".
-     * This language is used in {@link FopGlyphProcessor} to determine which glyphs are to be substituted.
-     * The default "dflt" means that all glyphs which can be replaced will be substituted.
+     * Text rendering options, including the default language of the document and a flag
+     * to enable font glyph substitution (if FOP is available)
+     * 
      * @since 3.1.15
      */
-    String documentLanguage = "dflt";
+    TextRenderingOptions textRenderingOptions = new TextRenderingOptions();
 
     // constructor
 
@@ -958,7 +958,7 @@ public class Document implements AutoCloseable, DocListener {
      * @param documentLanguage the wanted language
      */
     public void setDocumentLanguage(String documentLanguage) {
-        this.documentLanguage = documentLanguage;
+    	textRenderingOptions = textRenderingOptions.withDocumentLanguage(documentLanguage);
     }
 
     /**
@@ -970,6 +970,49 @@ public class Document implements AutoCloseable, DocListener {
      * @return the current document language
      */
     public String getDocumentLanguage() {
-        return documentLanguage;
+        return textRenderingOptions.getDocumentLanguage();
+    }
+
+    /**
+     * Set a flag that determine whether glyph substion is enabled when FOP is available.
+     * 
+     * @param glyphSubstitutionEnabled the glyph substitution enabled flag
+     * @see FopGlyphProcessor
+     * @see #setDocumentLanguage(String)
+     */
+	public void setGlyphSubstitutionEnabled(boolean glyphSubstitutionEnabled) {
+		textRenderingOptions = textRenderingOptions.withGlyphSubstitutionsEnabled(glyphSubstitutionEnabled);
+	}
+
+	/**
+	 * Returns the glyph substitution enabled flag.
+	 * 
+	 * @return the glyph substitution enabled flag
+	 * @see #setGlyphSubstitutionEnabled(boolean)
+	 */
+	public boolean isGlyphSubstitutionEnabled() {
+		return textRenderingOptions.isGlyphSubstitutionEnabled();
+	}
+    
+	/**
+	 * Sets the text rendering options.
+	 * 
+	 * @param textRenderingOptions the text rendering options
+	 * @see #setDocumentLanguage(String)
+	 * @see Document#setGlyphSubstitutionsEnabled(boolean)
+	 */
+    public void setTextRenderingOptions(TextRenderingOptions textRenderingOptions) {
+    	this.textRenderingOptions = textRenderingOptions == null ? new TextRenderingOptions() : textRenderingOptions;
+    }
+    
+    /**
+     * Gets the text rendering options.
+     * 
+     * @return the text rendering options
+     * @see #getDocumentLanguage()
+     * @see #isGlyphSubstitutionEnabled()
+     */
+    public TextRenderingOptions getTextRenderingOptions() {
+    	return textRenderingOptions;
     }
 }

--- a/openpdf/src/main/java/com/lowagie/text/TextRenderingOptions.java
+++ b/openpdf/src/main/java/com/lowagie/text/TextRenderingOptions.java
@@ -1,0 +1,87 @@
+package com.lowagie.text;
+
+import com.lowagie.text.pdf.FopGlyphProcessor;
+
+/**
+ * Text rendering options, including the default language of the document and a flag
+ * to enable font glyph substitution (if FOP is available).
+ * 
+ * @author Lucian Chirita (lucianc@users.sourceforge.net)
+ * @see Document#setTextRenderingOptions(TextRenderingOptions)
+ * @since 3.1.15
+ */
+public class TextRenderingOptions {
+
+	public static final String DOCUMENT_LANGUAGE_DEFAULT = "dflt";
+	
+    /**
+     * The default language of the document. Can be set to values like "en_US".
+     * This language is used in {@link FopGlyphProcessor} to determine which glyphs are to be substituted.
+     * The default "dflt" means that all glyphs which can be replaced will be substituted.
+     * 
+     */
+	private final String documentLanguage;
+	
+	private final boolean glyphSubstitutionEnabled;
+
+	/**
+	 * Creates a text rendering options instance with the default options: glyph substitution enabled 
+	 * and "dflt" as document language.
+	 */
+	public TextRenderingOptions() {
+		this(DOCUMENT_LANGUAGE_DEFAULT, true);
+	}
+
+	/**
+	 * Creates a text rendering options instance.
+	 * 
+     * @param documentLanguage the wanted language
+	 * @param glyphSubstitutionEnabled
+	 */
+	public TextRenderingOptions(String documentLanguage, boolean glyphSubstitutionEnabled) {
+		this.documentLanguage = documentLanguage;
+		this.glyphSubstitutionEnabled = glyphSubstitutionEnabled;
+	}
+
+    /**
+     * The default language of the document. Can be set to values like "en_US". This language is used in
+     * FopGlyphProcessor to determine which glyphs are to be substituted.
+     * <P/>
+     * The default "dflt" means that all glyphs which can be replaced will be substituted.
+     *
+     * @return the current document language
+     */
+	public String getDocumentLanguage() {
+		return documentLanguage;
+	}
+
+	/**
+	 * Returns the glyph substitution enabled flag.
+	 * 
+	 * @return the glyph substitution enabled flag
+	 * #see {@link Document#setGlyphSubstitutionEnabled(boolean)}
+	 */
+	public boolean isGlyphSubstitutionEnabled() {
+		return glyphSubstitutionEnabled;
+	}
+	
+	/**
+	 * Returns a new instance with the specified document language.
+	 * 
+	 * @param documentLanguage the document language
+	 * @return a new instance with the document language
+	 */
+	public TextRenderingOptions withDocumentLanguage(String documentLanguage) {
+		return new TextRenderingOptions(documentLanguage, glyphSubstitutionEnabled);
+	}
+	
+	/**
+	 * Returns a new instance with the specified glyph substitution enabled flag.
+	 * 
+	 * @param glyphSubstitutionEnabled whether glyph substitution is enabled
+	 * @return a new instance with the glyph substitution enabled flag
+	 */
+	public TextRenderingOptions withGlyphSubstitutionsEnabled(boolean glyphSubstitutionEnabled) {
+		return new TextRenderingOptions(documentLanguage, glyphSubstitutionEnabled);
+	}
+}

--- a/openpdf/src/main/java/com/lowagie/text/TextRenderingOptions.java
+++ b/openpdf/src/main/java/com/lowagie/text/TextRenderingOptions.java
@@ -36,7 +36,7 @@ public class TextRenderingOptions {
 	 * Creates a text rendering options instance.
 	 * 
      * @param documentLanguage the wanted language
-	 * @param glyphSubstitutionEnabled
+	 * @param glyphSubstitutionEnabled whether glyph substitution is enabled
 	 */
 	public TextRenderingOptions(String documentLanguage, boolean glyphSubstitutionEnabled) {
 		this.documentLanguage = documentLanguage;

--- a/openpdf/src/main/java/com/lowagie/text/TextRenderingOptions.java
+++ b/openpdf/src/main/java/com/lowagie/text/TextRenderingOptions.java
@@ -20,9 +20,9 @@ public class TextRenderingOptions {
      * The default "dflt" means that all glyphs which can be replaced will be substituted.
      * 
      */
-	private final String documentLanguage;
+	private String documentLanguage;
 	
-	private final boolean glyphSubstitutionEnabled;
+	private boolean glyphSubstitutionEnabled;
 
 	/**
 	 * Creates a text rendering options instance with the default options: glyph substitution enabled 
@@ -43,6 +43,16 @@ public class TextRenderingOptions {
 		this.glyphSubstitutionEnabled = glyphSubstitutionEnabled;
 	}
 
+	/**
+	 * Sets the default language of the document.
+	 * 
+	 * @param documentLanguage the document language
+	 * @see #getDocumentLanguage()
+	 */
+	public void setDocumentLanguage(String documentLanguage) {
+		this.documentLanguage = documentLanguage;
+	}
+
     /**
      * The default language of the document. Can be set to values like "en_US". This language is used in
      * FopGlyphProcessor to determine which glyphs are to be substituted.
@@ -56,6 +66,15 @@ public class TextRenderingOptions {
 	}
 
 	/**
+	 * Sets the font glyph substitution enabled flag.
+	 * 
+	 * @param glyphSubstitutionEnabled whether glyph substitution is enabled
+	 */
+	public void setGlyphSubstitutionEnabled(boolean glyphSubstitutionEnabled) {
+		this.glyphSubstitutionEnabled = glyphSubstitutionEnabled;
+	}
+
+	/**
 	 * Returns the glyph substitution enabled flag.
 	 * 
 	 * @return the glyph substitution enabled flag
@@ -63,25 +82,5 @@ public class TextRenderingOptions {
 	 */
 	public boolean isGlyphSubstitutionEnabled() {
 		return glyphSubstitutionEnabled;
-	}
-	
-	/**
-	 * Returns a new instance with the specified document language.
-	 * 
-	 * @param documentLanguage the document language
-	 * @return a new instance with the document language
-	 */
-	public TextRenderingOptions withDocumentLanguage(String documentLanguage) {
-		return new TextRenderingOptions(documentLanguage, glyphSubstitutionEnabled);
-	}
-	
-	/**
-	 * Returns a new instance with the specified glyph substitution enabled flag.
-	 * 
-	 * @param glyphSubstitutionEnabled whether glyph substitution is enabled
-	 * @return a new instance with the glyph substitution enabled flag
-	 */
-	public TextRenderingOptions withGlyphSubstitutionsEnabled(boolean glyphSubstitutionEnabled) {
-		return new TextRenderingOptions(documentLanguage, glyphSubstitutionEnabled);
 	}
 }

--- a/openpdf/src/main/java/com/lowagie/text/pdf/FontDetails.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/FontDetails.java
@@ -55,6 +55,7 @@ import java.util.HashMap;
 
 import com.lowagie.text.Utilities;
 import com.lowagie.text.ExceptionConverter;
+import com.lowagie.text.TextRenderingOptions;
 
 /**
  * Each font in the document will have an instance of this class
@@ -172,7 +173,7 @@ class FontDetails {
      * @param text the text to convert
      * @return the conversion
      */    
-    byte[] convertToBytes(String text, String language) {
+    byte[] convertToBytes(String text, TextRenderingOptions options) {
         byte[] b = null;
         switch (fontType) {
             case BaseFont.FONT_TYPE_T3:
@@ -217,9 +218,10 @@ class FontDetails {
                     }
                     else {
                         String fileName = ((TrueTypeFontUnicode)getBaseFont()).fileName;
-                        if (FopGlyphProcessor.isFopSupported() && (fileName!=null && fileName.length()>0 
+                        if (options.isGlyphSubstitutionEnabled() && FopGlyphProcessor.isFopSupported() 
+                        		&& (fileName!=null && fileName.length()>0 
                                                                    &&( fileName.contains(".ttf") || fileName.contains(".TTF")))){
-                            return FopGlyphProcessor.convertToBytesWithGlyphs(ttu,text,fileName,longTag,language);
+                            return FopGlyphProcessor.convertToBytesWithGlyphs(ttu,text,fileName,longTag, options.getDocumentLanguage());
                         }else {
                             return convertToBytesWithGlyphs(text);
                         }

--- a/openpdf/src/main/java/com/lowagie/text/pdf/PdfContentByte.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/PdfContentByte.java
@@ -1525,7 +1525,7 @@ public class PdfContentByte {
         if (state.fontDetails == null) {
             throw new NullPointerException(MessageLocalization.getComposedMessage("font.and.size.must.be.set.before.writing.any.text"));
         }
-        byte[] b = state.fontDetails.convertToBytes(text, getPdfDocument().getDocumentLanguage());
+        byte[] b = state.fontDetails.convertToBytes(text, getPdfDocument().getTextRenderingOptions());
         escapeString(b, content);
     }
 

--- a/openpdf/src/main/java/com/lowagie/text/pdf/PdfCopy.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/PdfCopy.java
@@ -153,7 +153,7 @@ public class PdfCopy extends PdfWriter {
    */
   public PdfCopy(Document document, OutputStream os) throws DocumentException {
     super(new PdfDocument(), os);
-    this.document.setDocumentLanguage(document.getDocumentLanguage());
+    this.document.setTextRenderingOptions(document.getTextRenderingOptions());
     document.addDocListener(pdf);
     pdf.addWriter(this);
     indirectMap = new HashMap<>();

--- a/openpdf/src/main/java/com/lowagie/text/pdf/PdfWriter.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/PdfWriter.java
@@ -604,7 +604,7 @@ public class PdfWriter extends DocWriter implements
     public static PdfWriter getInstance(Document document, OutputStream os)
     throws DocumentException {
         PdfDocument pdf = new PdfDocument();
-        pdf.setDocumentLanguage(document.getDocumentLanguage());
+        pdf.setTextRenderingOptions(document.getTextRenderingOptions());
         document.addDocListener(pdf);
         PdfWriter writer = new PdfWriter(pdf, os);
         pdf.addWriter(writer);
@@ -624,7 +624,7 @@ public class PdfWriter extends DocWriter implements
     public static PdfWriter getInstance(Document document, OutputStream os, DocListener listener)
     throws DocumentException {
         PdfDocument pdf = new PdfDocument();
-        pdf.setDocumentLanguage(document.getDocumentLanguage());
+        pdf.setTextRenderingOptions(document.getTextRenderingOptions());
         pdf.addDocListener(listener);
         document.addDocListener(pdf);
         PdfWriter writer = new PdfWriter(pdf, os);


### PR DESCRIPTION
## Description of the new Feature/Bugfix
When FOP is present on the classpath, it will be automatically used to perform glyph substitutions, which are mandatory for complex layout scripts.

But for scripts where glyph substitutions are optional (e.g. Latin ligatures), it makes sense to have an enable/disable flag because glyph substitutions come with drawbacks such as incorrect text when copying from the document.

The PR introduces a new method `Document.setGlyphSubstitutionEnabled` that can be used to disable glyph substitutions when FOP is present.

Related Issue: #297 