### PR TITLE
#1059 When converting HTML to PDF, font size specified in % is interpreted as pixels

### DIFF
--- a/openpdf/src/main/java/com/lowagie/text/html/Markup.java
+++ b/openpdf/src/main/java/com/lowagie/text/html/Markup.java
@@ -44,7 +44,7 @@
  *
  * Contributions by:
  * Lubos Strapko
- * 
+ *
  * If you didn't download this code from the following link, you should check if
  * you aren't using an obsolete version:
  * https://github.com/LibrePDF/OpenPDF
@@ -273,14 +273,14 @@ public class Markup {
     /** a CSS value for text decoration */
     public static final String CSS_VALUE_UNDERLINE = "underline";
 
-    /** a default value for font-size 
+    /** a default value for font-size
      * @since 2.1.3
      */
     public static final float DEFAULT_FONT_SIZE = 12f;
 
     /**
      * Parses a length.
-     * 
+     *
      * @param string
      *            a length in the form of an optional + or -, followed by a
      *            number and a unit.
@@ -407,6 +407,10 @@ public class Markup {
         if (string.startsWith("ex")) {
             return f * actualFontSize / 2;
         }
+        // percentage of current font size
+        if (string.endsWith("%")) {
+            return (f / 100) * actualFontSize;
+        }
         // default: we assume the length was measured in points
         return f;
     }
@@ -433,7 +437,7 @@ public class Markup {
     /**
      * This method parses a String with attributes and returns a Properties
      * object.
-     * 
+     *
      * @param string
      *            a String of this form: 'key1="value1"; key2="value2";...
      *            keyN="valueN" '
@@ -469,7 +473,7 @@ public class Markup {
 
     /**
      * Removes the comments sections of a String.
-     * 
+     *
      * @param string
      *            the original String
      * @param startComment

--- a/openpdf/src/test/java/com/lowagie/text/html/FontSizeTest.java
+++ b/openpdf/src/test/java/com/lowagie/text/html/FontSizeTest.java
@@ -1,0 +1,55 @@
+package com.lowagie.text.html;
+
+import com.lowagie.text.Chunk;
+import com.lowagie.text.Document;
+import com.lowagie.text.Element;
+import com.lowagie.text.Paragraph;
+import com.lowagie.text.html.simpleparser.HTMLWorker;
+import com.lowagie.text.html.simpleparser.StyleSheet;
+import com.lowagie.text.pdf.PdfName;
+import com.lowagie.text.pdf.PdfString;
+import com.lowagie.text.pdf.PdfWriter;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.io.FileOutputStream;
+import java.io.StringReader;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class FontSizeTest {
+
+    @Test
+    public void testFontSize() throws Exception {
+        StringReader reader = new StringReader(
+            "<span>Text</span>" +
+                "<span style=\"font-size:8.0pt\">Text 8.0pt</span>"
+                + "<span style=\"font-size:20px\">Text 20px</span>"
+                + "<span style=\"font-size:1.5em\">Text 1.5em</span>"
+                + "<span style=\"font-size:50%\">Text 50%</span>");
+        StyleSheet styleSheet = new StyleSheet();
+        Map<String, Object> interfaceProps = new HashMap<>();
+        List<Element> elements = HTMLWorker.parseToList(reader, styleSheet, interfaceProps);
+
+        Document document = new Document();
+        PdfWriter instance = PdfWriter.getInstance(document, new FileOutputStream("target/Font Size.pdf"));
+        document.open();
+        instance.getInfo().put(PdfName.CREATOR, new PdfString(Document.getVersion()));
+        for (Element e : elements) {
+            document.add(e);
+        }
+        document.close();
+        Paragraph paragraph = (Paragraph) elements.get(0);
+        Chunk chunk1 = (Chunk) paragraph.get(0);
+        float defaultFontSize = chunk1.getFont().getSize();
+        Chunk chunk2 = (Chunk) paragraph.get(1);
+        Assertions.assertEquals(8.0, chunk2.getFont().getSize());
+        Chunk chunk3 = (Chunk) paragraph.get(2);
+        Assertions.assertEquals(20.0, chunk3.getFont().getSize());
+        Chunk chunk4 = (Chunk) paragraph.get(3);
+        Assertions.assertEquals(1.5 * defaultFontSize, chunk4.getFont().getSize());
+        Chunk chunk5 = (Chunk) paragraph.get(4);
+        Assertions.assertEquals(0.5 * defaultFontSize, chunk5.getFont().getSize());
+    }
+}


### PR DESCRIPTION
## Description of the new Feature/Bugfix
Added support for font size specified in %.

Related Issue: #1059

## Unit-Tests for the new Feature/Bugfix
- [x] Unit-Tests added to reproduce the bug


## Compatibilities Issues
none, I hope

## Testing details
Run the `FontSizeTest`. See also the generated 'Font Size.pdf'
