### PR TITLE
#954 Speed up loading fonts from JAR

### DIFF
--- a/openpdf/src/main/java/com/lowagie/text/pdf/BaseFont.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/BaseFont.java
@@ -52,6 +52,7 @@ package com.lowagie.text.pdf;
 import com.lowagie.text.DocumentException;
 import com.lowagie.text.error_messages.MessageLocalization;
 
+import java.io.BufferedInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.security.SecureRandom;
@@ -1723,7 +1724,7 @@ public abstract class BaseFont {
         if (loader != null) {
             is = loader.getResourceAsStream(key);
             if (is != null) {
-                return is;
+                return new BufferedInputStream(is);
             }
         }
         // Try to use Context Class Loader to load the properties file.
@@ -1742,7 +1743,7 @@ public abstract class BaseFont {
         if (is == null) {
             is = ClassLoader.getSystemResourceAsStream(key);
         }
-        return is;
+         return is == null ? null : new BufferedInputStream(is);
     }
 
     /**


### PR DESCRIPTION
## Description of the new Feature/Bugfix
I've wrapped `InputStream` into `BufferedInputStream`. That made much faster loading fonts from `openpdf-*.jar`.

Related Issue: #954

## Unit-Tests for the new Feature/Bugfix
- [ ] Unit-Tests added to reproduce the bug
- [ ] Unit-Tests added to the added feature

The test is described in https://github.com/LibrePDF/OpenPDF/issues/954. 
Running test inside of OpenPDF doesn't really show the problem, so I decided not to commit it. 

## Compatibilities Issues
No.

## Testing details
Described in https://github.com/LibrePDF/OpenPDF/issues/954
