### PR TITLE
Reverted changes meant for 2.0.0 and restored Java8 compatibility

### DIFF
--- a/openpdf/src/main/java/com/lowagie/text/Annotation.java
+++ b/openpdf/src/main/java/com/lowagie/text/Annotation.java
@@ -579,6 +579,16 @@ public class Annotation implements Element {
 
     /**
      * Gets the content of this <CODE>Annotation</CODE>.
+     * @deprecated use {@link #getAttributes()}
+     * @return a reference
+     */
+    @Deprecated
+    public HashMap attributes() {
+        return (HashMap) annotationAttributes;
+    }
+
+    /**
+     * Gets the content of this <CODE>Annotation</CODE>.
      * 
      * @return a reference
      */

--- a/openpdf/src/main/java/com/lowagie/text/Cell.java
+++ b/openpdf/src/main/java/com/lowagie/text/Cell.java
@@ -273,11 +273,57 @@ public class Cell extends TableRectangle implements TextElementArray, WithHorizo
        }
 
     /**
+     * Sets the horizontal alignment.
+     * @param    value    the new value
+     * @deprecated Setting alignment through unconstrained types is non-obvious and error-prone,
+     * use {@link Cell#setHorizontalAlignment(HorizontalAlignment)} instead
+     */
+    @Deprecated
+    public void setHorizontalAlignment(int value) {
+        horizontalAlignment = value;
+    }
+
+    /**
+     * Sets the alignment of this cell.
+     * This methods allows you to set the alignment as a String.
+     * @param    alignment        the new alignment as a <CODE>String</CODE>
+     * @deprecated Setting alignment through unconstrained types is non-obvious and error-prone,
+     * use {@link Cell#setHorizontalAlignment(HorizontalAlignment)} instead
+     */
+    @Deprecated
+    public void setHorizontalAlignment(String alignment) {
+        setHorizontalAlignment(ElementTags.alignmentValue(alignment));
+    }
+
+    /**
      * Gets the vertical alignment.
      * @return    a value
      */
     public int getVerticalAlignment() {
         return verticalAlignment;
+    }
+
+    /**
+     * Sets the vertical alignment.
+     * @param    value    the new value
+     * @deprecated Setting alignment through unconstrained types is non-obvious and error-prone,
+     * use {@link Cell#setVerticalAlignment(VerticalAlignment)} instead
+     */
+    @Deprecated
+    public void setVerticalAlignment(int value) {
+        verticalAlignment = value;
+    }
+
+    /**
+     * Sets the alignment of this paragraph.
+     *
+     * @param    alignment        the new alignment as a <CODE>String</CODE>
+     * @deprecated Setting alignment through unconstrained types is non-obvious and error-prone,
+     * use {@link Cell#setVerticalAlignment(VerticalAlignment)} instead
+     */
+    @Deprecated
+    public void setVerticalAlignment(String alignment) {
+        setVerticalAlignment(ElementTags.alignmentValue(alignment));
     }
 
     /**

--- a/openpdf/src/main/java/com/lowagie/text/Chunk.java
+++ b/openpdf/src/main/java/com/lowagie/text/Chunk.java
@@ -418,12 +418,35 @@ public class Chunk implements Element {
      * Gets the attributes for this <CODE>Chunk</CODE>.
      * <P>
      * It may be null.
+     * @deprecated use {@link #getChunkAttributes()}
+     * @return the attributes for this <CODE>Chunk</CODE>
+     */
+    @Deprecated
+    public HashMap getAttributes() {
+        return (HashMap) attributes;
+    }
+
+    /**
+     * Gets the attributes for this <CODE>Chunk</CODE>.
+     * <P>
+     * It may be null.
      * 
      * @return the attributes for this <CODE>Chunk</CODE>
      */
 
     public Map<String, Object> getChunkAttributes() {
         return attributes;
+    }
+
+    /**
+     * Sets the attributes all at once.
+     * @param    attributes    the attributes of a Chunk
+     * @deprecated use {@link #setChunkAttributes(Map)}
+     */
+    @Deprecated
+    @SuppressWarnings("unchecked")
+    public void setAttributes(HashMap attributes) {
+        this.attributes = attributes;
     }
 
     /**

--- a/openpdf/src/main/java/com/lowagie/text/ImageLoader.java
+++ b/openpdf/src/main/java/com/lowagie/text/ImageLoader.java
@@ -162,6 +162,12 @@ public class ImageLoader {
 
     /**
      * Creates an Image from an array of tiff image bytes.
+     * For JRE < 9, `ImageIO.read()` requires a supporting library in the classpath to read tiffs.
+     * Options are:
+     * - https://github.com/jai-imageio/jai-imageio-core
+     * - https://github.com/haraldk/TwelveMonkeys 
+     *
+     * see: https://openjdk.java.net/jeps/262
      * 
      * @param imageData bytes of the tiff image
      * @return an objet of type <code>Image</code>

--- a/openpdf/src/main/java/com/lowagie/text/Paragraph.java
+++ b/openpdf/src/main/java/com/lowagie/text/Paragraph.java
@@ -204,8 +204,8 @@ public class Paragraph extends Phrase {
             setIndentationLeft(p.getIndentationLeft());
             setIndentationRight(p.getIndentationRight());
             setFirstLineIndent(p.getFirstLineIndent());
-            setSpacingAfter(p.getSpacingAfter());
-            setSpacingBefore(p.getSpacingBefore());
+            setSpacingAfter(p.spacingAfter());
+            setSpacingBefore(p.spacingBefore());
             setExtraParagraphSpace(p.getExtraParagraphSpace());
 			setRunDirection(p.getRunDirection());
         }
@@ -479,6 +479,32 @@ public class Paragraph extends Phrase {
      */
     public void setExtraParagraphSpace(float extraParagraphSpace) {
         this.extraParagraphSpace = extraParagraphSpace;
+    }
+    
+    // scheduled for removal
+    
+    /**
+     * Gets the spacing before this paragraph.
+     *
+     * @return    the spacing
+     * @deprecated As of iText 2.1.5, replaced by {@link #getSpacingBefore()},
+     * scheduled for removal at 2.3.0
+     */
+    @Deprecated
+    public float spacingBefore() {
+        return getSpacingBefore();
+    }
+
+    /**
+     * Gets the spacing after this paragraph.
+     *
+     * @return    the spacing
+     * @deprecated As of iText 2.1.5, replaced by {@link #getSpacingAfter()},
+     * scheduled for removal at 2.3.0
+     */
+    @Deprecated
+    public float spacingAfter() {
+        return spacingAfter;
     }
 
     public int getRunDirection() {

--- a/openpdf/src/main/java/com/lowagie/text/Paragraph.java
+++ b/openpdf/src/main/java/com/lowagie/text/Paragraph.java
@@ -204,8 +204,8 @@ public class Paragraph extends Phrase {
             setIndentationLeft(p.getIndentationLeft());
             setIndentationRight(p.getIndentationRight());
             setFirstLineIndent(p.getFirstLineIndent());
-            setSpacingAfter(p.spacingAfter());
-            setSpacingBefore(p.spacingBefore());
+            setSpacingAfter(p.getSpacingAfter());
+            setSpacingBefore(p.getSpacingBefore());
             setExtraParagraphSpace(p.getExtraParagraphSpace());
 			setRunDirection(p.getRunDirection());
         }

--- a/openpdf/src/main/java/com/lowagie/text/Row.java
+++ b/openpdf/src/main/java/com/lowagie/text/Row.java
@@ -366,6 +366,18 @@ public class Row implements Element, WithHorizontalAlignment {
     }
     
     /**
+     * Sets the horizontal alignment.
+     *
+     * @param value the new value
+     * @deprecated Setting alignment through unconstrained types is non-obvious and error-prone,
+     * use {@link Row#setHorizontalAlignment(HorizontalAlignment)} instead
+     */
+    @Deprecated
+    public void setHorizontalAlignment(int value) {
+        horizontalAlignment = value;
+    }
+    
+    /**
      * Gets the horizontal alignment.
      *
      * @return  a value

--- a/openpdf/src/main/java/com/lowagie/text/StandardFonts.java
+++ b/openpdf/src/main/java/com/lowagie/text/StandardFonts.java
@@ -8,79 +8,16 @@ public enum StandardFonts {
     COURIER_ITALIC(Font.COURIER, Font.ITALIC),
     COURIER_BOLD(Font.COURIER, Font.BOLD),
     COURIER_BOLDITALIC(Font.COURIER, Font.BOLDITALIC),
-    // Liberation Mono - Courier compatible
-    /**
-     * @deprecated Use Liberation
-     */
-    @Deprecated
-    LIBERATION_MONO("font-fallback/LiberationMono-Regular.ttf"),
-    /**
-     * @deprecated Use Liberation
-     */
-    @Deprecated
-    LIBERATION_MONO_ITALIC("font-fallback/LiberationMono-Italic.ttf"),
-    /**
-     * @deprecated Use Liberation
-     */
-    @Deprecated
-    LIBERATION_MONO_BOLD("font-fallback/LiberationMono-Bold.ttf"),
-    /**
-     * @deprecated Use Liberation
-     */
-    @Deprecated
-    LIBERATION_MONO_BOLDITALIC("font-fallback/LiberationMono-BoldItalic.ttf"),
     // Helvetica
     HELVETICA(Font.HELVETICA, Font.NORMAL),
     HELVETICA_ITALIC(Font.HELVETICA, Font.ITALIC),
     HELVETICA_BOLD(Font.HELVETICA, Font.BOLD),
     HELVETICA_BOLDITALIC(Font.HELVETICA, Font.BOLDITALIC),
-    // Liberation Sans - Helvetica/Arial compatible
-    /**
-     * @deprecated Use Liberation
-     */
-    @Deprecated
-    LIBERATION_SANS("font-fallback/LiberationSans-Regular.ttf"),
-    /**
-     * @deprecated Use Liberation
-     */
-    @Deprecated
-    LIBERATION_SANS_ITALIC("font-fallback/LiberationSans-Italic.ttf"),
-    /**
-     * @deprecated Use Liberation
-     */
-    @Deprecated
-    LIBERATION_SANS_BOLD("font-fallback/LiberationSans-Bold.ttf"),
-    /**
-     * @deprecated Use Liberation
-     */
-    @Deprecated
-    LIBERATION_SANS_BOLDITALIC("font-fallback/LiberationSans-BoldItalic.ttf"),
     // Times
     TIMES(Font.TIMES_ROMAN, Font.NORMAL),
     TIMES_ITALIC(Font.TIMES_ROMAN, Font.ITALIC),
     TIMES_BOLD(Font.TIMES_ROMAN, Font.BOLD),
     TIMES_BOLDITALIC(Font.TIMES_ROMAN, Font.BOLDITALIC),
-    // Liberation Serif - Times compatible
-    /**
-     * @deprecated Use Liberation
-     */
-    @Deprecated
-    LIBERATION_SERIF("font-fallback/LiberationSerif-Regular.ttf"),
-    /**
-     * @deprecated Use Liberation
-     */
-    @Deprecated
-    LIBERATION_SERIF_ITALIC("font-fallback/LiberationSerif-Italic.ttf"),
-    /**
-     * @deprecated Use Liberation
-     */
-    @Deprecated
-    LIBERATION_SERIF_BOLD("font-fallback/LiberationSerif-Bold.ttf"),
-    /**
-     * @deprecated Use Liberation
-     */
-    @Deprecated
-    LIBERATION_SERIF_BOLDITALIC("font-fallback/LiberationSerif-BoldItalic.ttf"),
     // Others
     SYMBOL(Font.SYMBOL, -1),
     ZAPFDINGBATS(Font.ZAPFDINGBATS, -1),

--- a/openpdf/src/main/java/com/lowagie/text/StandardFonts.java
+++ b/openpdf/src/main/java/com/lowagie/text/StandardFonts.java
@@ -8,17 +8,79 @@ public enum StandardFonts {
     COURIER_ITALIC(Font.COURIER, Font.ITALIC),
     COURIER_BOLD(Font.COURIER, Font.BOLD),
     COURIER_BOLDITALIC(Font.COURIER, Font.BOLDITALIC),
+    // Liberation Mono - Courier compatible
+    /**
+     * @deprecated Use Liberation
+     */
+    @Deprecated
+    LIBERATION_MONO("font-fallback/LiberationMono-Regular.ttf"),
+    /**
+     * @deprecated Use Liberation
+     */
+    @Deprecated
+    LIBERATION_MONO_ITALIC("font-fallback/LiberationMono-Italic.ttf"),
+    /**
+     * @deprecated Use Liberation
+     */
+    @Deprecated
+    LIBERATION_MONO_BOLD("font-fallback/LiberationMono-Bold.ttf"),
+    /**
+     * @deprecated Use Liberation
+     */
+    @Deprecated
+    LIBERATION_MONO_BOLDITALIC("font-fallback/LiberationMono-BoldItalic.ttf"),
     // Helvetica
     HELVETICA(Font.HELVETICA, Font.NORMAL),
     HELVETICA_ITALIC(Font.HELVETICA, Font.ITALIC),
     HELVETICA_BOLD(Font.HELVETICA, Font.BOLD),
     HELVETICA_BOLDITALIC(Font.HELVETICA, Font.BOLDITALIC),
-
+    // Liberation Sans - Helvetica/Arial compatible
+    /**
+     * @deprecated Use Liberation
+     */
+    @Deprecated
+    LIBERATION_SANS("font-fallback/LiberationSans-Regular.ttf"),
+    /**
+     * @deprecated Use Liberation
+     */
+    @Deprecated
+    LIBERATION_SANS_ITALIC("font-fallback/LiberationSans-Italic.ttf"),
+    /**
+     * @deprecated Use Liberation
+     */
+    @Deprecated
+    LIBERATION_SANS_BOLD("font-fallback/LiberationSans-Bold.ttf"),
+    /**
+     * @deprecated Use Liberation
+     */
+    @Deprecated
+    LIBERATION_SANS_BOLDITALIC("font-fallback/LiberationSans-BoldItalic.ttf"),
     // Times
     TIMES(Font.TIMES_ROMAN, Font.NORMAL),
     TIMES_ITALIC(Font.TIMES_ROMAN, Font.ITALIC),
     TIMES_BOLD(Font.TIMES_ROMAN, Font.BOLD),
     TIMES_BOLDITALIC(Font.TIMES_ROMAN, Font.BOLDITALIC),
+    // Liberation Serif - Times compatible
+    /**
+     * @deprecated Use Liberation
+     */
+    @Deprecated
+    LIBERATION_SERIF("font-fallback/LiberationSerif-Regular.ttf"),
+    /**
+     * @deprecated Use Liberation
+     */
+    @Deprecated
+    LIBERATION_SERIF_ITALIC("font-fallback/LiberationSerif-Italic.ttf"),
+    /**
+     * @deprecated Use Liberation
+     */
+    @Deprecated
+    LIBERATION_SERIF_BOLD("font-fallback/LiberationSerif-Bold.ttf"),
+    /**
+     * @deprecated Use Liberation
+     */
+    @Deprecated
+    LIBERATION_SERIF_BOLDITALIC("font-fallback/LiberationSerif-BoldItalic.ttf"),
     // Others
     SYMBOL(Font.SYMBOL, -1),
     ZAPFDINGBATS(Font.ZAPFDINGBATS, -1),
@@ -26,10 +88,23 @@ public enum StandardFonts {
 
     private int family;
     private int style;
+    /**
+     * @deprecated Use Liberation
+     */
+    @Deprecated
+    private String trueTypeFile;
 
     StandardFonts(int family, int style) {
         this.family = family;
         this.style = style;
+    }
+
+    /**
+     * @deprecated Use Liberation
+     */
+    @Deprecated
+    StandardFonts(String trueTypeFile) {
+        this.trueTypeFile = trueTypeFile;
     }
 
     public Font create() throws IOException {
@@ -38,7 +113,11 @@ public enum StandardFonts {
 
     public Font create(int size) throws IOException {
         final Font font;
-        if (style == -1) {
+        if (trueTypeFile != null) {
+            final String message = String
+                    .format("%s: Please use fonts from openpdf-fonts-extra (Liberation)", this);
+            throw new IOException(message);
+        } else if (style == -1) {
             font = new Font(family, size);
         } else {
             font = new Font(family, size, style);
@@ -47,6 +126,6 @@ public enum StandardFonts {
     }
 
     public boolean isDeprecated() {
-        return false;
+        return trueTypeFile != null;
     }
 }

--- a/openpdf/src/main/java/com/lowagie/text/Table.java
+++ b/openpdf/src/main/java/com/lowagie/text/Table.java
@@ -428,6 +428,39 @@ public class Table extends TableRectangle implements LargeElement, WithHorizonta
     public int getAlignment() {
         return alignment;
     }
+    
+    /**
+     * Sets the horizontal alignment.
+     *
+     * @param       value   the new value
+     * @deprecated Setting alignment through unconstrained types is non-obvious and error-prone,
+     * use {@link Table#setHorizontalAlignment(HorizontalAlignment)} instead
+     *
+     */
+    @Deprecated
+    public void setAlignment(int value) {
+        alignment = value;
+    }
+    
+    /**
+     * Sets the alignment of this paragraph.
+     *
+     * @param    alignment        the new alignment as a <CODE>String</CODE>
+     * @deprecated Setting alignment through unconstrained types is non-obvious and error-prone,
+     * use {@link Table#setHorizontalAlignment(HorizontalAlignment)} instead
+     */
+    @Deprecated
+    public void setAlignment(String alignment) {
+        if (ElementTags.ALIGN_LEFT.equalsIgnoreCase(alignment)) {
+            this.alignment = Element.ALIGN_LEFT;
+            return;
+        }
+        if (ElementTags.RIGHT.equalsIgnoreCase(alignment)) {
+            this.alignment = Element.ALIGN_RIGHT;
+            return;
+        }
+        this.alignment = Element.ALIGN_CENTER;
+    }
 
     @Override
     public void setHorizontalAlignment(final HorizontalAlignment alignment) {
@@ -1469,5 +1502,27 @@ public class Table extends TableRectangle implements LargeElement, WithHorizonta
     public void setComplete(boolean complete) {
         this.complete = complete;
     }
-
+    
+    /**
+     * Gets the default layout of the Table.
+     * @return a cell with all the defaults
+     * @deprecated As of iText 2.0.7, replaced by {@link #getDefaultCell()},
+     * scheduled for removal at 2.2.0
+     */
+    @Deprecated
+    public Cell getDefaultLayout() {
+        return getDefaultCell();
+    }
+    
+    /**
+     * Sets the default layout of the Table to
+     * the provided Cell
+     * @param value a cell with all the defaults
+     * @deprecated As of iText 2.0.7, replaced by {@link #setDefaultCell(Cell)},
+     * scheduled for removal at 2.2.0
+     */
+    @Deprecated
+    public void setDefaultLayout(Cell value) {
+        defaultCell = value;
+    }
 }

--- a/openpdf/src/main/java/com/lowagie/text/html/simpleparser/ChainedProperties.java
+++ b/openpdf/src/main/java/com/lowagie/text/html/simpleparser/ChainedProperties.java
@@ -63,7 +63,8 @@ public class ChainedProperties {
     /**
      * Will be replaced with types alternative
      */
-    public ArrayList<Object[]> chain = new ArrayList<>();
+    @Deprecated
+    public ArrayList chain = new ArrayList<>();
 
     /**
      * Creates a new instance of ChainedProperties
@@ -84,7 +85,7 @@ public class ChainedProperties {
      */
     public Optional<String> findProperty(String key) {
         for (int k = chain.size() - 1; k >= 0; --k) {
-            Object[] obj = chain.get(k);
+            Object[] obj = (Object[]) chain.get(k);
             HashMap prop = (HashMap) obj[1];
             String ret = (String) prop.get(key);
             if (ret != null) {
@@ -113,6 +114,17 @@ public class ChainedProperties {
                 return true;
         }
         return false;
+    }
+
+    /**
+     * @deprecated use {@link ChainedProperties#addToChain(String, HashMap)}
+     * @param key the key
+     * @param prop the properties
+     */
+    @Deprecated
+    @SuppressWarnings("unchecked")
+    public void addToChain(String key, HashMap prop) {
+        addToChain(key, (Map<String, String>) prop);
     }
 
     public void addToChain(String key, Map<String, String> prop) {

--- a/openpdf/src/main/java/com/lowagie/text/html/simpleparser/FactoryProperties.java
+++ b/openpdf/src/main/java/com/lowagie/text/html/simpleparser/FactoryProperties.java
@@ -219,7 +219,23 @@ public class FactoryProperties {
         return new HyphenationAuto(lang, country, leftMin, rightMin);
     }
 
+    /**
+     * This method isn't used by iText, but you can use it to analyze
+     * the value of a style attribute inside a HashMap.
+     * The different elements of the style attribute are added to the
+     * HashMap as key-value pairs.
+     *
+     * @param h a HashMap that should have at least a key named
+     *          style. After this method is invoked, more keys could be added.
+     *
+     * @deprecated use {@link FactoryProperties#insertStyle(Map)} instead. (since 1.2.22)
+     */
+    @SuppressWarnings("unchecked")
     @Deprecated // this method is nor called anywhere. But it is public so theoretically it could be called by consumers of OpenPdf, but why?
+    public static void insertStyle(HashMap h) {
+        insertStyle((Map<String, String>) h);
+    }
+
     public static void insertStyle(Map<String, String> h) {
         String style = h.get("style");
         if (style == null)
@@ -339,10 +355,10 @@ public class FactoryProperties {
                 case Markup.CSS_KEY_BG: {
                     for(String attribute: prop.getProperty(key).split(" ")) {
                         Color c = Markup.decodeColor(attribute.trim());
-                        if (c != null) {
+                    if (c != null) {
                             h.put(Markup.CSS_KEY_BGCOLOR, attribute.trim());
                             break;
-                        }
+                    }
                     }
                     break;
                 }

--- a/openpdf/src/main/java/com/lowagie/text/html/simpleparser/HTMLWorker.java
+++ b/openpdf/src/main/java/com/lowagie/text/html/simpleparser/HTMLWorker.java
@@ -126,6 +126,21 @@ public class HTMLWorker implements SimpleXMLDocHandler, DocListener {
         return parseToList(reader, style, interfaceProps);
     }
 
+    /**
+     * @deprecated use {@link HTMLWorker#parseToList(Reader, StyleSheet, Map)} since 1.2.22
+     * @param reader  the Reader
+     * @param style the StyleSheet
+     * @param interfaceProps the interface properties
+     * @return an ArrayList
+     * @throws IOException on error
+     */
+    @Deprecated
+    @SuppressWarnings("unchecked")
+    public static ArrayList<Element> parseToList(Reader reader, StyleSheet style, HashMap interfaceProps)
+            throws IOException {
+        return parseToList(reader, style, (Map<String, Object>) interfaceProps);
+    }
+
     public static ArrayList<Element> parseToList(Reader reader, StyleSheet style, Map<String, Object> interfaceProps)
             throws IOException {
         HTMLWorker worker = new HTMLWorker(null);
@@ -149,6 +164,17 @@ public class HTMLWorker implements SimpleXMLDocHandler, DocListener {
 
     public Map<String, Object> getInterfaceProps() {
         return interfaceProps;
+    }
+
+    /**
+     *
+     * @deprecated use {@link HTMLWorker#setInterfaceProps(Map)} since 1.2.22
+     * @param interfaceProps the properties of the interface
+     */
+    @SuppressWarnings("unchecked")
+    @Deprecated
+    public void setInterfaceProps(HashMap interfaceProps) {
+        setInterfaceProps((Map<String, Object>) interfaceProps);
     }
 
     public void setInterfaceProps(Map<String, Object> interfaceProps) {
@@ -180,6 +206,15 @@ public class HTMLWorker implements SimpleXMLDocHandler, DocListener {
         Map<String, String> h = new HashMap<>();
         style.applyStyle("body", h);
         cprops.addToChain("body", h);
+    }
+
+    /**
+     * @deprecated use {@link HTMLWorker#startElement(String, Map)}  } since 1.2.22
+     */
+    @Deprecated
+    @SuppressWarnings("unchecked")
+    public void startElement(String tag, HashMap h) {
+        startElement(tag, (Map<String, String>) h);
     }
 
     public void startElement(String tag, Map<String, String> style) {

--- a/openpdf/src/main/java/com/lowagie/text/html/simpleparser/IncTable.java
+++ b/openpdf/src/main/java/com/lowagie/text/html/simpleparser/IncTable.java
@@ -64,6 +64,15 @@ public class IncTable {
     private Map<String, String> props = new HashMap<>();
     private List<List<PdfPCell>> rows = new ArrayList<>();
     private List<PdfPCell> cols;
+    /** Creates a new instance of IncTable
+     * @param props a HashMap of the properties
+     */
+
+    @Deprecated
+    @SuppressWarnings("unchecked")
+    public IncTable(HashMap props) {
+        this.props.putAll(props);
+    }
 
     public IncTable(Map<String, String> props) {
         this.props.putAll(props);
@@ -73,6 +82,15 @@ public class IncTable {
         if (cols == null)
             cols = new ArrayList<>();
         cols.add(cell);
+    }
+
+    @Deprecated
+    @SuppressWarnings("unchecked")
+    public void addCols(ArrayList ncols) {
+        if (cols == null)
+            cols = (List<PdfPCell>)ncols;
+        else
+            cols.addAll(ncols);
     }
     
     public void addCols(List<PdfPCell> ncols) {
@@ -88,6 +106,15 @@ public class IncTable {
             rows.add(cols);
             cols = null;
         }
+    }
+
+    /**
+     * @deprecated use {@link #getTableRows()}
+     * @return an ArrayList of the Rows
+     */
+    @Deprecated
+    public ArrayList getRows() {
+        return (ArrayList) rows;
     }
     
     public List<List<PdfPCell>> getTableRows() {

--- a/openpdf/src/main/java/com/lowagie/text/html/simpleparser/StyleSheet.java
+++ b/openpdf/src/main/java/com/lowagie/text/html/simpleparser/StyleSheet.java
@@ -60,6 +60,18 @@ public class StyleSheet {
     private final Map<String, Map<String, String>> classMap = new HashMap<>();
     private final Map<String, Map<String, String>> tagMap = new HashMap<>();
 
+    /**
+     * @deprecated please use #applyStyle(String tag, Map&lt;String, String&gt; props) this method will be
+     * removed in 2.0
+     * @param props a HashMap
+     * @param tag the tag
+     */
+    @Deprecated
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    public void applyStyle(String tag, HashMap props) {
+        applyStyle(tag, (Map<String, String>) props);
+    }
+
     public void applyStyle(String tag, Map<String, String> props) {
         Map<String, String> map = tagMap.get(tag.toLowerCase());
         if (map != null) {

--- a/openpdf/src/main/java/com/lowagie/text/pdf/AcroFields.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/AcroFields.java
@@ -1831,6 +1831,19 @@ public class AcroFields {
    * Gets all the fields. The fields are keyed by the fully qualified field name and the value is an instance of
    * <CODE>AcroFields.Item</CODE>.
    *
+   * @deprecated use {@link AcroFields#getAllFields()}
+   *
+   * @return all the fields
+   */
+  @Deprecated
+  public HashMap getFields() {
+    return (HashMap) fields;
+  }
+
+  /**
+   * Gets all the fields. The fields are keyed by the fully qualified field name and the value is an instance of
+   * <CODE>AcroFields.Item</CODE>.
+   *
    * @return all the fields
    */
   public Map<String, Item> getAllFields() {
@@ -2160,37 +2173,49 @@ public class AcroFields {
     /**
      * An array of <CODE>PdfDictionary</CODE> where the value tag /V is present.
      *
+     * @deprecated (will remove ' public ' in the future)
      */
-    ArrayList<PdfDictionary> values = new ArrayList<>();
+    @Deprecated
+    public ArrayList<PdfDictionary> values = new ArrayList<>();
 
     /**
      * An array of <CODE>PdfDictionary</CODE> with the widgets.
      *
+     * @deprecated (will remove ' public ' in the future)
      */
-    ArrayList<PdfDictionary> widgets = new ArrayList<>();
+    @Deprecated
+    public ArrayList<PdfDictionary> widgets = new ArrayList<>();
 
     /**
      * An array of <CODE>PdfDictionary</CODE> with the widget references.
      *
+     * @deprecated (will remove ' public ' in the future)
      */
-    ArrayList<PdfIndirectReference> widgetRefs = new ArrayList<>();
+    @Deprecated
+    public ArrayList<PdfIndirectReference> widgetRefs = new ArrayList<>();
 
     /**
      * An array of <CODE>PdfDictionary</CODE> with all the field and widget tags merged.
      *
+     * @deprecated (will remove ' public ' in the future)
      */
-    ArrayList<PdfDictionary> merged = new ArrayList<>();
+    @Deprecated
+    public ArrayList<PdfDictionary> merged = new ArrayList<>();
 
     /**
      * An array of <CODE>Integer</CODE> with the page numbers where the widgets are displayed.
      *
+     * @deprecated (will remove ' public ' in the future)
      */
-    ArrayList<Integer> page = new ArrayList<>();
+    @Deprecated
+    public ArrayList<Integer> page = new ArrayList<>();
     /**
      * An array of <CODE>Integer</CODE> with the tab order of the field in the page.
      *
+     * @deprecated (will remove ' public ' in the future)
      */
-    ArrayList<Integer> tabOrder = new ArrayList<>();
+    @Deprecated
+    public ArrayList<Integer> tabOrder = new ArrayList<>();
     
     /**
      * The indirect reference of the item itself
@@ -2387,6 +2412,19 @@ public class AcroFields {
   /**
    * Gets the field names that have signatures and are signed.
    *
+   * @deprecated user {@link AcroFields#getSignedFieldNames()}
+   *
+   * @return the field names that have signatures and are signed
+   */
+  @Deprecated
+  @SuppressWarnings("unchecked")
+  public ArrayList<String> getSignatureNames() {
+      return (ArrayList<String>) getSignedFieldNames();
+  }
+
+  /**
+   * Gets the field names that have signatures and are signed.
+   *
    * @return the field names that have signatures and are signed
    */
   public List<String> getSignedFieldNames() {
@@ -2542,6 +2580,19 @@ public class AcroFields {
       }
       return this.sigTypes;
   }
+
+  /**
+   * Gets the field names that have blank signatures.
+   *
+   * @deprecated use {@link AcroFields#getFieldNamesWithBlankSignatures()}
+   *
+   * @return the field names that have blank signatures
+   */
+  @Deprecated
+  public ArrayList getBlankSignatureNames() {
+    return (ArrayList) getFieldNamesWithBlankSignatures();
+  }
+
     /**
      * Gets the field names that have blank signatures.
      *
@@ -2798,11 +2849,54 @@ public class AcroFields {
 
   /**
    * Gets the appearances cache.
+   * @deprecated use {@link AcroFields#getFieldCacheMap()}
+   * @return the appearances cache
+   * @since 2.1.5  this method used to return a HashMap
+   */
+  @Deprecated
+  public Map getFieldCache() {
+    return fieldCache;
+  }
+
+  /**
+   * Gets the appearances cache.
    *
    * @return the appearances cache
    */
   public Map<String, BaseField> getFieldCacheMap() {
     return fieldCache;
+  }
+
+  /**
+   * Sets a cache for field appearances. Parsing the existing PDF to create a new TextField is time expensive. For those tasks that
+   * repeatedly fill the same PDF with different field values the use of the cache has dramatic speed advantages. An example usage:
+   *
+   * <pre>
+   * String pdfFile = ...;// the pdf file used as template
+   * ArrayList xfdfFiles = ...;// the xfdf file names
+   * ArrayList pdfOutFiles = ...;// the output file names, one for each element in xpdfFiles
+   * HashMap cache = new HashMap();// the appearances cache
+   * PdfReader originalReader = new PdfReader(pdfFile);
+   * for (int k = 0; k &lt; xfdfFiles.size(); ++k) {
+   *    PdfReader reader = new PdfReader(originalReader);
+   *    XfdfReader xfdf = new XfdfReader((String)xfdfFiles.get(k));
+   *    PdfStamper stp = new PdfStamper(reader, new FileOutputStream((String)pdfOutFiles.get(k)));
+   *    AcroFields af = stp.getAcroFields();
+   *    af.setFieldCache(cache);
+   *    af.setFields(xfdf);
+   *    stp.close();
+   * }
+   * </pre>
+   *
+   * @deprecated use {@link AcroFields#setFieldCacheMap(Map)}
+   *
+   * @param fieldCache a Map that will carry the cached appearances
+   * @since 2.1.5  this method used to take a HashMap as parameter
+   */
+  @Deprecated
+  @SuppressWarnings("unchecked")
+  public void setFieldCache(Map fieldCache) {
+    this.fieldCache = fieldCache;
   }
 
   /**
@@ -2954,10 +3048,35 @@ public class AcroFields {
    * Gets the list of substitution fonts. The list is composed of <CODE>BaseFont</CODE> and can be <CODE>null</CODE>. The fonts in this list
    * will be used if the original font doesn't contain the needed glyphs.
    *
+   * @deprecated use {@link AcroFields#getAllSubstitutionFonts()}
+   * @return the list
+   */
+  @Deprecated
+  public ArrayList getSubstitutionFonts() {
+    return (ArrayList) substitutionFonts;
+  }
+
+  /**
+   * Gets the list of substitution fonts. The list is composed of <CODE>BaseFont</CODE> and can be <CODE>null</CODE>. The fonts in this list
+   * will be used if the original font doesn't contain the needed glyphs.
+   *
    * @return the list
    */
   public List<BaseFont> getAllSubstitutionFonts() {
     return substitutionFonts;
+  }
+
+  /**
+   * Sets a list of substitution fonts. The list is composed of <CODE>BaseFont</CODE> and can also be <CODE>null</CODE>. The fonts in this
+   * list will be used if the original font doesn't contain the needed glyphs.
+   *
+   * @deprecated use {@link AcroFields#setAllSubstitutionFonts(List)}
+   * @param substitutionFonts the list
+   */
+  @Deprecated
+  @SuppressWarnings("unchecked")
+  public void setSubstitutionFonts(ArrayList substitutionFonts) {
+    this.substitutionFonts = substitutionFonts;
   }
 
   /**

--- a/openpdf/src/main/java/com/lowagie/text/pdf/BaseField.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/BaseField.java
@@ -281,6 +281,16 @@ public abstract class BaseField {
         return app;
     }
 
+    /**
+     * @param text text
+     * @return an {@link ArrayList} of {@link String}
+     * @deprecated use {@link BaseField#getAllHardBreaks(String)}
+     */
+    @Deprecated
+    protected static ArrayList getHardBreaks(String text) {
+        return (ArrayList) getAllHardBreaks(text);
+    }
+
     protected static List<String> getAllHardBreaks(String text) {
         List<String> arr = new ArrayList<>();
         char[] cs = text.toCharArray();
@@ -314,6 +324,12 @@ public abstract class BaseField {
                 return;
             buf.setLength(len);
         }
+    }
+
+    @Deprecated
+    @SuppressWarnings("unchecked")
+    protected static ArrayList breakLines(ArrayList breaks, BaseFont font, float fontSize, float width) {
+        return (ArrayList) breakLines((List<String>) breaks, font, fontSize, width);
     }
 
     protected static List<String> breakLines(List<String> breaks, BaseFont font, float fontSize, float width) {

--- a/openpdf/src/main/java/com/lowagie/text/pdf/BidiLine.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/BidiLine.java
@@ -206,6 +206,16 @@ public class BidiLine {
         chunks.add(chunk);
     }
 
+    /**
+     * @param chunks an {@link ArrayList} of {@link PdfChunk}
+     * @deprecated  use {@link BidiLine#addChunks(List)}, since 1.2.22
+     */
+    @Deprecated
+    @SuppressWarnings("unchecked")
+    public void addChunks(ArrayList chunks) {
+        addChunks((List<PdfChunk>)chunks);
+    }
+
     public void addChunks(List<PdfChunk> chunks) {
         this.chunks.addAll(chunks);
     }

--- a/openpdf/src/main/java/com/lowagie/text/pdf/CMapAwareDocumentFont.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/CMapAwareDocumentFont.java
@@ -305,4 +305,23 @@ public class CMapAwareDocumentFont extends DocumentFont {
         }
         return result;
     }
+
+    /**
+     * Encodes bytes to a String.
+     * 
+     * @param bytes
+     *            the bytes from a stream
+     * @param offset
+     *            an offset
+     * @param len
+     *            a length
+     * @return a String encoded taking into account if the bytes are in unicode
+     *         or not.
+     * @deprecated method name is not indicative of what it does. Use
+     *             <code>decode</code> instead.
+     */
+    @Deprecated
+    public String encode(byte[] bytes, int offset, int len) {
+        return decode(bytes, offset, len);
+    }
 }

--- a/openpdf/src/main/java/com/lowagie/text/pdf/FdfReader.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/FdfReader.java
@@ -114,7 +114,7 @@ public class FdfReader extends PdfReader {
     protected void kidNode(PdfDictionary merged, String name) {
         PdfArray kids = merged.getAsArray(PdfName.KIDS);
         if (kids == null || kids.isEmpty()) {
-            if (!name.isEmpty())
+            if (name.length() > 0)
                 name = name.substring(1);
             fields.put(name, merged);
         }
@@ -150,6 +150,17 @@ public class FdfReader extends PdfReader {
         PdfDictionary merged = new PdfDictionary();
         merged.put(PdfName.KIDS, fld);
         kidNode(merged, "");
+    }
+
+    /** Gets all the fields. The map is keyed by the fully qualified
+     * field name and the value is a merged <CODE>PdfDictionary</CODE>
+     * with the field content.
+     * @deprecated use {@link #getAllFields()}
+     * @return all the fields
+     */
+    @Deprecated
+    public HashMap<String, PdfDictionary> getFields() {
+        return (HashMap<String, PdfDictionary>) fields;
     }
 
     /** Gets all the fields. The map is keyed by the fully qualified

--- a/openpdf/src/main/java/com/lowagie/text/pdf/FdfReader.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/FdfReader.java
@@ -114,7 +114,7 @@ public class FdfReader extends PdfReader {
     protected void kidNode(PdfDictionary merged, String name) {
         PdfArray kids = merged.getAsArray(PdfName.KIDS);
         if (kids == null || kids.isEmpty()) {
-            if (name.length() > 0)
+            if (name.isEmpty())
                 name = name.substring(1);
             fields.put(name, merged);
         }

--- a/openpdf/src/main/java/com/lowagie/text/pdf/FieldReader.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/FieldReader.java
@@ -1,5 +1,6 @@
 package com.lowagie.text.pdf;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -7,6 +8,9 @@ import java.util.Map;
  * Represents the basic needs for reading fields.
  */
 public interface FieldReader {
+
+    @Deprecated
+    HashMap<String, String> getFields();
 
     Map<String, String> getAllFields();
 

--- a/openpdf/src/main/java/com/lowagie/text/pdf/MappedRandomAccessFile.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/MappedRandomAccessFile.java
@@ -184,6 +184,7 @@ public class MappedRandomAccessFile implements AutoCloseable {
      * @throws IOException on error
      * @see java.io.RandomAccessFile#close()
      */
+    @Override
     public void close() throws IOException {
         clean(mappedByteBuffer);
         mappedByteBuffer = null;
@@ -198,6 +199,7 @@ public class MappedRandomAccessFile implements AutoCloseable {
      *
      * @see java.lang.Object#finalize()
      */
+    @Override
     protected void finalize() throws Throwable {
         close();
         super.finalize();
@@ -243,7 +245,7 @@ public class MappedRandomAccessFile implements AutoCloseable {
 
 
     private static boolean cleanJava9(final java.nio.ByteBuffer buffer) {
-        Boolean b = AccessController.doPrivileged((PrivilegedAction<Boolean>) () -> {
+        return AccessController.doPrivileged((PrivilegedAction<Boolean>) () -> {
         Boolean success = Boolean.FALSE;
         try {
                 final Class<?> unsafeClass = Class.forName("sun.misc.Unsafe");
@@ -259,8 +261,6 @@ public class MappedRandomAccessFile implements AutoCloseable {
         }
         return success;
         });
-        
-        return b;
     }
 
 

--- a/openpdf/src/main/java/com/lowagie/text/pdf/MappedRandomAccessFile.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/MappedRandomAccessFile.java
@@ -66,32 +66,32 @@ import java.security.PrivilegedAction;
  * @author Joakim Sandstroem Created on 6.9.2006
  */
 public class MappedRandomAccessFile implements AutoCloseable {
-
+    
     private MappedByteBuffer mappedByteBuffer = null;
     private FileChannel channel = null;
-
+    
     /**
      * Constructs a new MappedRandomAccessFile instance
      *
      * @param filename String
-     * @param mode     String r, w or rw
+     * @param mode String r, w or rw
      * @throws FileNotFoundException on error
-     * @throws IOException           on error
+     * @throws IOException on error
      */
     public MappedRandomAccessFile(String filename, String mode) throws IOException {
-
+        
         if (mode.equals("rw")) {
             init(
-                new java.io.RandomAccessFile(filename, mode).getChannel(),
-                FileChannel.MapMode.READ_WRITE);
+                    new java.io.RandomAccessFile(filename, mode).getChannel(),
+                    FileChannel.MapMode.READ_WRITE);
         } else {
             init(
-                new FileInputStream(filename).getChannel(),
-                FileChannel.MapMode.READ_ONLY);
+                    new FileInputStream(filename).getChannel(),
+                    FileChannel.MapMode.READ_ONLY);
         }
-
+        
     }
-
+    
     /**
      * initializes the channel and mapped bytebuffer
      *
@@ -100,7 +100,7 @@ public class MappedRandomAccessFile implements AutoCloseable {
      * @throws IOException
      */
     private void init(FileChannel channel, FileChannel.MapMode mapMode)
-        throws IOException {
+    throws IOException {
 
         if (channel.size() > Integer.MAX_VALUE) {
             throw new PdfException("The PDF file is too large. Max 2GB. Size: " + channel.size());
@@ -112,13 +112,13 @@ public class MappedRandomAccessFile implements AutoCloseable {
     }
 
     /**
-     * @return FileChannel
+     * @return  FileChannel
      * @since 2.0.8
      */
     public FileChannel getChannel() {
         return channel;
     }
-
+    
     /**
      * @return int next integer or -1 on EOF
      * @see java.io.RandomAccessFile#read()
@@ -126,17 +126,17 @@ public class MappedRandomAccessFile implements AutoCloseable {
     public int read() {
         try {
             byte b = mappedByteBuffer.get();
-
+            
             return b & 0xff;
         } catch (BufferUnderflowException e) {
             return -1; // EOF
         }
     }
-
+    
     /**
      * @param bytes byte[]
-     * @param off   int offset
-     * @param len   int length
+     * @param off int offset
+     * @param len int length
      * @return int bytes read or -1 on EOF
      * @see java.io.RandomAccessFile#read(byte[], int, int)
      */
@@ -153,7 +153,7 @@ public class MappedRandomAccessFile implements AutoCloseable {
         mappedByteBuffer.get(bytes, off, len);
         return len;
     }
-
+    
     /**
      * @return long
      * @see java.io.RandomAccessFile#getFilePointer()
@@ -161,7 +161,7 @@ public class MappedRandomAccessFile implements AutoCloseable {
     public long getFilePointer() {
         return mappedByteBuffer.position();
     }
-
+    
     /**
      * @param pos long position
      * @see java.io.RandomAccessFile#seek(long)
@@ -169,7 +169,7 @@ public class MappedRandomAccessFile implements AutoCloseable {
     public void seek(long pos) {
         mappedByteBuffer.position((int) pos);
     }
-
+    
     /**
      * @return long length
      * @see java.io.RandomAccessFile#length()
@@ -177,7 +177,7 @@ public class MappedRandomAccessFile implements AutoCloseable {
     public long length() {
         return mappedByteBuffer.limit();
     }
-
+    
     /**
      * Cleans the mapped bytebuffer and closes the channel
      *
@@ -192,7 +192,7 @@ public class MappedRandomAccessFile implements AutoCloseable {
         }
         channel = null;
     }
-
+    
     /**
      * invokes the close method
      *
@@ -202,7 +202,7 @@ public class MappedRandomAccessFile implements AutoCloseable {
         close();
         super.finalize();
     }
-
+    
 
     /**
      * invokes the clean method on the ByteBuffer's cleaner
@@ -217,7 +217,6 @@ public class MappedRandomAccessFile implements AutoCloseable {
 
         if (cleanJava9(buffer)) {
             return true;
-
         }
         return cleanOldsJDK(buffer);
     }
@@ -244,22 +243,24 @@ public class MappedRandomAccessFile implements AutoCloseable {
 
 
     private static boolean cleanJava9(final java.nio.ByteBuffer buffer) {
-        return AccessController.doPrivileged((PrivilegedAction<Boolean>) () -> {
-            Boolean success = Boolean.FALSE;
-            try {
+        Boolean b = AccessController.doPrivileged((PrivilegedAction<Boolean>) () -> {
+        Boolean success = Boolean.FALSE;
+        try {
                 final Class<?> unsafeClass = Class.forName("sun.misc.Unsafe");
                 final Field theUnsafeField = unsafeClass.getDeclaredField("theUnsafe");
                 theUnsafeField.setAccessible(true);
                 final Object theUnsafe = theUnsafeField.get(null);
                 final Method invokeCleanerMethod = unsafeClass
                     .getMethod("invokeCleaner", ByteBuffer.class);
-                invokeCleanerMethod.invoke(theUnsafe, buffer);
-                success = Boolean.TRUE;
+            invokeCleanerMethod.invoke(theUnsafe, buffer);
+            success = Boolean.TRUE;
             } catch (Exception ignore) {
-                // Ignore
-            }
-            return success;
+            // Ignore
+        }
+        return success;
         });
+        
+        return b;
     }
 
 

--- a/openpdf/src/main/java/com/lowagie/text/pdf/PdfAcroForm.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/PdfAcroForm.java
@@ -88,6 +88,16 @@ public class PdfAcroForm extends PdfDictionary {
         put(PdfName.NEEDAPPEARANCES, new PdfBoolean(value));
     }
 
+    /**
+     * Adds fieldTemplates.
+     * @param ft field templates
+     * @deprecated use {@link #addFieldTemplates(Map)}
+     */
+    @Deprecated
+    @SuppressWarnings("unchecked")
+    public void addFieldTemplates(HashMap ft) {
+        fieldTemplates.putAll(ft);
+    }
 
     /**
      * Adds fieldTemplates.

--- a/openpdf/src/main/java/com/lowagie/text/pdf/PdfArray.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/PdfArray.java
@@ -254,6 +254,17 @@ public class PdfArray extends PdfObject {
      */
     public boolean remove(PdfObject object) {
         return this.arrayList.remove(object);
+    }    
+
+    /**
+     * Get a copy the internal list for this PdfArray.
+     *
+     * @deprecated Please use getElements() instead.
+     * @return a copy of the the internal List.
+     */
+    @Deprecated
+    public List<PdfObject> getArrayList() {
+        return getElements();
     }
 
     /**

--- a/openpdf/src/main/java/com/lowagie/text/pdf/PdfCopyFields.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/PdfCopyFields.java
@@ -158,6 +158,7 @@ public class PdfCopyFields
     /**
      * Closes the output document.
      */    
+    @Override
     public void close() {
         fc.close();
     }
@@ -215,6 +216,7 @@ public class PdfCopyFields
     /**
      * @see com.lowagie.text.pdf.interfaces.PdfEncryptionSettings#setEncryption(byte[], byte[], int, int)
      */
+    @Override
     public void setEncryption(byte[] userPassword, byte[] ownerPassword, int permissions, int encryptionType) throws DocumentException {
         fc.setEncryption(userPassword, ownerPassword, permissions, encryptionType);
     }
@@ -222,6 +224,7 @@ public class PdfCopyFields
     /**
      * @see com.lowagie.text.pdf.interfaces.PdfViewerPreferences#addViewerPreference(com.lowagie.text.pdf.PdfName, com.lowagie.text.pdf.PdfObject)
      */
+    @Override
     public void addViewerPreference(PdfName key, PdfObject value) {
         fc.addViewerPreference(key, value);    
     }
@@ -229,6 +232,7 @@ public class PdfCopyFields
     /**
      * @see com.lowagie.text.pdf.interfaces.PdfViewerPreferences#setViewerPreferences(int)
      */
+    @Override
     public void setViewerPreferences(int preferences) {
         fc.setViewerPreferences(preferences);
     }
@@ -236,6 +240,7 @@ public class PdfCopyFields
     /**
      * @see com.lowagie.text.pdf.interfaces.PdfEncryptionSettings#setEncryption(java.security.cert.Certificate[], int[], int)
      */
+    @Override
     public void setEncryption(Certificate[] certs, int[] permissions, int encryptionType) throws DocumentException {
         fc.setEncryption(certs, permissions, encryptionType);
     }    

--- a/openpdf/src/main/java/com/lowagie/text/pdf/PdfCopyFieldsImp.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/PdfCopyFieldsImp.java
@@ -168,7 +168,7 @@ class PdfCopyFieldsImp extends PdfWriter {
         if (acro == null)
             return;
         PdfArray co = acro.getAsArray(PdfName.CO);
-        if (co == null || co.isEmpty())
+        if (co == null || co.size() == 0)
             return;
         AcroFields af = reader.getAcroFields();
         for (int k = 0; k < co.size(); ++k) {
@@ -261,6 +261,15 @@ class PdfCopyFieldsImp extends PdfWriter {
                 annots.add(0, ind);
             }
         }
+    }
+
+    /**
+     * @deprecated use {@link PdfCopyFieldsImp#branchForm(Map, PdfIndirectReference, String)}
+     */
+    @Deprecated
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    protected PdfArray branchForm(HashMap level, PdfIndirectReference parent, String fname) throws IOException {
+        return branchForm((Map<String, Object>) level, parent, fname);
     }
 
     protected PdfArray branchForm(Map<String, Object> level, PdfIndirectReference parent, String fname) throws IOException {

--- a/openpdf/src/main/java/com/lowagie/text/pdf/PdfCopyFieldsImp.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/PdfCopyFieldsImp.java
@@ -168,7 +168,7 @@ class PdfCopyFieldsImp extends PdfWriter {
         if (acro == null)
             return;
         PdfArray co = acro.getAsArray(PdfName.CO);
-        if (co == null || co.size() == 0)
+        if (co == null || co.isEmpty())
             return;
         AcroFields af = reader.getAcroFields();
         for (int k = 0; k < co.size(); ++k) {

--- a/openpdf/src/main/java/com/lowagie/text/pdf/PdfFormField.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/PdfFormField.java
@@ -248,6 +248,15 @@ public class PdfFormField extends PdfAnnotation {
             kids = new ArrayList<>();
         kids.add(field);
     }
+
+    /**
+     * @deprecated use {@link #getKidFields()}
+     * @return an ArrayList of the kids
+     */
+    @Deprecated
+    public ArrayList getKids() {
+        return (ArrayList) kids;
+    }
     
     public List<PdfFormField> getKidFields() {
         return kids;

--- a/openpdf/src/main/java/com/lowagie/text/pdf/PdfName.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/PdfName.java
@@ -973,13 +973,6 @@ public class PdfName extends PdfObject implements Comparable<PdfName> {
     public static final PdfName ITALICANGLE = new PdfName("ItalicAngle");
 
     /**
-     * @deprecated ITXT is a registered prefix of Bruno Lowagie (iText), and will be removed from OpenPDF. Will be
-     * deleted after 2022-04-30.
-     */
-    @Deprecated
-    public static final PdfName ITXT = new PdfName("ITXT");
-
-    /**
      * A name
      */
     public static final PdfName IX = new PdfName("IX");

--- a/openpdf/src/main/java/com/lowagie/text/pdf/PdfName.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/PdfName.java
@@ -973,6 +973,13 @@ public class PdfName extends PdfObject implements Comparable<PdfName> {
     public static final PdfName ITALICANGLE = new PdfName("ItalicAngle");
 
     /**
+     * @deprecated ITXT is a registered prefix of Bruno Lowagie (iText), and will be removed from OpenPDF. Will be
+     * deleted after 2022-04-30.
+     */
+    @Deprecated
+    public static final PdfName ITXT = new PdfName("ITXT");
+
+    /**
      * A name
      */
     public static final PdfName IX = new PdfName("IX");
@@ -1870,7 +1877,7 @@ public class PdfName extends PdfObject implements Comparable<PdfName> {
      *  <li>image dictionary</li>
      *  <li>Type 1 form dictionary</li>
      *  <li>group attributes dictionary</li>
-     *  <li>content group dictionary</li>
+     *  <li>content group dictionary</>
      *  <li>content membership dictionary</li>
      *  <li>Type 1 font dictionary</li>
      *  <li>Type 3 font dictionary</li>

--- a/openpdf/src/main/java/com/lowagie/text/pdf/PdfPKCS7.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/PdfPKCS7.java
@@ -1691,6 +1691,8 @@ public class PdfPKCS7 {
         /**
          * A HashMap with default symbols
          */
+        @Deprecated
+        public static HashMap DefaultSymbols = new HashMap();
         public static Map<ASN1Encodable, String> defaultSymbols = new HashMap<>();
 
         static {
@@ -1710,11 +1712,14 @@ public class PdfPKCS7 {
             defaultSymbols.put(INITIALS, "INITIALS");
             defaultSymbols.put(GENERATION, "GENERATION");
 
+            DefaultSymbols.putAll(defaultSymbols);
         }
 
         /**
          * A HashMap with values
          */
+        @Deprecated
+        public HashMap values = new HashMap();
         public Map<String, List<String>> valuesMap = new HashMap<>();
 
         /**
@@ -1774,11 +1779,34 @@ public class PdfPKCS7 {
         /**
          * gets a field array from the values Hashmap
          *
+         * @param name the name of the field to get
+         * @deprecated use {@link #getFieldsByName(String)}
+         * @return an ArrayList
+         */
+        @Deprecated
+        public ArrayList getFieldArray(String name) {
+            return (ArrayList) valuesMap.get(name);
+        }
+
+        /**
+         * gets a field array from the values Hashmap
+         *
          * @param name  the name of the field array to get
          * @return an ArrayList
          */
         public List<String> getFieldsByName(String name) {
             return valuesMap.get(name);
+        }
+
+        /**
+         * getter for values
+         *
+         * @deprecated use {@link #getAllFields()}
+         * @return a HashMap with the fields of the X509 name
+         */
+        @Deprecated
+        public HashMap getFields() {
+            return (HashMap) valuesMap;
         }
 
         /**

--- a/openpdf/src/main/java/com/lowagie/text/pdf/PdfStamper.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/PdfStamper.java
@@ -133,11 +133,34 @@ public class PdfStamper
 
     /** Gets the optional <CODE>String</CODE> map to add or change values in
      * the info dictionary.
+     * @deprecated use {@link #getInfoDictionary()}
+     * @return the map or <CODE>null</CODE>
+     *
+     */
+    @Deprecated
+    public HashMap getMoreInfo() {
+        return (HashMap) this.moreInfo;
+    }
+
+    /** Gets the optional <CODE>String</CODE> map to add or change values in
+     * the info dictionary.
      * @return the map or <CODE>null</CODE>
      *
      */
     public Map<String, String> getInfoDictionary() {
         return moreInfo;
+    }
+
+    /** An optional <CODE>String</CODE> map to add or change values in
+     * the info dictionary. Entries with <CODE>null</CODE>
+     * values delete the key in the original info dictionary
+     * @param moreInfo additional entries to the info dictionary
+     * @deprecated use {@link #setInfoDictionary(Map)}
+     */
+    @Deprecated
+    @SuppressWarnings("unchecked")
+    public void setMoreInfo(HashMap moreInfo) {
+        this.moreInfo = moreInfo;
     }
     
     /**

--- a/openpdf/src/main/java/com/lowagie/text/pdf/PdfWriter.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/PdfWriter.java
@@ -113,10 +113,10 @@ public class PdfWriter extends DocWriter implements
     /**
      * The highest generation number possible.
      *
-     * @since iText 2.1.6
+     * @since    iText 2.1.6
      */
     public static final int GENERATION_MAX = 65535;
-
+    
 // INNER CLASSES
 
     /**
@@ -126,9 +126,9 @@ public class PdfWriter extends DocWriter implements
      * (page 55-60). It contains the body of a PDF document (section 5.14) and it can also generate a Cross-reference
      * Table (section 5.15).
      *
-     * @see PdfWriter
-     * @see PdfObject
-     * @see PdfIndirectObject
+     * @see        PdfWriter
+     * @see        PdfObject
+     * @see        PdfIndirectObject
      */
     public static class PdfBody {
 
@@ -136,14 +136,14 @@ public class PdfWriter extends DocWriter implements
 
         // membervariables
 
-        /**
+          /**
          * array containing the cross-reference table of the normal objects.
-         */
+           */
         private final TreeSet<PdfCrossReference> xrefs;
-        private int refnum;
-        /**
+            private int refnum;
+            /**
          * the current byte position in the body.
-         */
+             */
         private long position;
         private final PdfWriter writer;
         private ByteBuffer index;
@@ -217,8 +217,8 @@ public class PdfWriter extends DocWriter implements
          * <CODE>PdfObject</CODE>. It also adds a <CODE>PdfCrossReference</CODE> for this object to an
          * <CODE>ArrayList</CODE> that will be used to build the Cross-reference Table.
          *
-         * @param object a <CODE>PdfObject</CODE>
-         * @return a <CODE>PdfIndirectObject</CODE>
+         * @param        object            a <CODE>PdfObject</CODE>
+         * @return        a <CODE>PdfIndirectObject</CODE>
          * @throws IOException
          */
         PdfIndirectObject add(PdfObject object) throws IOException {
@@ -252,9 +252,9 @@ public class PdfWriter extends DocWriter implements
          * It also adds a <CODE>PdfCrossReference</CODE> for this object to an <CODE>ArrayList</CODE> that will be used
          * to build the Cross-reference Table.
          *
-         * @param object a <CODE>PdfObject</CODE>
-         * @param ref    a <CODE>PdfIndirectReference</CODE>
-         * @return a <CODE>PdfIndirectObject</CODE>
+         * @param        object            a <CODE>PdfObject</CODE>
+         * @param        ref                a <CODE>PdfIndirectReference</CODE>
+         * @return        a <CODE>PdfIndirectObject</CODE>
          * @throws IOException
          */
         PdfIndirectObject add(PdfObject object, PdfIndirectReference ref) throws IOException {
@@ -294,7 +294,7 @@ public class PdfWriter extends DocWriter implements
         /**
          * Returns the offset of the Cross-Reference table.
          *
-         * @return an offset
+         * @return        an offset
          */
         long offset() {
             return position;
@@ -303,7 +303,7 @@ public class PdfWriter extends DocWriter implements
         /**
          * Returns the total number of objects contained in the CrossReferenceTable of this <CODE>Body</CODE>.
          *
-         * @return a number of objects
+         * @return    a number of objects
          */
         int size() {
             return Math.max((xrefs.last()).getRefnum() + 1, refnum);
@@ -434,9 +434,9 @@ public class PdfWriter extends DocWriter implements
                 this.offset = offset;
                 this.refnum = refnum;
                 this.generation = generation;
-            }
+    }
 
-            /**
+    /**
              * Constructs a cross-reference element for a PdfIndirectObject.
              *
              * @param refnum the reference number
@@ -506,10 +506,10 @@ public class PdfWriter extends DocWriter implements
              */
             @Override
             public boolean equals(Object obj) {
-                if (!(obj instanceof PdfCrossReference other)) {
+                if (!(obj instanceof PdfCrossReference)) {
                     return false;
                 }
-
+                final PdfCrossReference other = (PdfCrossReference)obj;
                 return refnum == other.refnum;
             }
 
@@ -534,9 +534,9 @@ public class PdfWriter extends DocWriter implements
         /**
          * Constructs a PDF-Trailer.
          *
-         * @param size       the number of entries in the <CODE>PdfCrossReferenceTable</CODE>
-         * @param root       an indirect reference to the root of the PDF document
-         * @param info       an indirect reference to the info object of the PDF document
+         * @param        size        the number of entries in the <CODE>PdfCrossReferenceTable</CODE>
+         * @param        root        an indirect reference to the root of the PDF document
+         * @param        info        an indirect reference to the info object of the PDF document
          * @param encryption
          * @param fileID
          * @param prevxref
@@ -557,7 +557,7 @@ public class PdfWriter extends DocWriter implements
             }
             if (prevxref > 0) {
                 put(PdfName.PREV, new PdfNumber(prevxref));
-            }
+        }
         }
 
         /**
@@ -591,8 +591,8 @@ public class PdfWriter extends DocWriter implements
      * Remark: a PdfWriter can only be constructed by calling the method
      * <CODE>getInstance(Document document, OutputStream os)</CODE>.
      *
-     * @param document The <CODE>PdfDocument</CODE> that has to be written
-     * @param os       The <CODE>OutputStream</CODE> the writer has to write to.
+     * @param    document    The <CODE>PdfDocument</CODE> that has to be written
+     * @param    os            The <CODE>OutputStream</CODE> the writer has to write to.
      */
 
     protected PdfWriter(PdfDocument document, OutputStream os) {
@@ -605,14 +605,14 @@ public class PdfWriter extends DocWriter implements
     /**
      * Use this method to get an instance of the <CODE>PdfWriter</CODE>.
      *
-     * @param document The <CODE>Document</CODE> that has to be written
-     * @param os       The <CODE>OutputStream</CODE> the writer has to write to.
-     * @return a new <CODE>PdfWriter</CODE>
-     * @throws DocumentException on error
+     * @param    document    The <CODE>Document</CODE> that has to be written
+     * @param    os    The <CODE>OutputStream</CODE> the writer has to write to.
+     * @return    a new <CODE>PdfWriter</CODE>
+     * @throws    DocumentException on error
      */
 
     public static PdfWriter getInstance(Document document, OutputStream os)
-        throws DocumentException {
+    throws DocumentException {
         PdfDocument pdf = new PdfDocument();
         pdf.setTextRenderingOptions(document.getTextRenderingOptions());
         document.addDocListener(pdf);
@@ -625,14 +625,14 @@ public class PdfWriter extends DocWriter implements
      * Use this method to get an instance of the <CODE>PdfWriter</CODE>.
      *
      * @param document The <CODE>Document</CODE> that has to be written
-     * @param os       The <CODE>OutputStream</CODE> the writer has to write to.
+     * @param os The <CODE>OutputStream</CODE> the writer has to write to.
      * @param listener A <CODE>DocListener</CODE> to pass to the PdfDocument.
      * @return a new <CODE>PdfWriter</CODE>
      * @throws DocumentException on error
      */
 
     public static PdfWriter getInstance(Document document, OutputStream os, DocListener listener)
-        throws DocumentException {
+    throws DocumentException {
         PdfDocument pdf = new PdfDocument();
         pdf.setTextRenderingOptions(document.getTextRenderingOptions());
         pdf.addDocListener(listener);
@@ -683,9 +683,9 @@ public class PdfWriter extends DocWriter implements
     /**
      * Sets the initial leading for the PDF document. This has to be done before the document is opened.
      *
-     * @param leading the initial leading
+     * @param    leading    the initial leading
      * @throws DocumentException if you try setting the leading after the document was opened.
-     * @since 2.1.6
+     * @since    2.1.6
      */
     public void setInitialLeading(float leading) throws DocumentException {
         if (open) {
@@ -694,17 +694,17 @@ public class PdfWriter extends DocWriter implements
         }
         pdf.setLeading(leading);
     }
-
+    
 //    the PdfDirectContentByte instances
 
-    /*
-     * You should see Direct Content as a canvas on which you can draw
-     * graphics and text. One canvas goes on top of the page (getDirectContent),
-     * the other goes underneath (getDirectContentUnder).
-     * You can always the same object throughout your document,
-     * even if you have moved to a new page. Whatever you add on
-     * the canvas will be displayed on top or under the current page.
-     */
+/*
+ * You should see Direct Content as a canvas on which you can draw
+ * graphics and text. One canvas goes on top of the page (getDirectContent),
+ * the other goes underneath (getDirectContentUnder).
+ * You can always the same object throughout your document,
+ * even if you have moved to a new page. Whatever you add on
+ * the canvas will be displayed on top or under the current page.
+ */
 
     /**
      * The direct content in this document.
@@ -754,13 +754,13 @@ public class PdfWriter extends DocWriter implements
 
 //    PDF body
 
-    /*
-     * A PDF file has 4 parts: a header, a body, a cross-reference table, and a trailer.
-     * The body contains all the PDF objects that make up the PDF document.
-     * Each element gets a reference (a set of numbers) and the byte position of
-     * every object is stored in the cross-reference table.
-     * Use these methods only if you know what you're doing.
-     */
+/*
+ * A PDF file has 4 parts: a header, a body, a cross-reference table, and a trailer.
+ * The body contains all the PDF objects that make up the PDF document.
+ * Each element gets a reference (a set of numbers) and the byte position of
+ * every object is stored in the cross-reference table.
+ * Use these methods only if you know what you're doing.
+ */
 
     /**
      * body of the PDF document
@@ -787,8 +787,8 @@ public class PdfWriter extends DocWriter implements
                 addToBody(new PdfString("invalid_" + name), (PdfIndirectReference) obj[1]);
             } else {
                 addToBody(destination, (PdfIndirectReference) obj[1]);
-            }
         }
+    }
     }
 
     /**
@@ -805,7 +805,7 @@ public class PdfWriter extends DocWriter implements
     /**
      * Use this method to add a PDF object to the PDF body. Use this method only if you know what you're doing!
      *
-     * @param object   the PDF object to add
+     * @param object the PDF object to add
      * @param inObjStm a boolean
      * @return a PdfIndirectObject
      * @throws IOException thrown when an I/O operation fails
@@ -818,7 +818,7 @@ public class PdfWriter extends DocWriter implements
      * Use this method to add a PDF object to the PDF body. Use this method only if you know what you're doing!
      *
      * @param object the object to add
-     * @param ref    the IndirectReference of that object
+     * @param ref the IndirectReference of that object
      * @return a PdfIndirectObject
      * @throws IOException thrown when an I/O operation fails
      */
@@ -829,8 +829,8 @@ public class PdfWriter extends DocWriter implements
     /**
      * Use this method to add a PDF object to the PDF body. Use this method only if you know what you're doing!
      *
-     * @param object   the object to add
-     * @param ref      the indirect reference
+     * @param object the object to add
+     * @param ref the indirect reference
      * @param inObjStm a boolean
      * @return a PdfIndirectObject
      * @throws IOException thrown when an I/O operation fails
@@ -843,7 +843,7 @@ public class PdfWriter extends DocWriter implements
     /**
      * Use this method to add a PDF object to the PDF body. Use this method only if you know what you're doing!
      *
-     * @param object    the object to add
+     * @param object the object to add
      * @param refNumber the reference number
      * @return a PdfIndirectObject
      * @throws IOException thrown when an I/O operation fails
@@ -855,9 +855,9 @@ public class PdfWriter extends DocWriter implements
     /**
      * Use this method to add a PDF object to the PDF body. Use this method only if you know what you're doing!
      *
-     * @param object    the object to add
+     * @param object the object to add
      * @param refNumber the reference number
-     * @param inObjStm  a boolean
+     * @param inObjStm a boolean
      * @return a PdfIndirectObject
      * @throws IOException thrown when an I/O operation fails
      */
@@ -891,13 +891,13 @@ public class PdfWriter extends DocWriter implements
 
 //    PDF Catalog
 
-    /*
-     * The Catalog is also called the root object of the document.
-     * Whereas the Cross-Reference maps the objects number with the
-     * byte offset so that the viewer can find the objects, the
-     * Catalog tells the viewer the numbers of the objects needed
-     * to render the document.
-     */
+/*
+ * The Catalog is also called the root object of the document.
+ * Whereas the Cross-Reference maps the objects number with the
+ * byte offset so that the viewer can find the objects, the
+ * Catalog tells the viewer the numbers of the objects needed
+ * to render the document.
+ */
 
     protected PdfDictionary getCatalog(PdfIndirectReference rootObj) {
         PdfDictionary catalog = pdf.getCatalog(rootObj);
@@ -943,12 +943,12 @@ public class PdfWriter extends DocWriter implements
 
 //    PdfPages
 
-    /*
-     * The page root keeps the complete page tree of the document.
-     * There's an entry in the Catalog that refers to the root
-     * of the page tree, the page tree contains the references
-     * to pages and other page trees.
-     */
+/*
+ * The page root keeps the complete page tree of the document.
+ * There's an entry in the Catalog that refers to the root
+ * of the page tree, the page tree contains the references
+ * to pages and other page trees.
+ */
 
     /**
      * The root of the page tree.
@@ -965,7 +965,7 @@ public class PdfWriter extends DocWriter implements
     /**
      * The value of the Tabs entry in the page dictionary.
      *
-     * @since 2.1.5
+     * @since    2.1.5
      */
     protected PdfName tabs = null;
 
@@ -973,7 +973,7 @@ public class PdfWriter extends DocWriter implements
      * Use this method to make sure the page tree has a linear structure (every leave is attached directly to the root).
      * Use this method to allow page reordering with method reorderPages.
      */
-    public void setLinearPageMode() {
+     public void setLinearPageMode() {
         root.setLinearMode(null);
     }
 
@@ -1045,7 +1045,7 @@ public class PdfWriter extends DocWriter implements
      *
      * @param tabs Can be PdfName.R, PdfName.C or PdfName.S. Since the Adobe Extensions Level 3, it can also be
      *             PdfName.A or PdfName.W
-     * @since 2.1.5
+     * @since    2.1.5
      */
     public void setTabs(PdfName tabs) {
         this.tabs = tabs;
@@ -1055,7 +1055,7 @@ public class PdfWriter extends DocWriter implements
      * Returns the value to be used for the Tabs entry in the page tree.
      *
      * @return a PdfName of the value of the Tabs entry in the page dictionnary
-     * @since 2.1.5
+     * @since    2.1.5
      */
     public PdfName getTabs() {
         return tabs;
@@ -1066,7 +1066,7 @@ public class PdfWriter extends DocWriter implements
      * <p>
      * The document has to be open before you can begin to add content to the body of the document.
      *
-     * @param page     the <CODE>PdfPage</CODE> to add
+     * @param page the <CODE>PdfPage</CODE> to add
      * @param contents the <CODE>PdfContents</CODE> of the page
      * @return a <CODE>PdfIndirectReference</CODE>
      * @throws PdfException on error
@@ -1101,12 +1101,12 @@ public class PdfWriter extends DocWriter implements
 
 //    page events
 
-    /*
-     * Page events are specific for iText, not for PDF.
-     * Upon specific events (for instance when a page starts
-     * or ends), the corresponding method in the page event
-     * implementation that is added to the writer is invoked.
-     */
+/*
+ * Page events are specific for iText, not for PDF.
+ * Upon specific events (for instance when a page starts
+ * or ends), the corresponding method in the page event
+ * implementation that is added to the writer is invoked.
+ */
 
     /**
      * The <CODE>PdfPageEvent</CODE> for this document.
@@ -1167,10 +1167,10 @@ public class PdfWriter extends DocWriter implements
             body = new PdfBody(this);
             if (pdfxConformance.isPdfX32002()) {
                 PdfDictionary sec = new PdfDictionary();
-                sec.put(PdfName.GAMMA, new PdfArray(new float[]{2.2f, 2.2f, 2.2f}));
+                sec.put(PdfName.GAMMA, new PdfArray(new float[]{2.2f,2.2f,2.2f}));
                 sec.put(PdfName.MATRIX, new PdfArray(
                     new float[]{0.4124f, 0.2126f, 0.0193f, 0.3576f, 0.7152f, 0.1192f, 0.1805f, 0.0722f, 0.9505f}));
-                sec.put(PdfName.WHITEPOINT, new PdfArray(new float[]{0.9505f, 1f, 1.089f}));
+                sec.put(PdfName.WHITEPOINT, new PdfArray(new float[]{0.9505f,1f,1.089f}));
                 PdfArray arr = new PdfArray(PdfName.CALRGB);
                 arr.add(sec);
                 setDefaultColorspace(PdfName.DEFAULTRGB, addToBody(arr).getIndirectReference());
@@ -1197,14 +1197,14 @@ public class PdfWriter extends DocWriter implements
                     .getComposedMessage("you.should.call.document.close.instead"));
             }
             if ((currentPageNumber - 1) != pageReferences.size())
-            // 2019-04-26: If you get this error, it could be that you are using OpenPDF or
-            // another library such as flying-saucer's ITextRenderer in a non-threadsafe way.
-            // ITextRenderer is not thread safe. So if you get this problem here, create a new
-            // instance, rather than re-using it.
-            // See: https://github.com/LibrePDF/OpenPDF/issues/164
+                // 2019-04-26: If you get this error, it could be that you are using OpenPDF or
+                // another library such as flying-saucer's ITextRenderer in a non-threadsafe way.
+                // ITextRenderer is not thread safe. So if you get this problem here, create a new
+                // instance, rather than re-using it.
+                // See: https://github.com/LibrePDF/OpenPDF/issues/164
             {
                 throw new RuntimeException("The page " + pageReferences.size() +
-                    " was requested but the document has only " + (currentPageNumber - 1) + " pages.");
+                " was requested but the document has only " + (currentPageNumber - 1) + " pages.");
             }
 
             try {
@@ -1260,7 +1260,7 @@ public class PdfWriter extends DocWriter implements
 
                 // write the cross-reference table of the body
                 body.writeCrossReferenceTable(os, indirectCatalog.getIndirectReference(),
-                    infoObj.getIndirectReference(), encryption, fileID, prevxref);
+                    infoObj.getIndirectReference(), encryption,  fileID, prevxref);
 
                 os.write(getISOBytes("startxref\n"));
                 os.write(getISOBytes(String.valueOf(body.offset())));
@@ -1319,7 +1319,8 @@ public class PdfWriter extends DocWriter implements
         for (Map.Entry<Object, PdfObject[]> entry : documentProperties.entrySet()) {
             Object prop = entry.getKey();
             PdfObject[] obj = entry.getValue();
-            if (prop instanceof PdfLayerMembership layer) {
+            if (prop instanceof PdfLayerMembership) {
+                PdfLayerMembership layer = (PdfLayerMembership) prop;
                 addToBody(layer.getPdfObject(), layer.getRef());
             } else if ((prop instanceof PdfDictionary) && !(prop instanceof PdfLayer)) {
                 addToBody((PdfDictionary) prop, (PdfIndirectReference) obj[1]);
@@ -1335,17 +1336,17 @@ public class PdfWriter extends DocWriter implements
 
 //  [C1] Outlines (bookmarks)
 
-    /**
+     /**
      * Use this method to get the root outline and construct bookmarks.
      *
-     * @return the root outline
-     */
+      * @return the root outline
+      */
 
-    public PdfOutline getRootOutline() {
-        return directContent.getRootOutline();
-    }
+     public PdfOutline getRootOutline() {
+         return directContent.getRootOutline();
+     }
 
-    protected List newBookmarks;
+     protected List newBookmarks;
 
     /**
      * Sets the bookmarks. The list structure is defined in {@link SimpleBookmark}.
@@ -1363,8 +1364,8 @@ public class PdfWriter extends DocWriter implements
         PdfDictionary top = new PdfDictionary();
         PdfIndirectReference topRef = getPdfIndirectReference();
         Object[] kids = SimpleBookmark.iterateOutlines(this, topRef, newBookmarks, namedAsNames);
-        top.put(PdfName.FIRST, (PdfIndirectReference) kids[0]);
-        top.put(PdfName.LAST, (PdfIndirectReference) kids[1]);
+        top.put(PdfName.FIRST, (PdfIndirectReference)kids[0]);
+        top.put(PdfName.LAST, (PdfIndirectReference)kids[1]);
         top.put(PdfName.COUNT, new PdfNumber((Integer) kids[2]));
         addToBody(top, topRef);
         catalog.put(PdfName.OUTLINES, topRef);
@@ -1374,52 +1375,52 @@ public class PdfWriter extends DocWriter implements
     /**
      * possible PDF version (header)
      */
-    public static final char VERSION_1_2 = '2';
+     public static final char VERSION_1_2 = '2';
     /**
      * possible PDF version (header)
      */
-    public static final char VERSION_1_3 = '3';
+     public static final char VERSION_1_3 = '3';
     /**
      * possible PDF version (header)
      */
-    public static final char VERSION_1_4 = '4';
+     public static final char VERSION_1_4 = '4';
     /**
      * possible PDF version (header)
      */
-    public static final char VERSION_1_5 = '5';
+     public static final char VERSION_1_5 = '5';
     /**
      * possible PDF version (header)
      */
-    public static final char VERSION_1_6 = '6';
+     public static final char VERSION_1_6 = '6';
     /**
      * possible PDF version (header)
      */
-    public static final char VERSION_1_7 = '7';
+     public static final char VERSION_1_7 = '7';
 
     /**
      * possible PDF version (catalog)
      */
-    public static final PdfName PDF_VERSION_1_2 = new PdfName("1.2");
+     public static final PdfName PDF_VERSION_1_2 = new PdfName("1.2");
     /**
      * possible PDF version (catalog)
      */
-    public static final PdfName PDF_VERSION_1_3 = new PdfName("1.3");
+     public static final PdfName PDF_VERSION_1_3 = new PdfName("1.3");
     /**
      * possible PDF version (catalog)
      */
-    public static final PdfName PDF_VERSION_1_4 = new PdfName("1.4");
+     public static final PdfName PDF_VERSION_1_4 = new PdfName("1.4");
     /**
      * possible PDF version (catalog)
      */
-    public static final PdfName PDF_VERSION_1_5 = new PdfName("1.5");
+     public static final PdfName PDF_VERSION_1_5 = new PdfName("1.5");
     /**
      * possible PDF version (catalog)
      */
-    public static final PdfName PDF_VERSION_1_6 = new PdfName("1.6");
+     public static final PdfName PDF_VERSION_1_6 = new PdfName("1.6");
     /**
      * possible PDF version (catalog)
      */
-    public static final PdfName PDF_VERSION_1_7 = new PdfName("1.7");
+     public static final PdfName PDF_VERSION_1_7 = new PdfName("1.7");
 
     /**
      * Stores the version information for the header and the catalog.
@@ -1429,6 +1430,7 @@ public class PdfWriter extends DocWriter implements
     /**
      * @see com.lowagie.text.pdf.interfaces.PdfVersion#setPdfVersion(char)
      */
+    @Override
     public void setPdfVersion(char version) {
         pdf_version.setPdfVersion(version);
     }
@@ -1436,6 +1438,7 @@ public class PdfWriter extends DocWriter implements
     /**
      * @see com.lowagie.text.pdf.interfaces.PdfVersion#setAtLeastPdfVersion(char)
      */
+    @Override
     public void setAtLeastPdfVersion(char version) {
         pdf_version.setAtLeastPdfVersion(version);
     }
@@ -1443,18 +1446,20 @@ public class PdfWriter extends DocWriter implements
     /**
      * @see com.lowagie.text.pdf.interfaces.PdfVersion#setPdfVersion(com.lowagie.text.pdf.PdfName)
      */
+    @Override
     public void setPdfVersion(PdfName version) {
         pdf_version.setPdfVersion(version);
     }
 
     /**
      * @see com.lowagie.text.pdf.interfaces.PdfVersion#addDeveloperExtension(com.lowagie.text.pdf.PdfDeveloperExtension)
-     * @since 2.1.6
+     * @since    2.1.6
      */
+    @Override
     public void addDeveloperExtension(PdfDeveloperExtension de) {
         pdf_version.addDeveloperExtension(de);
     }
-
+    
     /**
      * Returns the version information.
      */
@@ -1579,6 +1584,7 @@ public class PdfWriter extends DocWriter implements
     /**
      * @see com.lowagie.text.pdf.interfaces.PdfViewerPreferences#setViewerPreferences(int)
      */
+    @Override
     public void setViewerPreferences(int preferences) {
         pdf.setViewerPreferences(preferences);
     }
@@ -1587,6 +1593,7 @@ public class PdfWriter extends DocWriter implements
      * @see com.lowagie.text.pdf.interfaces.PdfViewerPreferences#addViewerPreference(com.lowagie.text.pdf.PdfName,
      * com.lowagie.text.pdf.PdfObject)
      */
+    @Override
     public void addViewerPreference(PdfName key, PdfObject value) {
         pdf.addViewerPreference(key, value);
     }
@@ -1611,8 +1618,8 @@ public class PdfWriter extends DocWriter implements
      * @param map         a map with strings as keys for the names, and structured strings as values for the
      *                    destinations
      * @param page_offset number of pages that has to be added to the page numbers in the destinations (useful if you
-     *                    use this method in combination with PdfCopy).
-     * @since iText 5.0
+     *          use this method in combination with PdfCopy).
+     * @since    iText 5.0
      */
     public void addNamedDestinations(Map<String, String> map, int page_offset) {
         Map.Entry<String, String> entry;
@@ -1627,175 +1634,178 @@ public class PdfWriter extends DocWriter implements
             addNamedDestination(entry.getKey(), page + page_offset, destination);
         }
     }
-
+    
     /**
      * Adds one named destination.
      *
-     * @param name the name for the destination
-     * @param page the page number where you want to jump to
-     * @param dest an explicit destination
-     * @since iText 5.0
+     * @param    name    the name for the destination
+     * @param    page    the page number where you want to jump to
+     * @param    dest    an explicit destination
+     * @since    iText 5.0
      */
     public void addNamedDestination(String name, int page, PdfDestination dest) {
         dest.addPage(getPageReference(page));
         pdf.localDestination(name, dest);
     }
-
-    /**
+    
+     /**
      * Use this method to add a JavaScript action at the document level. When the document opens, all this JavaScript
      * runs.
      *
-     * @param js The JavaScript action
-     */
-    public void addJavaScript(PdfAction js) {
-        pdf.addJavaScript(js);
-    }
+      * @param js The JavaScript action
+      */
+     public void addJavaScript(PdfAction js) {
+         pdf.addJavaScript(js);
+     }
 
-    /**
+     /**
      * Use this method to add a JavaScript action at the document level. When the document opens, all this JavaScript
      * runs.
      *
-     * @param code    the JavaScript code
+      * @param code the JavaScript code
      * @param unicode select JavaScript unicode. Note that the internal Acrobat JavaScript engine does not support
      *                unicode, so this may or may not work for you
-     */
-    public void addJavaScript(String code, boolean unicode) {
-        addJavaScript(PdfAction.javaScript(code, this, unicode));
-    }
+      */
+     public void addJavaScript(String code, boolean unicode) {
+         addJavaScript(PdfAction.javaScript(code, this, unicode));
+     }
 
-    /**
+     /**
      * Use this method to adds a JavaScript action at the document level. When the document opens, all this JavaScript
      * runs.
      *
-     * @param code the JavaScript code
-     */
-    public void addJavaScript(String code) {
-        addJavaScript(code, false);
-    }
+      * @param code the JavaScript code
+      */
+     public void addJavaScript(String code) {
+         addJavaScript(code, false);
+     }
 
-    /**
+     /**
      * Use this method to add a JavaScript action at the document level. When the document opens, all this JavaScript
      * runs.
      *
-     * @param name The name of the JS Action in the name tree
-     * @param js   The JavaScript action
-     */
-    public void addJavaScript(String name, PdfAction js) {
-        pdf.addJavaScript(name, js);
-    }
+      * @param name    The name of the JS Action in the name tree
+      * @param js The JavaScript action
+      */
+     public void addJavaScript(String name, PdfAction js) {
+         pdf.addJavaScript(name, js);
+     }
 
-    /**
+     /**
      * Use this method to add a JavaScript action at the document level. When the document opens, all this JavaScript
      * runs.
      *
-     * @param name    The name of the JS Action in the name tree
-     * @param code    the JavaScript code
+      * @param name    The name of the JS Action in the name tree
+      * @param code the JavaScript code
      * @param unicode select JavaScript unicode. Note that the internal Acrobat JavaScript engine does not support
      *                unicode, so this may or may not work for you
-     */
-    public void addJavaScript(String name, String code, boolean unicode) {
-        addJavaScript(name, PdfAction.javaScript(code, this, unicode));
-    }
+      */
+     public void addJavaScript(String name, String code, boolean unicode) {
+         addJavaScript(name, PdfAction.javaScript(code, this, unicode));
+     }
 
-    /**
+     /**
      * Use this method to adds a JavaScript action at the document level. When the document opens, all this JavaScript
      * runs.
      *
-     * @param name The name of the JS Action in the name tree
-     * @param code the JavaScript code
-     */
-    public void addJavaScript(String name, String code) {
-        addJavaScript(name, code, false);
-    }
+      * @param name    The name of the JS Action in the name tree
+      * @param code the JavaScript code
+      */
+     public void addJavaScript(String name, String code) {
+         addJavaScript(name, code, false);
+     }
 
-    /**
-     * Use this method to add a file attachment at the document level.
+     /**
+      * Use this method to add a file attachment at the document level.
      *
-     * @param description the file description
+      * @param description the file description
      * @param fileStore   an array with the file. If it's <CODE>null</CODE> the file will be read from the disk
-     * @param file        the path to the file. It will only be used if
-     *                    <CODE>fileStore</CODE> is not <CODE>null</CODE>
-     * @param fileDisplay the actual file name stored in the pdf
-     * @throws IOException on error
-     */
+      * @param file the path to the file. It will only be used if
+      * <CODE>fileStore</CODE> is not <CODE>null</CODE>
+      * @param fileDisplay the actual file name stored in the pdf
+      * @throws IOException on error
+      */
     public void addFileAttachment(String description, byte[] fileStore, String file, String fileDisplay)
         throws IOException {
-        addFileAttachment(description, PdfFileSpecification.fileEmbedded(this, file, fileDisplay, fileStore));
-    }
+         addFileAttachment(description, PdfFileSpecification.fileEmbedded(this, file, fileDisplay, fileStore));
+     }
 
-    /**
-     * Use this method to add a file attachment at the document level.
+     /**
+      * Use this method to add a file attachment at the document level.
      *
-     * @param description the file description
-     * @param fs          the file specification
-     * @throws IOException thrown when an I/O operation fails
-     */
-    public void addFileAttachment(String description, PdfFileSpecification fs) throws IOException {
-        pdf.addFileAttachment(description, fs);
-    }
+      * @param description the file description
+      * @param fs the file specification
+      * @throws IOException thrown when an I/O operation fails
+      */
+     public void addFileAttachment(String description, PdfFileSpecification fs) throws IOException {
+         pdf.addFileAttachment(description, fs);
+     }
 
-    /**
-     * Use this method to add a file attachment at the document level.
+     /**
+      * Use this method to add a file attachment at the document level.
      *
-     * @param fs the file specification
-     * @throws IOException thrown when an I/O operation fails
-     */
-    public void addFileAttachment(PdfFileSpecification fs) throws IOException {
-        addFileAttachment(null, fs);
-    }
+      * @param fs the file specification
+      * @throws IOException thrown when an I/O operation fails
+      */
+     public void addFileAttachment(PdfFileSpecification fs) throws IOException {
+         addFileAttachment(null, fs);
+     }
 
 // [C6] Actions (open and additional)
 
     /**
      * action value
      */
-    public static final PdfName DOCUMENT_CLOSE = PdfName.WC;
+     public static final PdfName DOCUMENT_CLOSE = PdfName.WC;
     /**
      * action value
      */
-    public static final PdfName WILL_SAVE = PdfName.WS;
+     public static final PdfName WILL_SAVE = PdfName.WS;
     /**
      * action value
      */
-    public static final PdfName DID_SAVE = PdfName.DS;
+     public static final PdfName DID_SAVE = PdfName.DS;
     /**
      * action value
      */
-    public static final PdfName WILL_PRINT = PdfName.WP;
+     public static final PdfName WILL_PRINT = PdfName.WP;
     /**
      * action value
      */
-    public static final PdfName DID_PRINT = PdfName.DP;
+     public static final PdfName DID_PRINT = PdfName.DP;
 
     /**
      * @see com.lowagie.text.pdf.interfaces.PdfDocumentActions#setOpenAction(java.lang.String)
      */
+    @Override
     public void setOpenAction(String name) {
-        pdf.setOpenAction(name);
-    }
+         pdf.setOpenAction(name);
+     }
 
     /**
      * @see com.lowagie.text.pdf.interfaces.PdfDocumentActions#setOpenAction(com.lowagie.text.pdf.PdfAction)
      */
+    @Override
     public void setOpenAction(PdfAction action) {
-        pdf.setOpenAction(action);
-    }
+         pdf.setOpenAction(action);
+     }
 
     /**
      * @see com.lowagie.text.pdf.interfaces.PdfDocumentActions#setAdditionalAction(com.lowagie.text.pdf.PdfName,
      * com.lowagie.text.pdf.PdfAction)
      */
+    @Override
     public void setAdditionalAction(PdfName actionType, PdfAction action) throws DocumentException {
-        if (!(actionType.equals(DOCUMENT_CLOSE) ||
-            actionType.equals(WILL_SAVE) ||
-            actionType.equals(DID_SAVE) ||
-            actionType.equals(WILL_PRINT) ||
-            actionType.equals(DID_PRINT))) {
+         if (!(actionType.equals(DOCUMENT_CLOSE) ||
+         actionType.equals(WILL_SAVE) ||
+         actionType.equals(DID_SAVE) ||
+         actionType.equals(WILL_PRINT) ||
+         actionType.equals(DID_PRINT))) {
             throw new DocumentException(
                 MessageLocalization.getComposedMessage("invalid.additional.action.type.1", actionType.toString()));
-        }
-        pdf.addAdditionalAction(actionType, action);
-    }
+         }
+         pdf.addAdditionalAction(actionType, action);
+     }
 
 //  [C7] portable collections
 
@@ -1823,6 +1833,7 @@ public class PdfWriter extends DocWriter implements
     /**
      * @see com.lowagie.text.pdf.interfaces.PdfAnnotations#getAcroForm()
      */
+    @Override
     public PdfAcroForm getAcroForm() {
         return pdf.getAcroForm();
     }
@@ -1830,6 +1841,7 @@ public class PdfWriter extends DocWriter implements
     /**
      * @see com.lowagie.text.pdf.interfaces.PdfAnnotations#addAnnotation(com.lowagie.text.pdf.PdfAnnotation)
      */
+    @Override
     public void addAnnotation(PdfAnnotation annot) {
         pdf.addAnnotation(annot);
     }
@@ -1841,6 +1853,7 @@ public class PdfWriter extends DocWriter implements
     /**
      * @see com.lowagie.text.pdf.interfaces.PdfAnnotations#addCalculationOrder(com.lowagie.text.pdf.PdfFormField)
      */
+    @Override
     public void addCalculationOrder(PdfFormField annot) {
         pdf.addCalculationOrder(annot);
     }
@@ -1848,6 +1861,7 @@ public class PdfWriter extends DocWriter implements
     /**
      * @see com.lowagie.text.pdf.interfaces.PdfAnnotations#setSigFlags(int)
      */
+    @Override
     public void setSigFlags(int f) {
         pdf.setSigFlags(f);
     }
@@ -1928,6 +1942,7 @@ public class PdfWriter extends DocWriter implements
     /**
      * @see com.lowagie.text.pdf.interfaces.PdfXConformance#setPDFXConformance(int)
      */
+    @Override
     public void setPDFXConformance(int pdfx) {
         if (pdfxConformance.getPDFXConformance() == pdfx) {
             return;
@@ -1952,6 +1967,7 @@ public class PdfWriter extends DocWriter implements
     /**
      * @see com.lowagie.text.pdf.interfaces.PdfXConformance#getPDFXConformance()
      */
+    @Override
     public int getPDFXConformance() {
         return pdfxConformance.getPDFXConformance();
     }
@@ -1959,6 +1975,7 @@ public class PdfWriter extends DocWriter implements
     /**
      * @see com.lowagie.text.pdf.interfaces.PdfXConformance#isPdfX()
      */
+    @Override
     public boolean isPdfX() {
         return pdfxConformance.isPdfX();
     }
@@ -2010,7 +2027,7 @@ public class PdfWriter extends DocWriter implements
         extraCatalog.put(PdfName.OUTPUTINTENTS, new PdfArray(out));
     }
 
-    /**
+   /**
      * Sets the values of the output intent dictionary. Null values are allowed to suppress any key.
      * <p>
      * Prefer the <CODE>ICC_Profile</CODE>-based version of this method.
@@ -2033,9 +2050,9 @@ public class PdfWriter extends DocWriter implements
     /**
      * Use this method to copy the output intent dictionary from another document to this one.
      *
-     * @param reader         the other document
+     * @param reader the other document
      * @param checkExistence <CODE>true</CODE> to just check for the existence of a valid output intent
-     *                       dictionary, <CODE>false</CODE> to insert the dictionary if it exists
+     * dictionary, <CODE>false</CODE> to insert the dictionary if it exists
      * @return <CODE>true</CODE> if the output intent dictionary exists, <CODE>false</CODE>
      * otherwise
      * @throws IOException on error
@@ -2057,7 +2074,7 @@ public class PdfWriter extends DocWriter implements
         if (checkExistence) {
             return true;
         }
-        PRStream stream = (PRStream) PdfReader.getPdfObject(out.get(PdfName.DESTOUTPUTPROFILE));
+        PRStream stream = (PRStream)PdfReader.getPdfObject(out.get(PdfName.DESTOUTPUTPROFILE));
         byte[] destProfile = null;
         if (stream != null) {
             destProfile = PdfReader.getStreamBytes(stream);
@@ -2073,7 +2090,7 @@ public class PdfWriter extends DocWriter implements
         if (obj == null || !obj.isString()) {
             return null;
         }
-        return ((PdfString) obj).toUnicodeString();
+        return ((PdfString)obj).toUnicodeString();
     }
 
 // PDF Objects that have an impact on the PDF body
@@ -2177,10 +2194,40 @@ public class PdfWriter extends DocWriter implements
      */
     public static final int ALLOW_DEGRADED_PRINTING = 4;
 
+    /** @deprecated As of iText 2.0.7, use {@link #ALLOW_PRINTING} instead. Scheduled for removal at or after 2.2.0 */
+    @Deprecated
+    public static final int AllowPrinting = ALLOW_PRINTING;
+    /** @deprecated As of iText 2.0.7, use {@link #ALLOW_MODIFY_CONTENTS} instead. Scheduled for removal at or after 2.2.0 */
+    @Deprecated
+    public static final int AllowModifyContents = ALLOW_MODIFY_CONTENTS;
+    /** @deprecated As of iText 2.0.7, use {@link #ALLOW_COPY} instead. Scheduled for removal at or after 2.2.0 */
+    @Deprecated
+    public static final int AllowCopy = ALLOW_COPY;
+    /** @deprecated As of iText 2.0.7, use {@link #ALLOW_MODIFY_ANNOTATIONS} instead. Scheduled for removal at or after 2.2.0 */
+    @Deprecated
+    public static final int AllowModifyAnnotations = ALLOW_MODIFY_ANNOTATIONS;
+    /** @deprecated As of iText 2.0.7, use {@link #ALLOW_FILL_IN} instead. Scheduled for removal at or after 2.2.0 */
+    @Deprecated
+    public static final int AllowFillIn = ALLOW_FILL_IN;
+    /** @deprecated As of iText 2.0.7, use {@link #ALLOW_SCREENREADERS} instead. Scheduled for removal at or after 2.2.0 */
+    @Deprecated
+    public static final int AllowScreenReaders = ALLOW_SCREENREADERS;
+    /** @deprecated As of iText 2.0.7, use {@link #ALLOW_ASSEMBLY} instead. Scheduled for removal at or after 2.2.0 */
+    @Deprecated
+    public static final int AllowAssembly = ALLOW_ASSEMBLY;
+    /** @deprecated As of iText 2.0.7, use {@link #ALLOW_DEGRADED_PRINTING} instead. Scheduled for removal at or after 2.2.0 */
+    @Deprecated
+    public static final int AllowDegradedPrinting = ALLOW_DEGRADED_PRINTING;
 
-    /**
-     * Contains the business logic for cryptography.
-     */
+    // Strength of the encryption (kept for historical reasons)
+    /** @deprecated As of iText 2.0.7, use {@link #STANDARD_ENCRYPTION_40} instead. Scheduled for removal at or after 2.2.0 */
+    @Deprecated
+    public static final boolean STRENGTH40BITS = false;
+    /** @deprecated As of iText 2.0.7, use {@link #STANDARD_ENCRYPTION_128} instead. Scheduled for removal at or after 2.2.0 */
+    @Deprecated
+    public static final boolean STRENGTH128BITS = true;
+
+    /** Contains the business logic for cryptography. */
     protected PdfEncryption crypto;
 
     PdfEncryption getEncryption() {
@@ -2190,6 +2237,7 @@ public class PdfWriter extends DocWriter implements
     /**
      * @see com.lowagie.text.pdf.interfaces.PdfEncryptionSettings#setEncryption(byte[], byte[], int, int)
      */
+    @Override
     public void setEncryption(byte[] userPassword, byte[] ownerPassword, int permissions, int encryptionType)
         throws DocumentException {
         if (pdf.isOpen()) {
@@ -2205,6 +2253,7 @@ public class PdfWriter extends DocWriter implements
      * @see com.lowagie.text.pdf.interfaces.PdfEncryptionSettings#setEncryption(java.security.cert.Certificate[], int[],
      * int)
      */
+    @Override
     public void setEncryption(Certificate[] certs, int[] permissions, int encryptionType) throws DocumentException {
         if (pdf.isOpen()) {
             throw new DocumentException(
@@ -2212,7 +2261,7 @@ public class PdfWriter extends DocWriter implements
         }
         crypto = new PdfEncryption();
         if (certs != null) {
-            for (int i = 0; i < certs.length; i++) {
+            for (int i=0; i < certs.length; i++) {
                 crypto.addRecipient(certs[i], permissions[i]);
             }
         }
@@ -2220,8 +2269,65 @@ public class PdfWriter extends DocWriter implements
         crypto.getEncryptionDictionary();
     }
 
-//  [F2] compression
+    /**
+     * Sets the encryption options for this document. The userPassword and the
+     *  ownerPassword can be null or have zero length. In this case the ownerPassword
+     *  is replaced by a random string. The open permissions for the document can be
+     *  AllowPrinting, AllowModifyContents, AllowCopy, AllowModifyAnnotations,
+     *  AllowFillIn, AllowScreenReaders, AllowAssembly and AllowDegradedPrinting.
+     *  The permissions can be combined by ORing them.
+     * @param userPassword the user password. Can be null or empty
+     * @param ownerPassword the owner password. Can be null or empty
+     * @param permissions the user permissions
+     * @param strength128Bits <code>true</code> for 128 bit key length, <code>false</code> for 40 bit key length
+     * @throws DocumentException if the document is already open
+     * @deprecated As of iText 2.0.3, replaced by (@link #setEncryption(byte[], byte[], int, int)}. Scheduled for removal at or after 2.2.0
+     */
+    @Deprecated
+    public void setEncryption(byte[] userPassword, byte[] ownerPassword, int permissions, boolean strength128Bits) throws DocumentException {
+        setEncryption(userPassword, ownerPassword, permissions, strength128Bits ? STANDARD_ENCRYPTION_128 : STANDARD_ENCRYPTION_40);
+    }
 
+    /**
+     * Sets the encryption options for this document. The userPassword and the
+     *  ownerPassword can be null or have zero length. In this case the ownerPassword
+     *  is replaced by a random string. The open permissions for the document can be
+     *  AllowPrinting, AllowModifyContents, AllowCopy, AllowModifyAnnotations,
+     *  AllowFillIn, AllowScreenReaders, AllowAssembly and AllowDegradedPrinting.
+     *  The permissions can be combined by ORing them.
+     * @param strength <code>true</code> for 128 bit key length, <code>false</code> for 40 bit key length
+     * @param userPassword the user password. Can be null or empty
+     * @param ownerPassword the owner password. Can be null or empty
+     * @param permissions the user permissions
+     * @throws DocumentException if the document is already open
+     * @deprecated As of iText 2.0.3, replaced by (@link #setEncryption(byte[], byte[], int, int)}. Scheduled for removal at or after 2.2.0
+     */
+    @Deprecated
+    public void setEncryption(boolean strength, String userPassword, String ownerPassword, int permissions) throws DocumentException {
+        setEncryption(getISOBytes(userPassword), getISOBytes(ownerPassword), permissions, strength ? STANDARD_ENCRYPTION_128 : STANDARD_ENCRYPTION_40);
+    }
+
+    /**
+     * Sets the encryption options for this document. The userPassword and the
+     *  ownerPassword can be null or have zero length. In this case the ownerPassword
+     *  is replaced by a random string. The open permissions for the document can be
+     *  AllowPrinting, AllowModifyContents, AllowCopy, AllowModifyAnnotations,
+     *  AllowFillIn, AllowScreenReaders, AllowAssembly and AllowDegradedPrinting.
+     *  The permissions can be combined by ORing them.
+     * @param encryptionType the type of encryption. It can be one of STANDARD_ENCRYPTION_40, STANDARD_ENCRYPTION_128 or ENCRYPTION_AES128.
+     * Optionally DO_NOT_ENCRYPT_METADATA can be ored to output the metadata in cleartext
+     * @param userPassword the user password. Can be null or empty
+     * @param ownerPassword the owner password. Can be null or empty
+     * @param permissions the user permissions
+     * @throws DocumentException if the document is already open
+     * @deprecated As of iText 2.0.3, replaced by (@link #setEncryption(byte[], byte[], int, int)}. Scheduled for removal at or after 2.2.0
+     */
+    @Deprecated
+    public void setEncryption(int encryptionType, String userPassword, String ownerPassword, int permissions) throws DocumentException {
+        setEncryption(getISOBytes(userPassword), getISOBytes(ownerPassword), permissions, encryptionType);
+    }
+
+    //  [F2] compression
     /**
      * Holds value of property fullCompression.
      */
@@ -2275,7 +2381,7 @@ public class PdfWriter extends DocWriter implements
             this.compressionLevel = PdfStream.DEFAULT_COMPRESSION;
         } else {
             this.compressionLevel = compressionLevel;
-        }
+    }
     }
 
 //  [F3] adding fonts
@@ -2300,7 +2406,7 @@ public class PdfWriter extends DocWriter implements
 
     FontDetails addSimple(BaseFont bf) {
         if (bf.getFontType() == BaseFont.FONT_TYPE_DOCUMENT) {
-            return new FontDetails(new PdfName("F" + (fontNumber++)), ((DocumentFont) bf).getIndirectReference(), bf);
+            return new FontDetails(new PdfName("F" + (fontNumber++)), ((DocumentFont)bf).getIndirectReference(), bf);
         }
         FontDetails ret = documentFonts.get(bf);
         if (ret == null) {
@@ -2315,8 +2421,8 @@ public class PdfWriter extends DocWriter implements
         for (FontDetails ft : documentFonts.values()) {
             if (fonts.get(ft.getFontName()) != null) {
                 ft.setSubset(false);
-            }
         }
+    }
     }
 
 //  [F4] adding (and releasing) form XObjects
@@ -2334,7 +2440,7 @@ public class PdfWriter extends DocWriter implements
     /**
      * Adds a template to the document but not to the page resources.
      *
-     * @param template   the template to add
+     * @param template the template to add
      * @param forcedName the template name, rather than a generated one. Can be null
      * @return the <CODE>PdfName</CODE> for this template
      */
@@ -2353,7 +2459,7 @@ public class PdfWriter extends DocWriter implements
                 }
                 if (template.getType() == PdfTemplate.TYPE_IMPORTED) {
                     // If we got here from PdfCopy we'll have to fill importedPages
-                    PdfImportedPage ip = (PdfImportedPage) template;
+                    PdfImportedPage ip = (PdfImportedPage)template;
                     PdfReader r = ip.getPdfReaderInstance().getReader();
                     if (!importedPages.containsKey(r)) {
                         importedPages.put(r, ip.getPdfReaderInstance());
@@ -2362,8 +2468,8 @@ public class PdfWriter extends DocWriter implements
                 }
                 formXObjects.put(ref, new Object[]{name, template});
             } else {
-                name = (PdfName) obj[0];
-            }
+                name = (PdfName)obj[0];
+        }
         } catch (Exception e) {
             throw new ExceptionConverter(e);
         }
@@ -2383,7 +2489,7 @@ public class PdfWriter extends DocWriter implements
         if (objs == null || objs[1] == null) {
             return;
         }
-        PdfTemplate template = (PdfTemplate) objs[1];
+        PdfTemplate template = (PdfTemplate)objs[1];
         if (template.getIndirectReference() instanceof PRIndirectReference) {
             return;
         }
@@ -2401,7 +2507,7 @@ public class PdfWriter extends DocWriter implements
      * Use this method to get a page from other PDF document. The page can be used as any other PdfTemplate. Note that
      * calling this method more than once with the same parameters will retrieve the same object.
      *
-     * @param reader     the PDF document where the page is
+     * @param reader the PDF document where the page is
      * @param pageNumber the page number. The first page is 1
      * @return the template representing the imported page
      */
@@ -2439,7 +2545,7 @@ public class PdfWriter extends DocWriter implements
      * @return the approximate size without fonts or templates
      */
     public long getCurrentDocumentSize() {
-        return body.offset() + (long) body.size() * 20L + 0x48;
+        return body.offset() + (long)body.size() * 20L + 0x48;
     }
 
     protected PdfReaderInstance currentPdfReaderInstance;
@@ -2505,7 +2611,7 @@ public class PdfWriter extends DocWriter implements
     PdfName addSimplePattern(PdfPatternPainter painter) {
         PdfName name = documentPatterns.get(painter);
         try {
-            if (name == null) {
+            if ( name == null ) {
                 name = new PdfName("P" + patternNumber);
                 ++patternNumber;
                 documentPatterns.put(painter, name);
@@ -2628,7 +2734,7 @@ public class PdfWriter extends DocWriter implements
     /**
      * The locked array in an OCG dictionary
      *
-     * @since 2.1.2
+     * @since   2.1.2
      */
     protected PdfArray OCGLocked = new PdfArray();
 
@@ -2656,7 +2762,7 @@ public class PdfWriter extends DocWriter implements
         for (PdfLayer layer : group) {
             if (layer.getTitle() == null) {
                 ar.add(layer.getRef());
-            }
+        }
         }
         if (ar.isEmpty()) {
             return;
@@ -2669,8 +2775,8 @@ public class PdfWriter extends DocWriter implements
      * interface of a viewer application. Producers can use this entry to prevent the visibility of content that depends
      * on these groups from being changed by users.
      *
-     * @param layer the layer that needs to be added to the array of locked OCGs
-     * @since 2.1.2
+     * @param layer    the layer that needs to be added to the array of locked OCGs
+     * @since    2.1.2
      */
     public void lockLayer(PdfLayer layer) {
         OCGLocked.add(layer.getRef());
@@ -2696,7 +2802,7 @@ public class PdfWriter extends DocWriter implements
         }
         if (!kids.isEmpty()) {
             order.add(kids);
-        }
+    }
     }
 
     private void addASEvent(PdfName event, PdfName category) {
@@ -2706,13 +2812,13 @@ public class PdfWriter extends DocWriter implements
             PdfDictionary usage = layer.getAsDict(PdfName.USAGE);
             if (usage != null && usage.get(category) != null) {
                 arr.add(layer.getRef());
-            }
+        }
         }
         if (arr.isEmpty()) {
             return;
         }
-        PdfDictionary d = (PdfDictionary) OCProperties.get(PdfName.D);
-        PdfArray arras = (PdfArray) d.get(PdfName.AS);
+        PdfDictionary d = (PdfDictionary)OCProperties.get(PdfName.D);
+        PdfArray arras = (PdfArray)d.get(PdfName.AS);
         if (arras == null) {
             arras = new PdfArray();
             d.put(PdfName.AS, arras);
@@ -2749,8 +2855,8 @@ public class PdfWriter extends DocWriter implements
         }
 
         List<PdfOCG> docOrder = documentOCGorder.stream()
-            .filter(pdfOCG -> ((PdfLayer) pdfOCG).getParent() == null)
-            .collect(Collectors.toList());
+                .filter(pdfOCG -> ((PdfLayer)pdfOCG).getParent() == null)
+                .collect(Collectors.toList());
 
         PdfArray order = new PdfArray();
         for (PdfOCG o1 : docOrder) {
@@ -2765,7 +2871,7 @@ public class PdfWriter extends DocWriter implements
             PdfLayer layer = (PdfLayer) o;
             if (!layer.isOn()) {
                 gr.add(layer.getRef());
-            }
+        }
         }
         if (!gr.isEmpty()) {
             d.put(PdfName.OFF, gr);
@@ -2785,7 +2891,8 @@ public class PdfWriter extends DocWriter implements
 
     void registerLayer(PdfOCG layer) {
         PdfXConformanceImp.checkPDFXConformance(this, PdfXConformanceImp.PDFXKEY_LAYER, null);
-        if (layer instanceof PdfLayer la) {
+        if (layer instanceof PdfLayer) {
+            PdfLayer la = (PdfLayer)layer;
             if (la.getTitle() == null) {
                 if (!documentOCG.contains(layer)) {
                     documentOCG.add(layer);
@@ -2826,7 +2933,7 @@ public class PdfWriter extends DocWriter implements
      * Use this method to set the page box sizes. Allowed names are: "crop", "trim", "art" and "bleed".
      *
      * @param boxName the box size
-     * @param size    the size
+     * @param size the size
      */
     public void setBoxSize(String boxName, Rectangle size) {
         pdf.setBoxSize(boxName, size);
@@ -2882,28 +2989,31 @@ public class PdfWriter extends DocWriter implements
      * @see com.lowagie.text.pdf.interfaces.PdfPageActions#setPageAction(com.lowagie.text.pdf.PdfName,
      * com.lowagie.text.pdf.PdfAction)
      */
+    @Override
     public void setPageAction(PdfName actionType, PdfAction action) throws DocumentException {
         if (!actionType.equals(PAGE_OPEN) && !actionType.equals(PAGE_CLOSE)) {
             throw new DocumentException(
                 MessageLocalization.getComposedMessage("invalid.page.additional.action.type.1",
                     actionType.toString()));
         }
-        pdf.setPageAction(actionType, action);
-    }
+          pdf.setPageAction(actionType, action);
+      }
 
     /**
      * @see com.lowagie.text.pdf.interfaces.PdfPageActions#setDuration(int)
      */
+    @Override
     public void setDuration(int seconds) {
-        pdf.setDuration(seconds);
-    }
+         pdf.setDuration(seconds);
+     }
 
     /**
      * @see com.lowagie.text.pdf.interfaces.PdfPageActions#setTransition(com.lowagie.text.pdf.PdfTransition)
      */
+    @Override
     public void setTransition(PdfTransition transition) {
-        pdf.setTransition(transition);
-    }
+         pdf.setTransition(transition);
+     }
 
 //  [U4] Thumbnail image
 
@@ -2911,7 +3021,7 @@ public class PdfWriter extends DocWriter implements
      * Use this method to set the thumbnail image for the current page.
      *
      * @param image the image
-     * @throws PdfException      on error
+     * @throws PdfException on error
      * @throws DocumentException or error
      */
     public void setThumbnail(Image image) throws DocumentException {
@@ -3009,6 +3119,7 @@ public class PdfWriter extends DocWriter implements
      *
      * @param runDirection the run direction
      */
+    @Override
     public void setRunDirection(int runDirection) {
         if (runDirection < RUN_DIRECTION_NO_BIDI || runDirection > RUN_DIRECTION_RTL) {
             throw new RuntimeException(MessageLocalization.getComposedMessage("invalid.run.direction.1", runDirection));
@@ -3021,13 +3132,14 @@ public class PdfWriter extends DocWriter implements
      *
      * @return the run direction
      */
+    @Override
     public int getRunDirection() {
         return runDirection;
     }
 
 //  [U8] user units
 
-    protected float userunit = 0f;
+     protected float userunit = 0f;
 
     /**
      * Use this method to get the user unit. A user unit is a value that defines the default user space unit. The
@@ -3048,14 +3160,14 @@ public class PdfWriter extends DocWriter implements
      * @param userunit The userunit to set.
      * @throws DocumentException on error
      */
-    public void setUserunit(float userunit) throws DocumentException {
+     public void setUserunit(float userunit) throws DocumentException {
         if (userunit < 1f || userunit > 75000f) {
             throw new DocumentException(
                 MessageLocalization.getComposedMessage("userunit.should.be.a.value.between.1.and.75000"));
         }
-        this.userunit = userunit;
-        setAtLeastPdfVersion(VERSION_1_6);
-    }
+         this.userunit = userunit;
+         setAtLeastPdfVersion(VERSION_1_6);
+     }
 
 // Miscellaneous topics
 
@@ -3080,7 +3192,7 @@ public class PdfWriter extends DocWriter implements
      *
      * @param key the name of the colorspace. It can be <CODE>PdfName.DEFAULTGRAY</CODE>,
      *            <CODE>PdfName.DEFAULTRGB</CODE> or <CODE>PdfName.DEFAULTCMYK</CODE>
-     * @param cs  the colorspace. A <CODE>null</CODE> or <CODE>PdfNull</CODE> removes any colorspace with the same name
+     * @param cs the colorspace. A <CODE>null</CODE> or <CODE>PdfNull</CODE> removes any colorspace with the same name
      */
     public void setDefaultColorspace(PdfName key, PdfObject cs) {
         if (cs == null || cs.isNull()) {
@@ -3132,7 +3244,7 @@ public class PdfWriter extends DocWriter implements
                     }
                     return patternColorspaceGRAY;
                 case ExtendedColor.TYPE_SEPARATION: {
-                    ColorDetails details = addSimple(((SpotColor) color).getPdfSpotColor());
+                    ColorDetails details = addSimple(((SpotColor)color).getPdfSpotColor());
                     ColorDetails patternDetails = documentSpotPatterns.get(details);
                     if (patternDetails == null) {
                         patternDetails = new ColorDetails(getColorspaceName(), body.getPdfIndirectReference(), null);
@@ -3196,7 +3308,7 @@ public class PdfWriter extends DocWriter implements
      *
      * @param image the <CODE>Image</CODE> to add
      * @return the name of the image added
-     * @throws PdfException      on error
+     * @throws PdfException on error
      * @throws DocumentException on error
      */
     public PdfName addDirectImageSimple(Image image) throws DocumentException {
@@ -3207,11 +3319,11 @@ public class PdfWriter extends DocWriter implements
      * Adds an image to the document but not to the page resources. It is used with templates and
      * <CODE>Document.add(Image)</CODE>. Use this method only if you know what you're doing!
      *
-     * @param image    the <CODE>Image</CODE> to add
+     * @param image the <CODE>Image</CODE> to add
      * @param fixedRef the reference to used. It may be <CODE>null</CODE>, a <CODE>PdfIndirectReference</CODE> or a
      *                 <CODE>PRIndirectReference</CODE>.
      * @return the name of the image added
-     * @throws PdfException      on error
+     * @throws PdfException on error
      * @throws DocumentException on error
      */
     public PdfName addDirectImageSimple(Image image, PdfIndirectReference fixedRef) throws DocumentException {
@@ -3224,9 +3336,9 @@ public class PdfWriter extends DocWriter implements
         else {
             if (image.isImgTemplate()) {
                 name = new PdfName("img" + images.size());
-                if (image instanceof ImgWMF) {
+                if(image instanceof ImgWMF){
                     try {
-                        ImgWMF wmf = (ImgWMF) image;
+                        ImgWMF wmf = (ImgWMF)image;
                         wmf.readWMF(PdfTemplate.createTemplate(this, 0, 0));
                     } catch (Exception e) {
                         throw new DocumentException(e);
@@ -3267,10 +3379,10 @@ public class PdfWriter extends DocWriter implements
                             colorspace.set(1, iccArray);
                         } else {
                             i.put(PdfName.COLORSPACE, iccArray);
-                        }
+                    }
                     } else {
                         i.put(PdfName.COLORSPACE, iccArray);
-                    }
+                }
                 }
                 add(i, fixedRef);
                 name = i.name();
@@ -3289,18 +3401,18 @@ public class PdfWriter extends DocWriter implements
      */
 
     PdfIndirectReference add(PdfImage pdfImage, PdfIndirectReference fixedRef) throws PdfException {
-        if (!imageDictionary.contains(pdfImage.name())) {
+        if (! imageDictionary.contains(pdfImage.name())) {
             PdfXConformanceImp.checkPDFXConformance(this, PdfXConformanceImp.PDFXKEY_IMAGE, pdfImage);
-            if (fixedRef instanceof PRIndirectReference r2) {
-                fixedRef = new PdfIndirectReference(0,
-                    getNewObjectNumber(r2.getReader(), r2.getNumber(), r2.getGeneration()));
+            if (fixedRef instanceof PRIndirectReference) {
+                PRIndirectReference r2 = (PRIndirectReference)fixedRef;
+                fixedRef = new PdfIndirectReference(0, getNewObjectNumber(r2.getReader(), r2.getNumber(), r2.getGeneration()));
             }
             try {
                 if (fixedRef == null) {
                     fixedRef = addToBody(pdfImage).getIndirectReference();
                 } else {
                     addToBody(pdfImage, fixedRef);
-                }
+            }
             } catch (IOException ioe) {
                 throw new ExceptionConverter(ioe);
             }
@@ -3342,9 +3454,9 @@ public class PdfWriter extends DocWriter implements
      * Gets an indirect reference to a JBIG2 Globals stream. Adds the stream if it hasn't already been added to the
      * writer.
      *
-     * @param content a byte array that may already been added to the writer inside a stream object.
+     * @param    content a byte array that may already been added to the writer inside a stream object.
      * @return the PdfIndirectReference
-     * @since 2.1.5
+     * @since  2.1.5
      */
     protected PdfIndirectReference getReferenceJBIG2Globals(byte[] content) {
         if (content == null) {
@@ -3373,9 +3485,9 @@ public class PdfWriter extends DocWriter implements
     /**
      * Checks if a <CODE>Table</CODE> fits the current page of the <CODE>PdfDocument</CODE>.
      *
-     * @param table  the table that has to be checked
-     * @param margin a certain margin
-     * @return <CODE>true</CODE> if the <CODE>Table</CODE> fits the page, <CODE>false</CODE> otherwise.
+     * @param   table   the table that has to be checked
+     * @param   margin  a certain margin
+     * @return  <CODE>true</CODE> if the <CODE>Table</CODE> fits the page, <CODE>false</CODE> otherwise.
      */
 
     public boolean fitsPage(Table table, float margin) {
@@ -3385,8 +3497,8 @@ public class PdfWriter extends DocWriter implements
     /**
      * Checks if a <CODE>Table</CODE> fits the current page of the <CODE>PdfDocument</CODE>.
      *
-     * @param table the table that has to be checked
-     * @return <CODE>true</CODE> if the <CODE>Table</CODE> fits the page, <CODE>false</CODE> otherwise.
+     * @param   table  the table that has to be checked
+     * @return  <CODE>true</CODE> if the <CODE>Table</CODE> fits the page, <CODE>false</CODE> otherwise.
      */
 
     public boolean fitsPage(Table table) {
@@ -3440,7 +3552,7 @@ public class PdfWriter extends DocWriter implements
      *
      * @param rgbTransparencyBlending <code>true</code> to set the transparency blending colorspace to RGB,
      *                                <code>false</code>
-     *                                to use the default blending colorspace
+     * to use the default blending colorspace
      * @since 2.1.0
      */
     public void setRgbTransparencyBlending(boolean rgbTransparencyBlending) {

--- a/openpdf/src/main/java/com/lowagie/text/pdf/RadioCheckField.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/RadioCheckField.java
@@ -432,6 +432,33 @@ public class RadioCheckField extends BaseField {
     }
     
     /**
+     * Gets the radio field. It's only composed of the widget keys and must be used
+     * with {@link #getRadioGroup(boolean,boolean)}.
+     * @return the radio field
+     * @throws IOException on error
+     * @throws DocumentException on error
+     * 
+     * @deprecated use {@link #getKidField()} instead
+     */
+    @Deprecated
+    public PdfFormField getRadioField() throws IOException, DocumentException {
+        return getField(true);
+    }
+    
+    /**
+     * Gets the check field.
+     * @return the check field
+     * @throws IOException on error
+     * @throws DocumentException on error
+     * 
+     * @deprecated use {@link #getFullField()} instead
+     */
+    @Deprecated
+    public PdfFormField getCheckField() throws IOException, DocumentException {
+        return getField(false);
+    }
+    
+    /**
      * Gets a parent of a checkbox autofill parent. 
      * It is composed of the field specific keys, without the widget ones. 
      * This field is to be used as a field aggregator with {@link PdfFormField#addKid(PdfFormField) addKid()}.

--- a/openpdf/src/main/java/com/lowagie/text/pdf/SimpleBookmark.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/SimpleBookmark.java
@@ -275,6 +275,20 @@ public final class SimpleBookmark implements SimpleXMLDocHandler {
         }
         return indirect.getNumber();
     }
+
+    /**
+     * Gets a <CODE>List</CODE> with the bookmarks. It returns <CODE>null</CODE> if
+     * the document doesn't have any bookmarks.
+     * @param reader the document
+     * @deprecated use {@link #getBookmarkList(PdfReader)}
+     * @return a <CODE>List</CODE> with the bookmarks or <CODE>null</CODE> if the
+     * document doesn't have any
+     */
+    @Deprecated
+    @SuppressWarnings("rawtypes")
+    public static List getBookmark(PdfReader reader) {
+        return getBookmarkList(reader);
+    }
     
     /**
      * Gets a <CODE>List</CODE> with the bookmarks. It returns <CODE>null</CODE> if
@@ -353,6 +367,23 @@ public final class SimpleBookmark implements SimpleXMLDocHandler {
                 }
             }
         }
+    }
+
+    /**
+     * For the pages in range add the <CODE>pageShift</CODE> to the page number.
+     * The page ranges
+     * consists of a number of pairs with the start/end page range. The page numbers
+     * are inclusive.
+     * @param list the bookmarks
+     * @param pageShift the number to add to the pages in range
+     * @param pageRange the page ranges, always in pairs. It can be <CODE>null</CODE>
+     * to include all the pages
+     * @deprecated use {@link #shiftPageNumbersInRange(List, int, int[])}
+     */
+    @Deprecated
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    public static void shiftPageNumbers(List list, int pageShift, int[] pageRange) {
+        shiftPageNumbersInRange(list, pageShift, pageRange);
     }
     
     /**
@@ -748,6 +779,15 @@ public final class SimpleBookmark implements SimpleXMLDocHandler {
     }
 
     public void startDocument() {
+    }
+
+    /**
+     * @deprecated user {@link SimpleBookmark#startElement(String, Map)}
+     */
+    @Deprecated
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    public void startElement(String tag, HashMap h) {
+        startElement(tag, (Map<String, String>) h);
     }
 
     public void startElement(String tag, Map<String, String> h) {

--- a/openpdf/src/main/java/com/lowagie/text/pdf/SimpleNamedDestination.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/SimpleNamedDestination.java
@@ -309,6 +309,12 @@ public final class SimpleNamedDestination implements SimpleXMLDocHandler {
     public void startDocument() {
     }
 
+    @Deprecated
+    @SuppressWarnings("unchecked")
+    public void startElement(String tag, HashMap h) {
+        startElement(tag, (Map<String, String>) h);
+    }
+
     public void startElement(String tag, Map<String, String> h) {
         if (xmlNames == null) {
             if (tag.equals("Destination")) {

--- a/openpdf/src/main/java/com/lowagie/text/pdf/TextField.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/TextField.java
@@ -96,7 +96,7 @@ public class TextField extends BaseField {
     }
 
     private static boolean checkRTL(String text) {
-        if (text == null || text.isEmpty())
+        if (text == null || text.length() == 0)
             return false;
         char[] cc = text.toCharArray();
         for (int c : cc) {
@@ -788,6 +788,18 @@ public class TextField extends BaseField {
      * replaces the existing selections with the param. If this field isn't a MULTISELECT
      * list, all but the first element will be removed.
      * @param selections new selections.  If null, it clear()s the underlying ArrayList.
+     * @deprecated use {@link #setChoiceSelections(List)}
+     */
+    @Deprecated
+    @SuppressWarnings("unchecked")
+    public void setChoiceSelections(ArrayList selections ) {
+        setChoiceSelections((List<Integer>) selections);
+    }
+    
+    /**
+     * replaces the existing selections with the param. If this field isn't a MULTISELECT
+     * list, all but the first element will be removed.
+     * @param selections new selections.  If null, it clear()s the underlying ArrayList.
      */
     public void setChoiceSelections(List<Integer> selections ) {
         if (selections != null) {
@@ -826,10 +838,32 @@ public class TextField extends BaseField {
     /**
      * Gets the list of substitution fonts. The list is composed of <CODE>BaseFont</CODE> and can be <CODE>null</CODE>. The fonts in this list will be used if the original
      * font doesn't contain the needed glyphs.
+     * @deprecated use {@link #getSubstitutionFontList()}
+     * @return the list
+     */
+    @Deprecated
+    public ArrayList getSubstitutionFonts() {
+        return (ArrayList) this.substitutionFonts;
+    }
+
+    /**
+     * Gets the list of substitution fonts. The list is composed of <CODE>BaseFont</CODE> and can be <CODE>null</CODE>. The fonts in this list will be used if the original
+     * font doesn't contain the needed glyphs.
      * @return the list
      */
     public List<BaseFont> getSubstitutionFontList() {
         return this.substitutionFonts;
+    }
+
+    /**
+     * Sets a list of substitution fonts. The list is composed of <CODE>BaseFont</CODE> and can also be <CODE>null</CODE>. The fonts in this list will be used if the original
+     * font doesn't contain the needed glyphs.
+     * @param substitutionFonts the list
+     * @deprecated use {@link #setSubstitutionFontList(List)}
+     */
+    @Deprecated
+    public void setSubstitutionFonts(List<BaseFont> substitutionFonts) {
+        this.substitutionFonts = substitutionFonts;
     }
 
     /**

--- a/openpdf/src/main/java/com/lowagie/text/pdf/XfaForm.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/XfaForm.java
@@ -609,6 +609,18 @@ public class XfaForm {
             addSomNameToSearchNodeChain(inverseSearch, stack, unstack);
         }
 
+        /**
+         * Adds a SOM name to the search node chain.
+         * @param inverseSearch the start point
+         * @param stack the stack with the separated SOM parts
+         * @param unstack the full name
+         * @deprecated use {@link #addSomNameToSearchNodeChain}
+         */
+        @Deprecated
+        @SuppressWarnings("unchecked")
+        public static void inverseSearchAdd(HashMap inverseSearch, Stack2 stack, String unstack) {
+            addSomNameToSearchNodeChain(inverseSearch, stack, unstack);
+        }
         
         /**
          * Adds a SOM name to the search node chain.
@@ -638,6 +650,18 @@ public class XfaForm {
             }
             store.part.add("");
             store.follow.add(unstack);
+        }
+
+        /**
+         * Searches the SOM hierarchy from the bottom.
+         * @param parts the SOM parts
+         * @deprecated use {@link #inverseSearch(List)}
+         * @return the full name or <CODE>null</CODE> if not found
+         */
+        @Deprecated
+        @SuppressWarnings("unchecked")
+        public String inverseSearchGlobal(ArrayList parts) {
+            return inverseSearch(parts);
         }
 
         /**
@@ -704,10 +728,31 @@ public class XfaForm {
 
         /**
          * Gets the order the names appear in the XML, depth first.
+         * @deprecated use {@link #getNamesOrder()}
+         * @return the order the names appear in the XML, depth first
+         */
+        @Deprecated
+        public ArrayList getOrder() {
+            return (ArrayList) order;
+        }
+
+        /**
+         * Gets the order the names appear in the XML, depth first.
          * @return the order the names appear in the XML, depth first
          */
         public List<String> getNamesOrder() {
             return order;
+        }
+
+        /**
+         * Sets the order the names appear in the XML, depth first
+         * @deprecated use {@link #setNamesOrder(List)}
+         * @param order the order the names appear in the XML, depth first
+         */
+        @Deprecated
+        @SuppressWarnings("unchecked")
+        public void setOrder(ArrayList order) {
+            this.order = order;
         }
 
         /**
@@ -720,10 +765,31 @@ public class XfaForm {
 
         /**
          * Gets the mapping of full names to nodes.
+         * @deprecated use {@link #getNodesByName()}
+         * @return the mapping of full names to nodes
+         */
+        @Deprecated
+        public HashMap getName2Node() {
+            return (HashMap) name2Node;
+        }
+
+        /**
+         * Gets the mapping of full names to nodes.
          * @return the mapping of full names to nodes
          */
         public Map<String, Node> getNodesByName() {
             return name2Node;
+        }
+
+        /**
+         * Sets the mapping of full names to nodes.
+         * @deprecated use {@link #setNodesByName(Map)}
+         * @param name2Node the mapping of full names to nodes
+         */
+        @Deprecated
+        @SuppressWarnings("unchecked")
+        public void setName2Node(HashMap name2Node) {
+            this.name2Node = name2Node;
         }
 
         /**
@@ -736,10 +802,30 @@ public class XfaForm {
 
         /**
          * Gets the data to do a search from the bottom hierarchy.
+         * @deprecated use {@link #getInverseSearchData()}
+         * @return the data to do a search from the bottom hierarchy
+         */
+        @Deprecated
+        public HashMap getInverseSearch() {
+            return (HashMap) inverseSearch;
+        }
+
+        /**
+         * Gets the data to do a search from the bottom hierarchy.
          * @return the data to do a search from the bottom hierarchy
          */
         public Map<String, InverseStore> getInverseSearchData() {
             return inverseSearch;
+        }
+
+        /**
+         * Sets the data to do a search from the bottom hierarchy.
+         * @deprecated use {@link #setInverseSearchData(Map)}
+         * @param inverseSearch the data to do a search from the bottom hierarchy
+         */
+        @Deprecated
+        public void setInverseSearch(Map<String, InverseStore> inverseSearch) {
+            this.inverseSearch = inverseSearch;
         }
 
         /**
@@ -881,6 +967,27 @@ public class XfaForm {
                 acroShort2LongName.put(itemShort, itemName);
                 addSomNameToSearchNodeChain(inverseSearch, splitParts(itemShort), itemName);
             }
+        }
+
+        /**
+         * Gets the mapping from short names to long names. A long 
+         * name may contain the #subform name part.
+         * @return the mapping from short names to long names
+         */
+        @Deprecated
+        public HashMap getAcroShort2LongName() {
+            return (HashMap) acroShort2LongName;
+        }
+
+        /**
+         * Sets the mapping from short names to long names. A long 
+         * name may contain the #subform name part.
+         * @param acroShort2LongName the mapping from short names to long names
+         */
+        @Deprecated
+        @SuppressWarnings("unchecked")
+        public void setAcroShort2LongName(HashMap acroShort2LongName) {
+            this.acroShort2LongName = acroShort2LongName;
         }
 
         /**

--- a/openpdf/src/main/java/com/lowagie/text/pdf/XfdfReader.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/XfdfReader.java
@@ -107,6 +107,20 @@ public class XfdfReader implements SimpleXMLDocHandler, FieldReader {
         SimpleXMLParser.parse(this, new ByteArrayInputStream(xfdfIn));
     }
 
+    /**
+     * Gets all the fields. The map is keyed by the fully qualified field name and the value is a merged
+     * <CODE>PdfDictionary</CODE> with the
+     * field content.
+     *
+     * @deprecated use {@link #getAllFields()}
+     * @return all the fields
+     */
+    @Override
+    @Deprecated
+    public HashMap<String, String> getFields() {
+        return (HashMap<String, String>) fields;
+    }
+
     @Override
     public Map<String, String> getAllFields() {
         return fields;
@@ -152,6 +166,19 @@ public class XfdfReader implements SimpleXMLDocHandler, FieldReader {
      */
     public String getFileSpec() {
         return fileSpec;
+    }
+
+    /**
+     * Called when a start tag is found.
+     *
+     * @param tag the tag name
+     * @param h   the tag's attributes
+     */
+    @Deprecated
+    @Override
+    @SuppressWarnings("unchecked")
+    public void startElement(String tag, HashMap h) {
+        startElement(tag, (Map<String, String>) h);
     }
 
     /**

--- a/openpdf/src/main/java/com/lowagie/text/pdf/hyphenation/Hyphenator.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/hyphenation/Hyphenator.java
@@ -91,12 +91,14 @@ public class Hyphenator {
      * @return a hyphenation tree
      */
     public static HyphenationTree getResourceHyphenationTree(String key) {
-        try {
-            InputStream stream = BaseFont.getResourceStream(defaultHyphLocation + key + ".xml");
-            if (stream == null && key.length() > 2)
-                stream = BaseFont.getResourceStream(defaultHyphLocation + key.substring(0, 2) + ".xml");
-            if (stream == null)
-                return null;
+        
+        InputStream stream = readHyphenationFile(key);
+        
+        if (stream == null) {
+            return null;
+        }
+        
+        try (InputStream resourceStream = stream){
             HyphenationTree hTree = new HyphenationTree();
             hTree.loadSimplePatterns(stream);
             return hTree;
@@ -105,26 +107,32 @@ public class Hyphenator {
             return null;
         }
     }
+    
+    private static InputStream readHyphenationFile(String key) {
+        InputStream stream = BaseFont.getResourceStream(defaultHyphLocation + key + ".xml");
+        if (stream == null && key.length() > 2) {
+            stream = BaseFont.getResourceStream(defaultHyphLocation + key.substring(0, 2) + ".xml");
+        }
+        return stream;
+    }
+    
 
     /**
-     * @param key   The language to get the tree from
-     * @return a hyphenation tree
+     * @param key The language to get the tree from
+     * @return a hyphenation tree or null
      */
     public static HyphenationTree getFileHyphenationTree(String key) {
-        try {
-            if (hyphenDir == null)
-                return null;
-            InputStream stream = null;
-            File hyphenFile = new File(hyphenDir, key + ".xml");
-            if (hyphenFile.canRead())
-                stream = new FileInputStream(hyphenFile);
-            if (stream == null && key.length() > 2) {
-                hyphenFile = new File(hyphenDir, key.substring(0, 2) + ".xml");
-                if (hyphenFile.canRead())
-                    stream = new FileInputStream(hyphenFile);
-            }
-            if (stream == null)
-                return null;
+        
+        if (hyphenDir == null) {
+            return null;
+        }
+        
+        File hyphenFile = getHyphenFile(key);
+        if (hyphenFile == null) {
+            return null;
+        }
+        
+        try (InputStream stream = new FileInputStream(hyphenFile)){
             HyphenationTree hTree = new HyphenationTree();
             hTree.loadSimplePatterns(stream);
             return hTree;
@@ -132,6 +140,22 @@ public class Hyphenator {
         catch (Exception e) {
             return null;
         }
+    }
+    
+    private static File getHyphenFile(String key) {
+        File hyphenFile = new File(hyphenDir, key + ".xml");
+        if (hyphenFile.canRead()) {
+            return hyphenFile;
+        }
+        
+        if (key.length() > 2) {
+            hyphenFile = new File(hyphenDir, key.substring(0, 2) + ".xml");
+            if (hyphenFile.canRead()) {
+                return hyphenFile;
+            }
+        }
+        
+        return null;
     }
 
     /**

--- a/openpdf/src/main/java/com/lowagie/text/pdf/hyphenation/SimplePatternParser.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/hyphenation/SimplePatternParser.java
@@ -59,6 +59,7 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.StringTokenizer;
@@ -101,6 +102,11 @@ public class SimplePatternParser implements SimpleXMLDocHandler,
             SimpleXMLParser.parse(this, stream);
         } catch (IOException e) {
             throw new ExceptionConverter(e);
+        } finally {
+            try {
+                stream.close();
+            } catch (Exception e) {
+            }
         }
     }
 
@@ -212,6 +218,16 @@ public class SimplePatternParser implements SimpleXMLDocHandler,
 
     @Override
     public void startDocument() {
+    }
+
+    /**
+     * @deprecated use {@link SimplePatternParser#startElement(String, Map)}
+     */
+    @Override
+    @Deprecated
+    @SuppressWarnings("unchecked")
+    public void startElement(String tag, HashMap h) {
+        startElement(tag, ((Map<String, String>) h));
     }
 
     @Override

--- a/openpdf/src/main/java/com/lowagie/text/pdf/hyphenation/SimplePatternParser.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/hyphenation/SimplePatternParser.java
@@ -102,12 +102,7 @@ public class SimplePatternParser implements SimpleXMLDocHandler,
             SimpleXMLParser.parse(this, stream);
         } catch (IOException e) {
             throw new ExceptionConverter(e);
-        } finally {
-            try {
-                stream.close();
-            } catch (Exception e) {
-            }
-        }
+        } 
     }
 
     protected static String getPattern(String word) {
@@ -181,9 +176,11 @@ public class SimplePatternParser implements SimpleXMLDocHandler,
         return il.toString();
     }
 
+    @Override
     public void endDocument() {
     }
 
+    @Override
     public void endElement(String tag) {
         if (token.length() > 0) {
             String word = token.toString();
@@ -260,6 +257,7 @@ public class SimplePatternParser implements SimpleXMLDocHandler,
         token.setLength(0);
     }
 
+    @Override
     public void text(String str) {
         StringTokenizer tk = new StringTokenizer(str);
         while (tk.hasMoreTokens()) {
@@ -285,23 +283,26 @@ public class SimplePatternParser implements SimpleXMLDocHandler,
     }
 
     // PatternConsumer implementation for testing purposes
+    @Override
     public void addClass(String c) {
         System.out.println("class: " + c);
     }
 
+    @Override
     public void addException(String w, ArrayList e) {
         System.out.println("exception: " + w + " : " + e.toString());
     }
 
+    @Override
     public void addPattern(String p, String v) {
         System.out.println("pattern: " + p + " : " + v);
     }
 
     public static void main(String[] args) {
-        try {
+        try (FileInputStream fis = new FileInputStream(args[0]);){
             if (args.length > 0) {
                 SimplePatternParser pp = new SimplePatternParser();
-                pp.parse(new FileInputStream(args[0]), pp);
+                pp.parse(fis, pp);
             }
         } catch (Exception e) {
             e.printStackTrace();

--- a/openpdf/src/main/java/com/lowagie/text/pdf/parser/ParsedText.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/parser/ParsedText.java
@@ -67,6 +67,22 @@ public class ParsedText extends ParsedTextImpl {
      */
     private PdfString pdfText = null;
 
+    /**
+     * This constructor should only be called when the origin for text display is at (0,0) and the
+     * graphical state reflects all transformations of the baseline. This is in text space units.
+     * <p>
+     * Decodes a String (which will contain glyph ids encoded in the font's encoding) based on
+     * the active font. This is supported for compatibility, but is no longer preferred.
+     *
+     * @param text          string
+     * @param graphicsState graphical state
+     * @param textMatrix    transform from text space to graphics (drawing space)
+     */
+    @Deprecated
+    ParsedText(String text, GraphicsState graphicsState, Matrix textMatrix) {
+        this(text, new GraphicsState(graphicsState), textMatrix.multiply(graphicsState.getCtm()),
+                getUnscaledFontSpaceWidth(graphicsState));
+    }
 
     /**
      * This constructor should only be called when the origin for text display is at (0,0) and the
@@ -114,6 +130,25 @@ public class ParsedText extends ParsedTextImpl {
         this.graphicsState = graphicsState;
     }
 
+    /**
+     * Internal constructor when the code points are already in a string.
+     *
+     * @param text          string
+     * @param graphicsState graphical state
+     * @param textMatrix    transform from text space to graphics (drawing space)
+     * @param unscaledWidth width of the space character in the font.
+     */
+    @Deprecated
+    private ParsedText(String text, GraphicsState graphicsState, Matrix textMatrix, float unscaledWidth) {
+        super(text, pointToUserSpace(0, 0, textMatrix),
+                pointToUserSpace(getStringWidth(text, graphicsState), 0f, textMatrix),
+                pointToUserSpace(1.0f, 0f, textMatrix),
+                convertHeightToUser(graphicsState.getFontAscentDescriptor(), textMatrix),
+                convertHeightToUser(graphicsState.getFontDescentDescriptor(), textMatrix),
+                convertWidthToUser(unscaledWidth, textMatrix));
+        textToUserSpaceTransformMatrix = textMatrix;
+        this.graphicsState = graphicsState;
+    }
 
     /**
      * @param xOffset offset in x direction

--- a/openpdf/src/main/java/com/lowagie/text/xml/TagMap.java
+++ b/openpdf/src/main/java/com/lowagie/text/xml/TagMap.java
@@ -151,6 +151,18 @@ public class TagMap extends HashMap<String, XmlPeer> {
          */
         private XmlPeer currentPeer;
 
+        /**
+         * Constructs a new SAXiTextHandler that will translate all the events
+         * triggered by the parser to actions on the <CODE>Document</CODE>-object.
+         *
+         * @param tagMap A Hashmap containing XmlPeer-objects
+         */
+        @Deprecated
+        @SuppressWarnings("unchecked")
+        public AttributeHandler(HashMap tagMap) {
+            this.tagMap = tagMap;
+        }
+
         public AttributeHandler(Map<String, XmlPeer> tagMap) {
             this.tagMap = tagMap;
         }

--- a/openpdf/src/main/java/com/lowagie/text/xml/simpleparser/EntitiesToSymbol.java
+++ b/openpdf/src/main/java/com/lowagie/text/xml/simpleparser/EntitiesToSymbol.java
@@ -69,8 +69,11 @@ public class EntitiesToSymbol {
     /**
      * This is a map that contains all possible id values of the entity tag
      * that can be translated to a character in font Symbol.
+     *
+     * @deprecated use the getter ({@link EntitiesToSymbol#getMap()}) instead of accessing this field directly
      */
-    static final HashMap<String, Character> map;
+    @Deprecated
+    public static final HashMap<String, Character> map;
 
     static {
         map = new HashMap<>(300);

--- a/openpdf/src/main/java/com/lowagie/text/xml/simpleparser/EntitiesToUnicode.java
+++ b/openpdf/src/main/java/com/lowagie/text/xml/simpleparser/EntitiesToUnicode.java
@@ -65,8 +65,11 @@ public class EntitiesToUnicode {
 
     /**
      * This is a map that contains the names of entities and their unicode value.
+     *
+     * @deprecated use the getter ({@link EntitiesToUnicode#getMap()}) instead of accessing this field directly
      */
-     static final HashMap<String, Character> map = new HashMap<>();
+    @Deprecated
+    public static final HashMap<String, Character> map = new HashMap<>();
 
     static {
         map.put("nbsp", '\u00a0'); // no-break space = non-breaking space, U+00A0 ISOnum

--- a/openpdf/src/main/java/com/lowagie/text/xml/simpleparser/SimpleXMLDocHandler.java
+++ b/openpdf/src/main/java/com/lowagie/text/xml/simpleparser/SimpleXMLDocHandler.java
@@ -46,6 +46,7 @@
  */
 package com.lowagie.text.xml.simpleparser;
 
+import java.util.HashMap;
 import java.util.Map;
 
 /**
@@ -53,6 +54,12 @@ import java.util.Map;
  * @author Paulo Soares (psoares@consiste.pt)
  */
 public interface SimpleXMLDocHandler {
+    /**
+     * Called when a start tag is found.
+     * @param tag the tag name
+     * @param h the tag's attributes
+     */
+    void startElement(String tag, HashMap h);
     /**
      * Called when a start tag is found.
      * @param tag the tag name

--- a/openpdf/src/test/java/com/lowagie/text/pdf/PdfDocumentCJKExtensionTest.java
+++ b/openpdf/src/test/java/com/lowagie/text/pdf/PdfDocumentCJKExtensionTest.java
@@ -1,0 +1,65 @@
+package com.lowagie.text.pdf;
+
+import java.io.FileOutputStream;
+import java.io.IOException;
+
+import com.lowagie.text.Chunk;
+import com.lowagie.text.Document;
+import com.lowagie.text.Font;
+import com.lowagie.text.FontFactory;
+import org.junit.jupiter.api.Test;
+
+class PdfDocumentCJKExtensionTest {
+	@Test
+	void generateDocumentsWithCJKExtension() throws IOException {
+		String fontName = "TakaoMjMincho";
+
+		// TakaoMjMincho Version 003.01.01
+		// Please download and place it below. 
+		// https://launchpad.net/takao-fonts
+		// https://launchpad.net/takao-fonts/trunk/15.03/+download/TakaoMjFonts_00301.01.zip
+		String fontPath = "src/test/resources/fonts/TakaoMjFonts/TakaoMjMincho.ttf";
+
+		// register font
+		FontFactory.register(fontPath, fontName);
+
+		Document document = new Document();
+
+		// FOP off 
+		document.setGlyphSubstitutionEnabled(false);
+
+		PdfWriter.getInstance(document, new FileOutputStream("target/" + PdfDocumentCJKExtensionTest.class.getSimpleName() + ".pdf"));
+
+		try {
+			Font font = FontFactory.getFont(fontName, "Identity-H", false, 10, 0, null);
+
+			document.open();
+			// CJK Unified Ideographs Extension B
+			// https://en.wikipedia.org/wiki/CJK_Unified_Ideographs_Extension_B
+
+			// U+20000
+			String cjkB_OK = "𠀀";
+			// U+2A000 
+			String cjkB_NG = "𪀀";
+
+
+			// CJK Unified Ideographs Extension C
+			// https://en.wikipedia.org/wiki/CJK_Unified_Ideographs_Extension_C
+
+			// U+2A746
+			String cjkC_NG = "𪝆";
+
+
+			// CJK Unified Ideographs Extension D
+			// https://en.wikipedia.org/wiki/CJK_Unified_Ideographs_Extension_D
+
+			// U+2B746
+			String cjkD_NG = "𫝆";
+
+			document.add(new Chunk(cjkB_OK + " " + cjkB_NG + " " + cjkC_NG + " " + cjkD_NG, font));
+
+		} finally {
+			document.close();
+		}
+	}
+}

--- a/openpdf/src/test/java/com/lowagie/text/pdf/SimpleBookmarkTest.java
+++ b/openpdf/src/test/java/com/lowagie/text/pdf/SimpleBookmarkTest.java
@@ -15,7 +15,7 @@ class SimpleBookmarkTest {
     void testGetBookmarkWithNoTitle() throws IOException {
         InputStream is = getClass().getResourceAsStream("/OutlineUriActionWithNoTitle.pdf");
         PdfReader reader = new PdfReader(is);
-        List<?> list = SimpleBookmark.getBookmark(reader);
+        List<?> list = SimpleBookmark.getBookmarkList(reader);
         assertNotNull(list);
         assertEquals(3, list.size());
     }

--- a/openpdf/src/test/java/com/lowagie/text/pdf/SimpleBookmarkTest.java
+++ b/openpdf/src/test/java/com/lowagie/text/pdf/SimpleBookmarkTest.java
@@ -15,7 +15,7 @@ class SimpleBookmarkTest {
     void testGetBookmarkWithNoTitle() throws IOException {
         InputStream is = getClass().getResourceAsStream("/OutlineUriActionWithNoTitle.pdf");
         PdfReader reader = new PdfReader(is);
-        List<?> list = SimpleBookmark.getBookmarkList(reader);
+        List<?> list = SimpleBookmark.getBookmark(reader);
         assertNotNull(list);
         assertEquals(3, list.size());
     }

--- a/openpdf/src/test/java/com/lowagie/text/xml/simpleparser/SimpleXMLParserTest.java
+++ b/openpdf/src/test/java/com/lowagie/text/xml/simpleparser/SimpleXMLParserTest.java
@@ -4,6 +4,7 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
 import java.util.Map;
 
 import org.junit.jupiter.api.Assertions;
@@ -56,6 +57,9 @@ public class SimpleXMLParserTest {
         TestHandler(Charset charset) {
             this.charset = charset.displayName();
         }
+
+        @Override
+        public void startElement(String tag, HashMap h) {}
 
         @Override
         public void startElement(String tag, Map<String, String> h) {}


### PR DESCRIPTION
1) Reverted be388653bc948ebfc707be58192da61eec71abd1 to maintain compatibility with iText. This kind of changes will be done in 2.0.0 onwards.

2) Commit 63a678d6089bbaaf53e0a82e6061e2de36cf9206  broke java8 compatibility