### PR TITLE
#1077: PdfPrinterGraphics2D does not override create

### DIFF
--- a/openpdf/src/main/java/com/lowagie/text/pdf/PdfGraphics2D.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/PdfGraphics2D.java
@@ -203,6 +203,47 @@ public class PdfGraphics2D extends Graphics2D {
     }
 
     /**
+     * Copy constructor for child PdfGraphics2D objects.
+     * @param parent the parent PdfGraphics2D
+     * @see #create()
+     */
+    protected PdfGraphics2D(PdfGraphics2D parent) {
+        this();
+        rhints.putAll( parent.rhints );
+        onlyShapes = parent.onlyShapes;
+        transform = new AffineTransform(parent.transform);
+        baseFonts = parent.baseFonts;
+        fontMapper = parent.fontMapper;
+        paint = parent.paint;
+        fillGState = parent.fillGState;
+        currentFillGState = parent.currentFillGState;
+        currentStrokeGState = parent.currentStrokeGState;
+        strokeGState = parent.strokeGState;
+        background = parent.background;
+        mediaTracker = parent.mediaTracker;
+        convertImagesToJPEG = parent.convertImagesToJPEG;
+        jpegQuality = parent.jpegQuality;
+        setFont(parent.font);
+        cb = parent.cb.getDuplicate();
+        cb.saveState();
+        width = parent.width;
+        height = parent.height;
+        followPath(new Area(new Rectangle2D.Float(0, 0, width, height)), CLIP);
+        if (parent.clip != null)
+            clip = new Area(parent.clip);
+        composite = parent.composite;
+        stroke = parent.stroke;
+        originalStroke = parent.originalStroke;
+        strokeOne = (BasicStroke)transformStroke(parent.strokeOne);
+        oldStroke = parent.strokeOne;
+        setStrokeDiff(oldStroke, null);
+        cb.saveState();
+        if (clip != null)
+            followPath(clip, CLIP);
+        kid = true;
+    }
+
+    /**
      * Shortcut constructor for PDFGraphics2D.
      * @param cb the PdfContentByte
      * @param width the width
@@ -953,46 +994,18 @@ public class PdfGraphics2D extends Graphics2D {
      * @see Graphics#create()
      */
     public Graphics create() {
-        PdfGraphics2D g2 = new PdfGraphics2D();
-        g2.rhints.putAll( this.rhints );
-        g2.onlyShapes = this.onlyShapes;
-        g2.transform = new AffineTransform(this.transform);
-        g2.baseFonts = this.baseFonts;
-        g2.fontMapper = this.fontMapper;
-        g2.paint = this.paint;
-        g2.fillGState = this.fillGState;
-        g2.currentFillGState = this.currentFillGState;
-        g2.currentStrokeGState = this.currentStrokeGState;
-        g2.strokeGState = this.strokeGState;
-        g2.background = this.background;
-        g2.mediaTracker = this.mediaTracker;
-        g2.convertImagesToJPEG = this.convertImagesToJPEG;
-        g2.jpegQuality = this.jpegQuality;
-        g2.setFont(this.font);
-        g2.cb = this.cb.getDuplicate();
-        g2.cb.saveState();
-        g2.width = this.width;
-        g2.height = this.height;
-        g2.followPath(new Area(new Rectangle2D.Float(0, 0, width, height)), CLIP);
-        if (this.clip != null)
-            g2.clip = new Area(this.clip);
-        g2.composite = composite;
-        g2.stroke = stroke;
-        g2.originalStroke = originalStroke;
-        g2.strokeOne = (BasicStroke)g2.transformStroke(g2.strokeOne);
-        g2.oldStroke = g2.strokeOne;
-        g2.setStrokeDiff(g2.oldStroke, null);
-        g2.cb.saveState();
-        if (g2.clip != null)
-            g2.followPath(g2.clip, CLIP);
-        g2.kid = true;
-        if (this.kids == null)
-            this.kids = new ArrayList<>();
-        this.kids.add(cb.getInternalBuffer().size());
-        this.kids.add(g2);
+        PdfGraphics2D g2 = createChild();
+        if (kids == null)
+            kids = new ArrayList<>();
+        kids.add(cb.getInternalBuffer().size());
+        kids.add(g2);
         return g2;
     }
-    
+
+    protected PdfGraphics2D createChild() {
+        return new PdfGraphics2D(this);
+    }
+
     public PdfContentByte getContent() {
         return this.cb;
     }

--- a/openpdf/src/main/java/com/lowagie/text/pdf/PdfGraphics2D.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/PdfGraphics2D.java
@@ -234,7 +234,7 @@ public class PdfGraphics2D extends Graphics2D {
         composite = parent.composite;
         stroke = parent.stroke;
         originalStroke = parent.originalStroke;
-        strokeOne = (BasicStroke)transformStroke(parent.strokeOne);
+        strokeOne = (BasicStroke)transformStroke(strokeOne);
         oldStroke = parent.strokeOne;
         setStrokeDiff(oldStroke, null);
         cb.saveState();

--- a/openpdf/src/main/java/com/lowagie/text/pdf/PdfPrinterGraphics2D.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/PdfPrinterGraphics2D.java
@@ -66,7 +66,16 @@ public class PdfPrinterGraphics2D extends PdfGraphics2D implements PrinterGraphi
         this.printerJob = printerJob;
     }
 
+    protected PdfPrinterGraphics2D(PdfPrinterGraphics2D parent) {
+        super(parent);
+        printerJob = parent.printerJob;
+    }
+
     public PrinterJob getPrinterJob()    {
         return printerJob;
+    }
+
+    protected PdfGraphics2D createChild() {
+        return new PdfPrinterGraphics2D(this);
     }
 }

--- a/openpdf/src/test/java/com/lowagie/text/pdf/PdfPrinterGraphics2DTest.java
+++ b/openpdf/src/test/java/com/lowagie/text/pdf/PdfPrinterGraphics2DTest.java
@@ -1,0 +1,29 @@
+package com.lowagie.text.pdf;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.lowagie.text.Document;
+
+import java.awt.Graphics;
+import java.awt.Graphics2D;
+import java.awt.print.PrinterJob;
+import java.io.ByteArrayOutputStream;
+
+import org.junit.jupiter.api.Test;
+
+class PdfPrinterGraphics2DTest
+{
+	@Test
+	void testCreate() {
+		try (Document document = new Document()) {
+			PdfWriter writer = PdfWriter.getInstance(document, new ByteArrayOutputStream());
+			document.open();
+			Graphics2D graphics1 = writer.getDirectContent().createPrinterGraphics(10, 10, PrinterJob.getPrinterJob());
+			Graphics graphics2 = graphics1.create();
+			assertEquals(PdfPrinterGraphics2D.class, graphics1.getClass());
+			assertEquals(PdfPrinterGraphics2D.class, graphics2.getClass());
+			graphics2.dispose();
+			graphics1.dispose();
+		}
+	}
+}

--- a/openpdf/src/test/java/com/lowagie/text/pdf/PdfPrinterGraphics2DTest.java
+++ b/openpdf/src/test/java/com/lowagie/text/pdf/PdfPrinterGraphics2DTest.java
@@ -1,6 +1,6 @@
 package com.lowagie.text.pdf;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.lowagie.text.Document;
 


### PR DESCRIPTION
## Description of the new Feature/Bugfix
Override `create()` in `PdfPrinterGraphics2D`.
Introduces a copy constructor and a protected `createChild` method for this purpose. The `createChild` method only creates the new copy using the copy constructor, whereas `create` calls `createChild` and then adds the new copy to its `kids` before returning it.

This is just one of many possible designs. For example, a copyFrom (or copyTo) method could be used instead of a copy constructor, or we could delegate to the clone mechanism. Also, it would have been possible to add the kid directly in the copy constructor, so the createChild method would not be needed. However, I didn't like the idea of mutating the parameter of the copy constructor.

So in the end I chose this design because I think it this is the cleanest option, but of course it's up to you to change anything.

Related Issue: #1077

## Unit-Tests for the new Feature/Bugfix
- [x] Unit-Tests added to reproduce the bug
- [ ] Unit-Tests added to the added feature
