### PR TITLE
lift TrueTypeFontUnicode.includeCidSet flag up to BaseFont to make it publicly accessible (#1041)

### DIFF
--- a/openpdf/src/main/java/com/lowagie/text/pdf/BaseFont.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/BaseFont.java
@@ -342,6 +342,11 @@ public abstract class BaseFont {
      * Used to build a randomized prefix for a subset name
      */
     protected SecureRandom secureRandom;
+    
+    /**
+     * Indicates if a CIDSet stream should be included in the document.
+     */
+    protected boolean includeCidSet = true;
 
     static {
         BuiltinFonts14.put(COURIER, PdfName.COURIER);
@@ -1986,5 +1991,26 @@ public abstract class BaseFont {
         } else {
             this.compressionLevel = compressionLevel;
         }
+    }
+    
+    /**
+     * Indicates if a CIDSet stream should be included in the document for {@link TrueTypeFontUnicode}.
+     *
+     * @return <CODE>true</CODE> to include a CIDSet stream.
+     */
+    public boolean isIncludeCidSet() {
+        return includeCidSet;
+    }
+    
+    /**
+     * Indicates if a CIDSet stream should be included in the document for {@link TrueTypeFontUnicode}.
+     * When set to <CODE>true</CODE>, a CIDSet stream will be included in the document.
+     * When set to <CODE>false</CODE>, and {@link PdfWriter#getPDFXConformance()} does not require it,
+     * no CIDSet stream will be included.
+     *
+     * @param includeCidSet new value of {@link BaseFont#includeCidSet}
+     */
+    public void setIncludeCidSet(boolean includeCidSet) {
+        this.includeCidSet = includeCidSet;
     }
 }

--- a/openpdf/src/main/java/com/lowagie/text/pdf/TrueTypeFontUnicode.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/TrueTypeFontUnicode.java
@@ -76,8 +76,6 @@ class TrueTypeFontUnicode extends TrueTypeFont implements Comparator{
     
     Map<Integer, Integer> inverseCmap;
 
-    boolean includeCidSet = true;
-    
     /**
      * Creates a new TrueType font addressed by Unicode characters. The font
      * will always be embedded.
@@ -544,11 +542,4 @@ class TrueTypeFontUnicode extends TrueTypeFont implements Comparator{
         return bboxes[m[0]];
     }
 
-    public boolean isIncludeCidSet() {
-        return includeCidSet;
-    }
-
-    public void setIncludeCidSet(boolean includeCidSet) {
-        this.includeCidSet = includeCidSet;
-    }
 }

--- a/openpdf/src/test/java/com/lowagie/text/pdf/FontSubsetTest.java
+++ b/openpdf/src/test/java/com/lowagie/text/pdf/FontSubsetTest.java
@@ -68,7 +68,7 @@ public class FontSubsetTest {
             PdfWriter.getInstance(document, baos);
             document.open();
 
-            TrueTypeFontUnicode font = (TrueTypeFontUnicode) BaseFont.createFont("LiberationSerif-Regular.ttf", BaseFont.IDENTITY_H,
+            BaseFont font = BaseFont.createFont("LiberationSerif-Regular.ttf", BaseFont.IDENTITY_H,
                     BaseFont.EMBEDDED,true, getFontByte("fonts/liberation-serif/LiberationSerif-Regular.ttf"), null);
             font.setIncludeCidSet(includeCidSet);
             String text = "This is the test string.";


### PR DESCRIPTION
## Description of the new Feature/Bugfix
this is a follow-up to #1045 which added a new `TrueTypeFontUnicode.includeCidSet` flag.
but due to the class `TrueTypeFontUnicode` being package private, that class cannot be used directly in consumer application code (i.e. to downcast `BaseFont`), meaning the flag is not accessible.
this commit lifts the flag along with its getter/setter up to `BaseFont` to make it publicly accessible.

Related Issue: #1041

## Unit-Tests for the new Feature/Bugfix
- [x] Unit-Tests added to the added feature

## Compatibilities Issues
n/a

## Testing details
@andreasrosdal sorry for not spotting this right away.. missed it as the unit-test resides in the same package..
i hope this approach makes sense to you, too - i did not want to change `TrueTypeFontUnicode` visibility. added some javadoc.