### PR TITLE
Small refactoring - moved rectangle normalization into PdfRectangle constructor to avoid issues with using this constructor in the future

### DIFF
--- a/openpdf/src/main/java/com/lowagie/text/pdf/PdfRectangle.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/PdfRectangle.java
@@ -160,16 +160,7 @@ public class PdfRectangle extends PdfArray {
      * @param rectangle as a PdfArray
      */
     public PdfRectangle(PdfArray rectangle) {
-        this(convertToFloat(rectangle.getPdfObject(0)), convertToFloat(rectangle.getPdfObject(1)),
-                convertToFloat(rectangle.getPdfObject(2)), convertToFloat(rectangle.getPdfObject(3)));
-    }
-
-    private static float convertToFloat(PdfObject object) {
-        if (!(object instanceof PdfNumber)) {
-            throw new IllegalArgumentException(
-                    "Invalid argument. Float value (coordinate) expected! But was " + object);
-        }
-        return ((PdfNumber) object).floatValue();
+        this(PdfReader.getNormalizedRectangle(rectangle));
     }
 
     // methods

--- a/openpdf/src/main/java/com/lowagie/text/pdf/PdfStamperImp.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/PdfStamperImp.java
@@ -979,8 +979,8 @@ class PdfStamperImp extends PdfWriter {
 
                     if (bboxRaw != null && rectRaw != null) {
                         transformNeeded = true;
-                        PdfRectangle bbox = new PdfRectangle(PdfReader.getNormalizedRectangle(bboxRaw));
-                        PdfRectangle rect = new PdfRectangle(PdfReader.getNormalizedRectangle(rectRaw));
+                        PdfRectangle bbox = new PdfRectangle(bboxRaw);
+                        PdfRectangle rect = new PdfRectangle(rectRaw);
 
                         float rectWidth = rect.width();
                         float rectHeight = rect.height();
@@ -1060,8 +1060,7 @@ class PdfStamperImp extends PdfWriter {
                             if (!(objReal instanceof PdfIndirectReference)) {
 
                                 // Lonzak: npe bugfix
-                                PdfRectangle bBoxCoordinates = new PdfRectangle(
-                                        ((PdfDictionary) objReal).getAsArray(PdfName.BBOX));
+                                PdfArray bBoxCoordinates = ((PdfDictionary) objReal).getAsArray(PdfName.BBOX);
                                 if (bBoxCoordinates != null && bBoxCoordinates.size() >= 4) {
                                     // DEVSIX-1741 - Bugfix backported as Jonthan of iText suggested
                                     Rectangle bBox = PdfReader.getNormalizedRectangle(bBoxCoordinates);


### PR DESCRIPTION
## Description of the new Feature

As suggested here  https://github.com/LibrePDF/OpenPDF/pull/1116#pullrequestreview-1965603725
Small refactoring applied for PdfRectangle -  the fix moved into constructor to avoid similar bugs in the future.

Related Issue: https://github.com/LibrePDF/OpenPDF/pull/1116

## Unit-Tests for the new Feature/Bugfix

 [-] No new tests added, existing Unit-Tests covers the changes

## Compatibilities Issues

not known, not expected

## Testing details

Tested by existing unit tests
