### PR TITLE
Fix row height calculation for tables with locked width

### DIFF
--- a/openpdf/src/main/java/com/lowagie/text/pdf/ColumnText.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/ColumnText.java
@@ -1361,6 +1361,7 @@ public class ColumnText {
                 float tableWidth;
                 if (table.isLockedWidth()) {
                     tableWidth = table.getTotalWidth();
+                    table.calculateHeights(true);
                     updateFilledWidth(tableWidth);
                 }
                 else {

--- a/openpdf/src/test/java/com/lowagie/text/pdf/TableRowSpanEvenSplitTest.java
+++ b/openpdf/src/test/java/com/lowagie/text/pdf/TableRowSpanEvenSplitTest.java
@@ -3,6 +3,7 @@ package com.lowagie.text.pdf;
 import com.lowagie.text.Chunk;
 import com.lowagie.text.Document;
 import com.lowagie.text.PageSize;
+import com.lowagie.text.Phrase;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import java.io.ByteArrayOutputStream;
@@ -136,5 +137,76 @@ public class TableRowSpanEvenSplitTest {
         Assertions.assertEquals(heightRow2, heightRow3, 0.01);
         Assertions.assertNotEquals(heightRow1, heightRow2, 0.01);
         Assertions.assertTrue(heightRow1 > heightRow2);
+    }
+
+    @Test
+    public void threeRowsLockedWidth() {
+        Document document = new Document(PageSize.A4, 10, 10, 10, 10);
+        ByteArrayOutputStream pdfOut = new ByteArrayOutputStream();
+        PdfWriter.getInstance(document, pdfOut);
+
+        float width = document.getPageSize().getWidth() - 20;
+
+        float[] columns = {33.3F, 33.3F, 33.3F};
+        PdfPTable table = new PdfPTable(columns);
+        table.setTotalWidth(width * 0.5f);
+        table.setLockedWidth(true);
+        table.setHeaderRows(1);
+
+        PdfPCell cell = new PdfPCell();
+        cell.addElement(new Phrase("ITEM NO."));
+        table.addCell(cell);
+        cell = new PdfPCell();
+        cell.addElement(new Phrase("PART"));
+        table.addCell(cell);
+        cell = new PdfPCell();
+        cell.addElement(new Phrase("PROCESS"));
+        table.addCell(cell);
+
+        cell = new PdfPCell();
+        cell.setRowspan(6);
+        cell.addElement(new Phrase("item 1"));
+        table.addCell(cell);
+
+        cell = new PdfPCell();
+        cell.setRowspan(3);
+        cell.setMinimumHeight(30);
+        cell.addElement(new Phrase("part 1"));
+        table.addCell(cell);
+
+        cell = new PdfPCell();
+        cell.setRowspan(2);
+        cell.setMinimumHeight(20);
+        cell.addElement(new Phrase("process 1"));
+        table.addCell(cell);
+
+        cell = new PdfPCell();
+        cell.setRowspan(2);
+        cell.setMinimumHeight(20);
+        cell.addElement(new Phrase("process 2"));
+        table.addCell(cell);
+
+        cell = new PdfPCell();
+        cell.setRowspan(3);
+        cell.setMinimumHeight(30);
+        cell.addElement(new Phrase("part 2"));
+        table.addCell(cell);
+
+        cell = new PdfPCell();
+        cell.setRowspan(2);
+        cell.setMinimumHeight(20);
+        cell.addElement(new Phrase("process 3"));
+        table.addCell(cell);
+
+        System.out.println("COLS");
+        document.open();
+        document.add(table);
+        document.close();
+
+        for(int i=1;i<6;i++) {
+            System.out.println(table.rows.get(i).getMaxHeights() + ", " + i);
+            Assertions.assertTrue(table.rows.get(i).getMaxHeights()> 5f, "Row " + i + " is too small");
+            Assertions.assertEquals(table.rows.get(i).getMaxHeights(), table.rows.get(i + 1).getMaxHeights(), 0.01);
+        }
     }
 }


### PR DESCRIPTION
## Description of the new Feature/Bugfix
Calculate row height for tables with locked width.

Related Issue: #1025 

## Unit-Tests for the new Feature/Bugfix
- [x] Unit-Tests added to reproduce the bug