### PR TITLE
garbled CJK Unified Ideographs Extension text test and fix

### DIFF
--- a/openpdf/src/main/java/com/lowagie/text/pdf/FontDetails.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/FontDetails.java
@@ -239,7 +239,7 @@ class FontDetails {
     private byte[] convertToBytesWithGlyphs(String text) throws UnsupportedEncodingException {
         int len = text.length();
         int[] metrics = null;
-        char[] glyph = new char[len];
+        int[] glyph = new int[len];
         int i = 0;
         for (int k = 0; k < len; ++k) {
             int val;
@@ -257,10 +257,19 @@ class FontDetails {
             Integer gl = m0;
             if (!longTag.containsKey(gl))
                 longTag.put(gl, new int[]{m0, metrics[1], val});
-            glyph[i++] = (char)m0;
+            glyph[i++] = m0;
         }
-        String s = new String(glyph, 0, i);
-        return s.getBytes(CJKFont.CJK_ENCODING);
+        return getCJKEncodingBytes(glyph, i);
+    }
+
+    private byte[] getCJKEncodingBytes(int[] glyph, int size) {
+        byte[] result = new byte[size * 2];
+        for (int i = 0; i < size; i++) {
+            int g = glyph[i];
+            result[i * 2] = (byte)(g >> 8);
+            result[i * 2 + 1] = (byte)(g & 0xFF);
+        }
+        return result;
     }
 
     byte[] convertToBytes(GlyphVector glyphVector) {

--- a/openpdf/src/test/java/com/lowagie/text/pdf/PdfDocumentCJKExtensionTest.java
+++ b/openpdf/src/test/java/com/lowagie/text/pdf/PdfDocumentCJKExtensionTest.java
@@ -1,0 +1,66 @@
+package com.lowagie.text.pdf;
+
+import java.io.FileOutputStream;
+import java.io.IOException;
+
+import org.junit.jupiter.api.Test;
+
+import com.lowagie.text.Chunk;
+import com.lowagie.text.Document;
+import com.lowagie.text.Font;
+import com.lowagie.text.FontFactory;
+
+class PdfDocumentCJKExtensionTest {
+	@Test
+	void generateDocumentsWithCJKExtension() throws IOException {
+		String fontName = "TakaoMjMincho";
+
+		// TakaoMjMincho Version 003.01.01
+		// Please download and place it below. 
+		// https://launchpad.net/takao-fonts
+		// https://launchpad.net/takao-fonts/trunk/15.03/+download/TakaoMjFonts_00301.01.zip
+		String fontPath = "src/test/resources/fonts/TakaoMjFonts/TakaoMjMincho.ttf";
+
+		// register font
+		FontFactory.register(fontPath, fontName);
+
+		Document document = new Document();
+
+		// FOP off 
+		document.setGlyphSubstitutionEnabled(false);
+
+		PdfWriter.getInstance(document, new FileOutputStream("target/" + PdfDocumentCJKExtensionTest.class.getSimpleName() + ".pdf"));
+
+		try {
+			Font font = FontFactory.getFont(fontName, "Identity-H", false, 10, 0, null);
+
+			document.open();
+			// CJK Unified Ideographs Extension B
+			// https://en.wikipedia.org/wiki/CJK_Unified_Ideographs_Extension_B
+
+			// U+20000
+			String cjkB_OK = "𠀀";
+			// U+2A000 
+			String cjkB_NG = "𪀀";
+
+
+			// CJK Unified Ideographs Extension C
+			// https://en.wikipedia.org/wiki/CJK_Unified_Ideographs_Extension_C
+
+			// U+2A746
+			String cjkC_NG = "𪝆";
+
+
+			// CJK Unified Ideographs Extension D
+			// https://en.wikipedia.org/wiki/CJK_Unified_Ideographs_Extension_D
+
+			// U+2B746
+			String cjkD_NG = "𫝆";
+
+			document.add(new Chunk(cjkB_OK + " " + cjkB_NG + " " + cjkC_NG + " " + cjkD_NG, font));
+
+		} finally {
+			document.close();
+		}
+	}
+}

--- a/openpdf/src/test/java/com/lowagie/text/pdf/fonts/AdvanceTypographyTest.java
+++ b/openpdf/src/test/java/com/lowagie/text/pdf/fonts/AdvanceTypographyTest.java
@@ -8,7 +8,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.HashMap;
 import org.apache.commons.io.IOUtils;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 /**


### PR DESCRIPTION
## Description of the new Feature/Bugfix
Implemented a test and fix that reproduces the issue #986.

openpdf/src/test/java/com/lowagie/text/pdf/PdfDocumentCJKExtensionTest.java
-> Test to reproduce the problem.

openpdf/src/main/java/com/lowagie/text/pdf/FontDetails.java
-> Logic to fix the problematic part (the text can be displayed by fixing the problem) .

### Problem

While debugging and running the test class I created, I noticed that the result of the FontDetails#convertToBytesWithGlyphs(String) method was wrong.

Below are the values of each variable obtained while debugging.

In the case of garbled characters, the pattern of the byte array was `[-3, -1]`.

| Unicode | variable text | (int)gliph[n] | s.getBytes byte value |
| ---- | :----: | ----: | ---- | 
| U+20000 | 𠀀 | 31146 | [121, -86] |
| U+2A000 | 𪀀 | 55813 | [-1, -3] |
| U+2A746 | 𪝆 | 57261 | [-1, -3] | 
| U+2B746 | 𫝆 | 57237 | [-1, -3] |


### Fix

Implemented method `getCJKEncodingBytes` to replace byte conversion process.
\* The getCJKEncodingBytes method cannot handle glyph values larger than 65535.

Since the number `31146` in `𠀀` is a byte `[121, -86]`, we assumed that UnicodeBigUnmarked is converted by the following rule.

(decimal) `31146` => (binary) `0111 1001 1010 1010` ⇒ (binary array) `[0111 1001, 1010 1010]` ⇒ (byte array) `[121, -86]`


| Unicode | variable text | (int)gliph[n] | getCJKEncodingBytes method result  |
| ---- | :----: | ----: | ---- | 
| U+20000 | 𠀀 | 31146 | [121, -86] |
| U+2A000 | 𪀀 | 55813 | [-38,  5] |
| U+2A746 | 𪝆 | 57261 | [-33, -83] | 
| U+2B746 | 𫝆 | 57237 | [-33, -107] |

After this modification, the PDF output can be displayed without garbled characters as shown below.

![image](https://github.com/LibrePDF/OpenPDF/assets/10181637/d56a5978-45ba-427f-b007-b3589b74bf7b)

This modification may need to be applied to other areas as well.
For example, the following line

- https://github.com/LibrePDF/OpenPDF/blob/master/openpdf/src/main/java/com/lowagie/text/pdf/FontDetails.java#L216
- https://github.com/LibrePDF/OpenPDF/blob/master/openpdf/src/main/java/com/lowagie/text/pdf/FontDetails.java#L298


## Unit-Tests for the new Feature/Bugfix
- [x] Unit-Tests added to reproduce the bug
- [ ] Unit-Tests added to the added feature

## Compatibilities Issues
None

## Testing details
Please download the font file from below and place it as `src/test/resources/fonts/TakaoMjFonts/TakaoMjMincho.ttf` when running the test.

- https://launchpad.net/takao-fonts
- https://launchpad.net/takao-fonts/trunk/15.03/+download/TakaoMjFonts_00301.01.zip
