### PR TITLE
Update README.md and CONTRIBUTING.md, to require real name of contributors

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -35,9 +35,9 @@ If applicable, add screenshots to help explain your problem.
 - Used font:
 - OpenPDF version:
 
-### Your real name
-
-Please list your full name here, so that we can verify your identity. If you have a conflict of interest describe this here also.
+## Your real name
+Please specify your full name here, so that we can verify your identity. 
+If you have a conflict of interest describe this here also.
 
 ### Additional context
 

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -35,6 +35,10 @@ If applicable, add screenshots to help explain your problem.
 - Used font:
 - OpenPDF version:
 
+### Your real name
+
+Please list your full name here, so that we can verify your identity. If you have a conflict of interest describe this here also.
+
 ### Additional context
 
 Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -17,7 +17,8 @@ A clear and concise description of what you want to happen.
 A clear and concise description of any alternative solutions or features you've considered.
 
 **Your real name**
-Please specify your full name here, so that we can verify your identity. If you have a conflict of interest describe this here also.
+Please specify your full name here, so that we can verify your identity. 
+If you have a conflict of interest describe this here also.
 
 **Additional context**
 Add any other context or screenshots about the feature request here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -16,5 +16,8 @@ A clear and concise description of what you want to happen.
 **Describe alternatives you've considered**
 A clear and concise description of any alternative solutions or features you've considered.
 
+**Your real name**
+Please specify your full name here, so that we can verify your identity. If you have a conflict of interest describe this here also.
+
 **Additional context**
 Add any other context or screenshots about the feature request here.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -14,7 +14,8 @@ Related Issue: #
 Is anything broken because of the new code? Any changes in method signatures?
 
 ## Your real name
-Please specify your full name here, so that we can verify your identity. If you have a conflict of interest describe this here also.
+Please specify your full name here, so that we can verify your identity. 
+If you have a conflict of interest describe this here also.
 
 ## Testing details
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -13,6 +13,9 @@ Related Issue: #
 
 Is anything broken because of the new code? Any changes in method signatures?
 
+## Your real name
+Please specify your full name here, so that we can verify your identity. If you have a conflict of interest describe this here also.
+
 ## Testing details
 
 Any other details about how to test the new feature or bugfix?

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,9 +1,9 @@
 # Contributing to OpenPDF
 
-To contribute code to the OpenPDF project, your GitHub account must contain your real name, so that we can verify 
-your identity. This is to ensure the trust, security and integrity of the OpenPDF project, and to prevent security incidents
-such as the "XZ Utils backdoor". Knowning the real name of the contributors will also identify and prevent
-conflict of interests. 
+To contribute code to the OpenPDF project, your GitHub account must contain your real name, so that 
+we can verify your identity. This is to ensure the trust, security and integrity of the OpenPDF 
+project, and to prevent security incidents such as the "XZ Utils backdoor". Knowning the real name
+of the contributors will also identify and prevent conflict of interests. 
 
 ## How to contribute with Code
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,8 @@
 
 To contribute code to the OpenPDF project, your GitHub account must contain your real name, so that we can verify 
 your identity. This is to ensure the trust, security and integrity of the OpenPDF project, and to prevent security incidents
-such as the "XZ Utils backdoor". Knowning the real name of the contributors will also identify and prevent conflict of interests. 
+such as the "XZ Utils backdoor". Knowning the real name of the contributors will also identify and prevent
+conflict of interests. 
 
 ## How to contribute with Code
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,8 @@
 # Contributing to OpenPDF
 
 To contribute code to the OpenPDF project, your GitHub account must contain your real name, so that we can verify 
-your identity. This is to ensure the trust, security and integrity of the OpenPDF project, and to prevent security incidents such as the "XZ Utils backdoor".
+your identity. This is to ensure the trust, security and integrity of the OpenPDF project, and to prevent security incidents
+such as the "XZ Utils backdoor". Knowning the real name of the contributors will also identify and prevent conflict of interests. 
 
 ## How to contribute with Code
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,8 @@
 # Contributing to OpenPDF
 
+To contribute code to the OpenPDF project, your GitHub account must contain your real name, so that we can verify 
+your identity. This is to ensure the trust, security and integrity of the OpenPDF project, and to prevent security incidents such as the "XZ Utils backdoor".
+
 ## How to contribute with Code
 
 1. Create a GitHub account

--- a/README.md
+++ b/README.md
@@ -120,10 +120,10 @@ Release the hounds!  Please send all pull requests. Make sure that your contribu
 released with a dual LGPL and MPL license. In particular, pull requests to the OpenPDF project must
 only contain code that you have written yourself. GPL or AGPL licensed code will not be acceptable.
 
-To contribute code to the OpenPDF project, your GitHub account must contain your real name, so that we can verify 
-your identity. This is to ensure the trust, security and integrity of the OpenPDF project, and to prevent security incidents
-such as the "XZ Utils backdoor". Knowning the real name of the contributors will also identify and prevent
-conflict of interests. 
+To contribute code to the OpenPDF project, your GitHub account must contain your real name, so that 
+we can verify your identity. This is to ensure the trust, security and integrity of the OpenPDF 
+project, and to prevent security incidents such as the "XZ Utils backdoor". Knowning the real name
+of the contributors will also identify and prevent conflict of interests. 
 
 More details: [Contributing](CONTRIBUTING.md)
 

--- a/README.md
+++ b/README.md
@@ -120,6 +120,10 @@ Release the hounds!  Please send all pull requests. Make sure that your contribu
 released with a dual LGPL and MPL license. In particular, pull requests to the OpenPDF project must
 only contain code that you have written yourself. GPL or AGPL licensed code will not be acceptable.
 
+To contribute code to the OpenPDF project, your GitHub account must contain your real name, so that we can verify 
+your identity. This is to ensure the trust, security and integrity of the OpenPDF project, and to prevent security incidents
+such as the "XZ Utils backdoor". Knowning the real name of the contributors will also identify and prevent conflict of interests. 
+
 More details: [Contributing](CONTRIBUTING.md)
 
 ### Coding Style

--- a/README.md
+++ b/README.md
@@ -122,7 +122,8 @@ only contain code that you have written yourself. GPL or AGPL licensed code will
 
 To contribute code to the OpenPDF project, your GitHub account must contain your real name, so that we can verify 
 your identity. This is to ensure the trust, security and integrity of the OpenPDF project, and to prevent security incidents
-such as the "XZ Utils backdoor". Knowning the real name of the contributors will also identify and prevent conflict of interests. 
+such as the "XZ Utils backdoor". Knowning the real name of the contributors will also identify and prevent
+conflict of interests. 
 
 More details: [Contributing](CONTRIBUTING.md)
 


### PR DESCRIPTION
Update README.md, CONTRIBUTING.md, and Github template files, to require real name of contributors.

I strongly recommend to enforce and document the requirement that the real name must be known of contributors from now on.

Based on discussions in https://github.com/LibrePDF/OpenPDF/discussions/1128 and in light of  https://en.wikipedia.org/wiki/XZ_Utils_backdoor

@asturio 