### PR TITLE
Provide PDF/A conform annotations

### DIFF
--- a/openpdf/src/main/java/com/lowagie/text/pdf/PdfAnnotation.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/PdfAnnotation.java
@@ -220,6 +220,7 @@ public class PdfAnnotation extends PdfDictionary {
     if (rect != null) {
       put(PdfName.RECT, new PdfRectangle(rect));
     }
+    addFKey();
   }
 
   /**
@@ -239,6 +240,7 @@ public class PdfAnnotation extends PdfDictionary {
     put(PdfName.T, title);
     put(PdfName.RECT, new PdfRectangle(llx, lly, urx, ury));
     put(PdfName.CONTENTS, content);
+    addFKey();
   }
 
   /**
@@ -259,6 +261,7 @@ public class PdfAnnotation extends PdfDictionary {
     put(PdfName.A, action);
     put(PdfName.BORDER, new PdfBorderArray(0, 0, 0));
     put(PdfName.C, new PdfColor(0x00, 0x00, 0xFF));
+    addFKey();
   }
 
   /**
@@ -1072,5 +1075,11 @@ public class PdfAnnotation extends PdfDictionary {
       buf.append(parameters);
       return buf.toString();
     }
+  }
+
+  private void addFKey() {
+      if (writer.isPdfA1()) {
+          put(PdfName.F, new PdfNumber(FLAGS_PRINT));
+      }
   }
 }

--- a/openpdf/src/main/java/com/lowagie/text/pdf/PdfWriter.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/PdfWriter.java
@@ -1769,6 +1769,10 @@ public class PdfWriter extends DocWriter implements
         return pdfxConformance.isPdfX();
     }
 
+    public boolean isPdfA1() {
+        return pdfxConformance.isPdfA1();
+    }
+
 //  [C11] Output intents
     /**
      * Sets the values of the output intent dictionary. Null values are allowed to

--- a/openpdf/src/test/java/com/lowagie/text/validation/PDFValidationTest.java
+++ b/openpdf/src/test/java/com/lowagie/text/validation/PDFValidationTest.java
@@ -5,6 +5,7 @@ import com.lowagie.text.Document;
 import com.lowagie.text.PageSize;
 import com.lowagie.text.Rectangle;
 import com.lowagie.text.pdf.PdfWriter;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.verapdf.core.ModelParsingException;
 import org.verapdf.gf.model.GFModelParser;
@@ -24,10 +25,12 @@ import java.io.InputStream;
 public class PDFValidationTest {
 
     @Test
-    void validatePDFWithVera() throws Exception {
+    public void testValidatePDFWithVera() throws Exception {
         Document document = new Document(PageSize.A4);
         ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
-        PdfWriter.getInstance(document, byteArrayOutputStream);
+        PdfWriter pdfWriter = PdfWriter.getInstance(document, byteArrayOutputStream);
+        pdfWriter.setPDFXConformance(PdfWriter.PDFA1B);
+        pdfWriter.createXmpMetadata();
 
         try {
             document.open();
@@ -39,7 +42,7 @@ public class PDFValidationTest {
             document.close();
 
             // Create a veraPDF validator
-            PDFAFlavour flavour = PDFAFlavour.PDFA_1_A;
+            PDFAFlavour flavour = PDFAFlavour.PDFA_1_B;
             try (InputStream inputStream = new ByteArrayInputStream(byteArrayOutputStream.toByteArray());
                  GFModelParser parser = GFModelParser.createModelWithFlavour(inputStream, flavour)) {
                 PDFAValidator validator = ValidatorFactory.createValidator(flavour, false, 10);
@@ -56,6 +59,7 @@ public class PDFValidationTest {
                     }
 
                 }
+                Assertions.assertTrue(result.isCompliant());
             }
         } catch (ModelParsingException e) {
             e.printStackTrace();


### PR DESCRIPTION
## Description of the new Feature/Bugfix
It's currently not possible to create annotations which are PDF/A conform. The validation test with VeraPDF fails with this message:
```
ruleId=RuleId [specification=ISO 19005-1:2005, clause=6.5.3, testNumber=2], status=failed, message=An annotation dictionary shall contain the F key. The F key’s Print flag bit shall be set to 1 and its Hidden, Invisible and NoView flag bits shall be set to 0
```

Related Issue: #980 

## Unit-Tests for the new Feature/Bugfix
- [ ] Unit-Tests added to reproduce the bug
- [x] Unit-Tests added to the added feature

## Compatibilities Issues
As far as I can tell this does not cause compatibility issues.
Would you consider a backport to 1.3.x?

## Testing details
Not that I know of.

Thanks in advance for your review / comments
