### PR TITLE
issue 1024: newline (or other control char below 0x20) should not switch font

### DIFF
--- a/openpdf/src/main/java/com/lowagie/text/pdf/PdfChunk.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/PdfChunk.java
@@ -210,7 +210,7 @@ public class PdfChunk {
              */
 
             // Check if the chunk content is text
-            if (chunk.getContent().chars().allMatch(c -> ((c >= 0x20 && c <= 0xFF) || c == 0x09))) {
+            if (chunk.getContent().chars().allMatch(c -> (c >= 0x0 && c <= 0xFF))) {
                 // translation of the font-family to a PDF font-family
                 baseFont = f.getCalculatedBaseFont(false);
             } else {


### PR DESCRIPTION
## Description of the new Feature/Bugfix

Related Issue: #1024

## Unit-Tests for the new Feature/Bugfix
- [ ] Unit-Tests added to reproduce the bug
- [ ] Unit-Tests added to the added feature

## Compatibilities Issues
Now no control character (neither tab nor newline nor others from 0x0 below 0x20) causes switching to the embedded font.

## Testing details
Don't know how to verify the font used in the generated PDF.
