### PR TITLE
Fix for localgoto in pdf/a-1b documents

### DIFF
--- a/openpdf/src/main/java/com/lowagie/text/pdf/PdfDocument.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/PdfDocument.java
@@ -49,6 +49,7 @@
 
 package com.lowagie.text.pdf;
 
+import static com.lowagie.text.pdf.PdfAnnotation.FLAGS_PRINT;
 import static java.awt.Font.LAYOUT_RIGHT_TO_LEFT;
 
 import com.lowagie.text.Anchor;
@@ -2090,7 +2091,9 @@ public class PdfDocument extends Document {
      */
     void localGoto(String name, float llx, float lly, float urx, float ury) {
         PdfAction action = getLocalGotoAction(name);
-        annotationsImp.addPlainAnnotation(new PdfAnnotation(writer, llx, lly, urx, ury, action));
+        PdfAnnotation pdfAnnotation = new PdfAnnotation(writer, llx, lly, urx, ury, action);
+        pdfAnnotation.setFlags(FLAGS_PRINT);
+        annotationsImp.addPlainAnnotation(pdfAnnotation);
     }
 
     /**


### PR DESCRIPTION
## Description of the new Feature/Bugfix
Added the flag when creating the localgoto attributes

The fix is really similar to the fix done in [this PR](https://github.com/LibrePDF/OpenPDF/pull/877), adding the flag in the PdfAnnotation contructor may be the better solution here if this rule should be applied to all different types of action

Related Issue: [#912](https://github.com/LibrePDF/OpenPDF/issues/912)

## Unit-Tests for the new Feature/Bugfix
- [ ] Unit-Tests added to reproduce the bug
- [ ] Unit-Tests added to the added feature

## Compatibilities Issues
No compatibility issues

## Testing details
Test using veraPDF, see issue
