### PR TITLE
add TrueTypeFontUnicode.includeCidSet flag (#1041)

### DIFF
--- a/openpdf/src/main/java/com/lowagie/text/pdf/TrueTypeFontUnicode.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/TrueTypeFontUnicode.java
@@ -75,6 +75,8 @@ class TrueTypeFontUnicode extends TrueTypeFont implements Comparator{
     boolean vertical = false;
     
     Map<Integer, Integer> inverseCmap;
+
+    boolean includeCidSet = true;
     
     /**
      * Creates a new TrueType font addressed by Unicode characters. The font
@@ -396,7 +398,7 @@ class TrueTypeFontUnicode extends TrueTypeFont implements Comparator{
         PdfObject pobj = null;
         PdfIndirectObject obj = null;
         PdfIndirectReference cidset = null;
-        if (subset || writer.getPDFXConformance() == PdfWriter.PDFA1A || writer.getPDFXConformance() == PdfWriter.PDFA1B) {
+        if (includeCidSet || writer.getPDFXConformance() == PdfWriter.PDFA1A || writer.getPDFXConformance() == PdfWriter.PDFA1B) {
             PdfStream stream;
             if (metrics.length == 0) {
                 stream = new PdfStream(new byte[]{(byte)0x80});
@@ -540,5 +542,13 @@ class TrueTypeFontUnicode extends TrueTypeFont implements Comparator{
         if (m == null)
             return null;
         return bboxes[m[0]];
+    }
+
+    public boolean isIncludeCidSet() {
+        return includeCidSet;
+    }
+
+    public void setIncludeCidSet(boolean includeCidSet) {
+        this.includeCidSet = includeCidSet;
     }
 }

--- a/openpdf/src/test/java/com/lowagie/text/pdf/FontSubsetTest.java
+++ b/openpdf/src/test/java/com/lowagie/text/pdf/FontSubsetTest.java
@@ -53,24 +53,24 @@ public class FontSubsetTest {
     }
 
     /*
-     * This test is to ensure creation of CIDSet dictionary when using a font subset (required for PDF/A compliance)
+     * This test is to ensure creation of CIDSet dictionary according to the includeCidSet flag
      */
     @Test
-    public void subsetTest() throws Exception {
-        checkSubsetPresence(true);
-        checkSubsetPresence(false);
+    public void includeCidSetTest() throws Exception {
+        checkCidSetPresence(true);
+        checkCidSetPresence(false);
     }
 
-    private void checkSubsetPresence(boolean subsetIncluded) throws Exception {
+    private void checkCidSetPresence(boolean includeCidSet) throws Exception {
         byte[] documentBytes;
         try (ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
             Document document = new Document();
             PdfWriter.getInstance(document, baos);
             document.open();
 
-            BaseFont font = BaseFont.createFont("LiberationSerif-Regular.ttf", BaseFont.IDENTITY_H,
+            TrueTypeFontUnicode font = (TrueTypeFontUnicode) BaseFont.createFont("LiberationSerif-Regular.ttf", BaseFont.IDENTITY_H,
                     BaseFont.EMBEDDED,true, getFontByte("fonts/liberation-serif/LiberationSerif-Regular.ttf"), null);
-            font.setSubset(subsetIncluded);
+            font.setIncludeCidSet(includeCidSet);
             String text = "This is the test string.";
             document.add(new Paragraph(text, new Font(font, 12)));
             document.close();
@@ -91,7 +91,7 @@ public class FontSubsetTest {
                 PdfDictionary fd = dic.getAsDict(PdfName.FONTDESCRIPTOR);
                 if (PdfName.FONT.equals(type) && fd != null) {
                     PdfIndirectReference cidset = fd.getAsIndirectObject(PdfName.CIDSET);
-                    assertEquals(subsetIncluded, cidset != null);
+                    assertEquals(includeCidSet, cidset != null);
                     fontFound = true;
                     break;
                 }


### PR DESCRIPTION
## Description of the new Feature/Bugfix
Add a separate `TrueTypeFontUnicode.includeCidSet` flag in order to control CIDSet generation.

Related Issue: #1041 

## Unit-Tests for the new Feature/Bugfix
- [x] Unit-Tests added to the added feature

## Compatibilities Issues
n/a

## Testing details
n/a
