### PR TITLE
Fix performance for rowspan height distribution

### DIFF
--- a/openpdf/src/main/java/com/lowagie/text/pdf/PdfPTable.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/PdfPTable.java
@@ -418,6 +418,11 @@ public class PdfPTable implements LargeElement{
         for (int k = 0; k < rows.size(); ++k) {
             totalHeight += getRowHeight(k, firsttime);
         }
+        if(firsttime) {
+            // Redistribute row height for row span once
+            this.redistributeRowspanHeight();
+            calculateHeights(false);
+        }
         return totalHeight;
     }
     
@@ -850,9 +855,6 @@ public class PdfPTable implements LargeElement{
 
     private void redistributeRowspanHeight() {
         float delta = 0.001f;
-        for (PdfPRow pdfPRow : rows) {
-            pdfPRow.calculateHeights();
-        }
         for (int rowIdx = 0; rowIdx < rows.size(); rowIdx++) {
             PdfPRow row = rows.get(rowIdx);
             PdfPCell[] cells = row.getCells();
@@ -909,7 +911,7 @@ public class PdfPTable implements LargeElement{
             return 0;
         if (firsttime) {
             row.setWidths(absoluteWidths);
-            this.redistributeRowspanHeight();
+            row.calculateHeights();
         }
         return row.getMaxHeights();
     }

--- a/openpdf/src/test/java/com/lowagie/text/pdf/TableRowSpanEvenSplitTest.java
+++ b/openpdf/src/test/java/com/lowagie/text/pdf/TableRowSpanEvenSplitTest.java
@@ -28,8 +28,8 @@ public class TableRowSpanEvenSplitTest {
         float heightRow2 = table.getRows().get(1).getMaxHeights();
         float heightRow3 = table.getRows().get(2).getMaxHeights();
         document.close();
-        Assertions.assertEquals(0, heightRow1 - heightRow2);
-        Assertions.assertEquals(0, heightRow3 - heightRow2);
+        Assertions.assertEquals(heightRow1, heightRow2, 0.01);
+        Assertions.assertEquals(heightRow3, heightRow2, 0.01);
     }
 
     @Test
@@ -52,8 +52,40 @@ public class TableRowSpanEvenSplitTest {
         float heightRow2 = table.getRows().get(1).getMaxHeights();
         float heightRow3 = table.getRows().get(2).getMaxHeights();
         document.close();
-        Assertions.assertEquals(0, heightRow2 - heightRow3);
-        Assertions.assertNotEquals(0, heightRow1 - heightRow2);
+        Assertions.assertEquals(heightRow2, heightRow3, 0.01);
+        Assertions.assertNotEquals(heightRow1, heightRow2, 0.01);
+    }
+
+    @Test
+    public void threeWithLargeRowspanCellHugeTableTest() {
+        Document document = new Document(PageSize.A4);
+        ByteArrayOutputStream pdfOut = new ByteArrayOutputStream();
+        PdfWriter.getInstance(document, pdfOut);
+        PdfPTable table = new PdfPTable(2);
+
+        int rows = 9_000;
+
+        for (int i = 0; i < rows; i += 3) {
+            PdfPCell cell = new PdfPCell();
+            cell.setRowspan(3);
+            cell.addElement(new Chunk("rowspan1\nrowspan2\nrowspan3\nrowspan4\nrowspan5\nrowspan6\nrowspan7"));
+            table.addCell(cell);
+
+            table.addCell("row1");
+            table.addCell("row2");
+            table.addCell("row3");
+        }
+
+        document.open();
+        document.add(table);
+        for (int i = 0; i < rows; i += 3) {
+            float heightRow1 = table.getRows().get(i).getMaxHeights();
+            float heightRow2 = table.getRows().get(i + 1).getMaxHeights();
+            float heightRow3 = table.getRows().get(i + 2).getMaxHeights();
+            Assertions.assertEquals(heightRow2, heightRow3, 0.01);
+            Assertions.assertEquals(heightRow1, heightRow2, 0.01);
+        }
+        document.close();
     }
 
     @Test
@@ -76,8 +108,9 @@ public class TableRowSpanEvenSplitTest {
         float heightRow2 = table.getRows().get(1).getMaxHeights();
         float heightRow3 = table.getRows().get(2).getMaxHeights();
         document.close();
-        Assertions.assertEquals(0, heightRow2 - heightRow3);
-        Assertions.assertEquals(0, heightRow1 - heightRow2);
+        Assertions.assertEquals(heightRow2, heightRow3, 0.01);
+        Assertions.assertEquals(heightRow1, heightRow2, 0.01);
+
     }
 
     @Test
@@ -100,8 +133,8 @@ public class TableRowSpanEvenSplitTest {
         float heightRow2 = table.getRows().get(1).getMaxHeights();
         float heightRow3 = table.getRows().get(2).getMaxHeights();
         document.close();
-        Assertions.assertEquals(0, heightRow2 - heightRow3);
-        Assertions.assertNotEquals(0, heightRow1 - heightRow2);
+        Assertions.assertEquals(heightRow2, heightRow3, 0.01);
+        Assertions.assertNotEquals(heightRow1, heightRow2, 0.01);
         Assertions.assertTrue(heightRow1 > heightRow2);
     }
 }


### PR DESCRIPTION
## Description of the new Feature/Bugfix
Fix performance when adding large table to PDF document.
Added test `threeWithLargeRowspanCellHugeTableTest`.
Performance for adding a large table with 9000 rows (after JVM warmup):
- Before: ~ 4 min 30 sec
- After: ~ 500ms
- When redistribution is disabled: ~400ms

Related Issue: https://github.com/LibrePDF/OpenPDF/issues/1017

## Unit-Tests for the new Feature/Bugfix
- [x] Unit-Tests added to reproduce the bug
- [ ] Unit-Tests added to the added feature
