### PR TITLE
#1161 Fix List rendering in ColumnText

### DIFF
--- a/openpdf/src/main/java/com/lowagie/text/pdf/ColumnText.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/ColumnText.java
@@ -1301,7 +1301,18 @@ public class ColumnText {
                 float listIndentation = list.getIndentationLeft();
                 int count = 0;
                 Stack<Object[]> stack = new Stack<>();
-                for (int k = 0; k < items.size(); ++k) {
+                for (int k = 0; k <= items.size(); ++k) {
+                    if (k == items.size()) {
+                        if (!stack.isEmpty()) {
+                            Object[] objs = stack.pop();
+                            list = (com.lowagie.text.List) objs[0];
+                            items = list.getItems();
+                            k = (Integer) objs[1];
+                            listIndentation = (Float) objs[2];
+                        }
+                        continue;
+                    }
+
                     Object obj = items.get(k);
                     if (obj instanceof ListItem) {
                         if (count == listIdx) {
@@ -1316,16 +1327,6 @@ public class ColumnText {
                         items = list.getItems();
                         listIndentation += list.getIndentationLeft();
                         k = -1;
-                        continue;
-                    }
-                    if (k == items.size() - 1) {
-                        if (!stack.isEmpty()) {
-                            Object[] objs = stack.pop();
-                            list = (com.lowagie.text.List) objs[0];
-                            items = list.getItems();
-                            k = (Integer) objs[1];
-                            listIndentation = (Float) objs[2];
-                        }
                     }
                 }
                 int status = 0;


### PR DESCRIPTION
## Description of the Bugfix

When adding nested Lists to ColumnText sometimes the rendering of the List just stops midway through. This is caused by nesting levels of lists being reduced by more than one at a time. See the related issue for more detailed information.

The issue was caused by the `if (k == items.size() - 1)` section not being reached, because of the `k < items.size();` of the for loop. So when going back to the last item in the stack, the list rendering loop just exited instead of continuing with the previous list. I increased the for loop to run until `k <= item.size()` and changed the check to only run once `k == items.size()`. This ensures we run through each nested list completely and go back to the previous stack item if there is one in the stack.

Related Issue: #1161

## Compatibilities Issues

In my tests, List rendering in ColumnText still worked as expected.

## Your real name
Joost Zöllner

## Testing details

See the reproduction repo mentioned in the issue #1161 
