### PR TITLE
PdfStructureTreeRoot update - fixing Page linking

### DIFF
--- a/openpdf/src/main/java/com/lowagie/text/pdf/PdfDocument.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/PdfDocument.java
@@ -977,7 +977,10 @@ public class PdfDocument extends Document {
 
             // [F12] we add tag info
             if (writer.isTagged()) {
-                page.put(PdfName.STRUCTPARENTS, new PdfNumber(writer.getCurrentPageNumber() - 1));
+                //connecting /NUMS array entry (pageIdValue) with Page via /STRUCTPARENTS value
+                int pageIdValue = writer.getStructureTreeRoot()
+                        .getOrCreatePageKey(writer.getCurrentPageNumber() - 1);
+                page.put(PdfName.STRUCTPARENTS, new PdfNumber(pageIdValue));
             }
 
             if (text.size() > textEmptySize) {

--- a/openpdf/src/main/java/com/lowagie/text/pdf/PdfWriter.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/PdfWriter.java
@@ -1093,15 +1093,26 @@ public class PdfWriter extends DocWriter implements
      *
      * @return a page number
      */
-
     public int getPageNumber() {
         return pdf.getPageNumber();
     }
 
-    PdfIndirectReference getCurrentPage() {
+    /**
+     * Retrieves a reference to the current page of the document.
+     * The current page is typically the last page that was modified or accessed.
+     *
+     * @return a {@link PdfIndirectReference} object pointing to the current page in the PDF document.
+     */
+    public PdfIndirectReference getCurrentPage() {
         return getPageReference(currentPageNumber);
     }
 
+    /**
+     * Returns the number of the current page in the document.
+     * The current page is typically the last page that was modified or accessed.
+     *
+     * @return the current page number.
+     */
     public int getCurrentPageNumber() {
         return currentPageNumber;
     }

--- a/openpdf/src/test/java/com/lowagie/text/pdf/PdfStructureTreeRootTest.java
+++ b/openpdf/src/test/java/com/lowagie/text/pdf/PdfStructureTreeRootTest.java
@@ -75,7 +75,7 @@ class PdfStructureTreeRootTest {
 
         PdfStructureTreeRoot treeRoot = new PdfStructureTreeRoot(mockWriter);
 
-        assertDoesNotThrow(() -> treeRoot.buildTree());
+        assertDoesNotThrow(treeRoot::buildTree);
     }
 
     @Test
@@ -86,6 +86,38 @@ class PdfStructureTreeRootTest {
         PdfStructureTreeRoot treeRoot = new PdfStructureTreeRoot(mockWriter);
         treeRoot.setPageMark(1, mock(PdfIndirectReference.class));
 
-        assertThrows(IOException.class, () -> treeRoot.buildTree());
+        assertThrows(IOException.class, treeRoot::buildTree);
+    }
+
+    @Test
+    void getOrCreatePageKeyShouldCreateNewPageArrayWhenNotExists() {
+        PdfWriter mockWriter = mock(PdfWriter.class);
+        PdfStructureTreeRoot treeRoot = new PdfStructureTreeRoot(mockWriter);
+
+        PdfIndirectReference mockRef = mock(PdfIndirectReference.class);
+
+        int firstKey = treeRoot.addExistingObject(mockRef);
+        assertEquals(0, firstKey);
+
+        int pageKey = treeRoot.getOrCreatePageKey(1);
+        assertEquals(1, pageKey);
+    }
+
+    @Test
+    void getOrCreatePageKeyShouldReturnExistingPageKey() {
+        PdfWriter mockWriter = mock(PdfWriter.class);
+        PdfStructureTreeRoot treeRoot = new PdfStructureTreeRoot(mockWriter);
+
+        PdfIndirectReference mockRef = mock(PdfIndirectReference.class);
+
+        int firstKey = treeRoot.addExistingObject(mockRef);
+        assertEquals(0, firstKey);
+
+        //key should be created when setting page mark
+        treeRoot.setPageMark(1, mock(PdfIndirectReference.class));
+
+        //existing key should be returned
+        int pageKey = treeRoot.getOrCreatePageKey(1);
+        assertEquals(1, pageKey);
     }
 }


### PR DESCRIPTION
## Description of the new Feature/Bugfix

A follow-up / bugfix for PR #1127 

* For cases when existing object is being added to `/NUMS` array via `PdfStructureTreeRoot.addExistingObject`, we need to save correct array entry into Page's `/STRUCTPARENTS` field. 
Previously this reference was populated with `id = pageNumber` which was broken by PR #1127 
* `PdfWriter.getCurrentPage()` is made `public` as far as both `getPageReference()` and `getCurrentPageNumber()` are public. So this method can be used instead of `writer.getPageReference(writer.getCurrentPageNumber())`

## Unit-Tests for the new Feature/Bugfix

- [ ] Unit-Tests added to reproduce the bug
- [X] Unit-Tests added to the added feature

## Compatibilities Issues

> Is anything broken because of the new code? Any changes in method signatures?
* Visibility of one method `PdfWriter.getCurrentPage()` was changed from default to public, no compatibility issues expected. 

## Testing details

> Any other details about how to test the new feature or bugfix?
