### PR TITLE
PdfStructureTreeRoot update - allowing to save Object References

### DIFF
--- a/openpdf/src/test/java/com/lowagie/text/pdf/PdfStructureTreeRootTest.java
+++ b/openpdf/src/test/java/com/lowagie/text/pdf/PdfStructureTreeRootTest.java
@@ -1,0 +1,91 @@
+package com.lowagie.text.pdf;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import org.junit.jupiter.api.Test;
+
+class PdfStructureTreeRootTest {
+
+    @Test
+    void shouldCreateNewInstanceSuccessfully() {
+        PdfWriter writer = mock(PdfWriter.class);
+        when(writer.getPdfIndirectReference()).thenReturn(mock(PdfIndirectReference.class));
+
+        PdfStructureTreeRoot root = new PdfStructureTreeRoot(writer);
+
+        assertNotNull(root);
+        assertEquals(PdfName.STRUCTTREEROOT, root.get(PdfName.TYPE));
+        assertNotNull(root.getReference());
+        assertSame(writer, root.getWriter());
+    }
+
+    @Test
+    void shouldMapUserTagToStandardTag() {
+        PdfStructureTreeRoot root = new PdfStructureTreeRoot(mock(PdfWriter.class));
+        PdfName userTag = new PdfName("MyTag");
+        PdfName standardTag = PdfName.H1;
+
+        root.mapRole(userTag, standardTag);
+
+        PdfDictionary roleMap = (PdfDictionary) root.get(PdfName.ROLEMAP);
+        assertNotNull(roleMap);
+        assertEquals(standardTag, roleMap.get(userTag));
+    }
+
+    @Test
+    void getWriterShouldReturnCorrectWriter() {
+        PdfWriter mockWriter = mock(PdfWriter.class);
+        PdfStructureTreeRoot treeRoot = new PdfStructureTreeRoot(mockWriter);
+
+        PdfWriter result = treeRoot.getWriter();
+
+        assertSame(mockWriter, result);
+    }
+
+    @Test
+    void addExistingObjectShouldIncreaseParentTreeNextKey() {
+        PdfWriter mockWriter = mock(PdfWriter.class);
+        PdfStructureTreeRoot treeRoot = new PdfStructureTreeRoot(mockWriter);
+        PdfIndirectReference mockRef = mock(PdfIndirectReference.class);
+
+        int firstKey = treeRoot.addExistingObject(mockRef);
+        int secondKey = treeRoot.addExistingObject(mockRef);
+
+        assertNotEquals(firstKey, secondKey);
+        assertEquals(firstKey + 1, secondKey);
+    }
+
+    @Test
+    void buildTreeShouldGenerateParentTreeWithoutException() throws IOException {
+        PdfWriter mockWriter = mock(PdfWriter.class);
+        when(mockWriter.addToBody(any(PdfObject.class))).thenAnswer(invocation -> {
+            PdfObject arg = invocation.getArgument(0);
+            return new PdfIndirectObject(0, arg, mockWriter);
+        });
+
+        PdfStructureTreeRoot treeRoot = new PdfStructureTreeRoot(mockWriter);
+
+        assertDoesNotThrow(() -> treeRoot.buildTree());
+    }
+
+    @Test
+    void buildTreeShouldHandleIOException() throws IOException {
+        PdfWriter mockWriter = mock(PdfWriter.class);
+        doThrow(IOException.class).when(mockWriter).addToBody(any(PdfObject.class));
+
+        PdfStructureTreeRoot treeRoot = new PdfStructureTreeRoot(mockWriter);
+        treeRoot.setPageMark(1, mock(PdfIndirectReference.class));
+
+        assertThrows(IOException.class, () -> treeRoot.buildTree());
+    }
+}


### PR DESCRIPTION
## Description of the new Feature

> Describe here how you fixed the bug, or implemented the new feature.

I'm working on generation of PDF/UA-compatible PDFs, and I've faced an issue related to connecting tagged Link element with corresponding Annotation inside a PDF.

The way annotation should reference a link to pass PDF/UA validation:
1. `Annotation` should contains a `/StructParent` property which is pointing to a key in `/Nums` array
2. `/Nums` array should contains a reference to the `Link` pdf object (written to the PDF before)

Use case for this situation described in [this answer on StackOverflow](https://stackoverflow.com/a/54434599). 

Proposed implementation allows to add an existing object reference to the `PdfStructureTreeRoot`, so it will be saved into `/Nums` array.

## Unit-Tests for the new Feature/Bugfix

- [ ] Unit-Tests added to reproduce the bug
- [X] Unit-Tests added to the added feature

## Compatibilities Issues

> Is anything broken because of the new code? Any changes in method signatures?

No changes in existing signatures

## Testing details

> Any other details about how to test the new feature or bugfix?
