### PR TITLE
Allow PdfCopy to be used for writing new pages

### DIFF
--- a/openpdf/src/main/java/com/lowagie/text/pdf/PdfCopy.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/PdfCopy.java
@@ -489,17 +489,6 @@ public class PdfCopy extends PdfWriter {
         }
     }
 
-    public PdfIndirectReference add(PdfOutline outline) {
-        return null;
-    }
-
-    public void addAnnotation(PdfAnnotation annot) {
-    }
-
-    PdfIndirectReference add(PdfPage page, PdfContents contents) throws PdfException {
-        return null;
-    }
-
     public void freeReader(PdfReader reader) throws IOException {
         indirectMap.remove(reader);
         if (currentPdfReaderInstance != null) {

--- a/openpdf/src/test/java/com/lowagie/text/pdf/PdfSmartCopyTest.java
+++ b/openpdf/src/test/java/com/lowagie/text/pdf/PdfSmartCopyTest.java
@@ -109,31 +109,4 @@ public class PdfSmartCopyTest {
             }
         }
     }
-
-
-    @Test
-    void verbose() throws IOException {
-        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
-        try (Document document = new Document()) {
-            try (PdfCopy copy = new PdfSmartCopy(document, outputStream)) {
-                document.open();
-
-                ByteArrayOutputStream baos = new ByteArrayOutputStream();
-                Document tempDocument = new Document();
-                PdfWriter tempWriter = PdfWriter.getInstance(tempDocument, baos);
-                tempDocument.open();
-                tempDocument.add(new Phrase("Front page"));
-                tempDocument.close();
-                PdfReader tempReader = new PdfReader(baos.toByteArray());
-                PdfImportedPage page = copy.getImportedPage(tempReader, 1);
-                copy.addPage(page);
-                copy.freeReader(tempReader);
-
-                document.newPage();
-                document.add(new Paragraph("Last page"));
-            }
-        }
-        Files.write(Path.of("/home/faber-espensenr/tmp/x3.pdf"), outputStream.toByteArray());
-
-    }
 }

--- a/openpdf/src/test/java/com/lowagie/text/pdf/PdfSmartCopyTest.java
+++ b/openpdf/src/test/java/com/lowagie/text/pdf/PdfSmartCopyTest.java
@@ -20,7 +20,7 @@ public class PdfSmartCopyTest {
     }
 
     @Test
-    public void test1() {
+    void test1() {
         File orig = new File("src/test/resources/pdfsmartcopy_bec.pdf");
         check(orig, 1);
     }
@@ -49,7 +49,7 @@ public class PdfSmartCopyTest {
     }
 
     @Test
-    public void canWriteAndCopy() throws IOException {
+    void canWriteAndCopy() throws IOException {
         try (PdfReader reader = new PdfReader("src/test/resources/pdfsmartcopy_bec.pdf")) {
             ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
             try (Document document = new Document()) {

--- a/openpdf/src/test/java/com/lowagie/text/pdf/PdfSmartCopyTest.java
+++ b/openpdf/src/test/java/com/lowagie/text/pdf/PdfSmartCopyTest.java
@@ -1,20 +1,17 @@
 package com.lowagie.text.pdf;
 
-import com.lowagie.text.Document;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import com.lowagie.text.Document;
+import com.lowagie.text.Paragraph;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.nio.file.Files;
-import java.nio.file.Path;
 import java.time.Duration;
-
-import com.lowagie.text.Paragraph;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class PdfSmartCopyTest {
 

--- a/openpdf/src/test/java/com/lowagie/text/pdf/PdfSmartCopyTest.java
+++ b/openpdf/src/test/java/com/lowagie/text/pdf/PdfSmartCopyTest.java
@@ -4,14 +4,14 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.lowagie.text.Document;
 import com.lowagie.text.Paragraph;
-
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.time.Duration;
-
+import com.lowagie.text.Phrase;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -110,4 +110,30 @@ public class PdfSmartCopyTest {
         }
     }
 
+
+    @Test
+    void verbose() throws IOException {
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        try (Document document = new Document()) {
+            try (PdfCopy copy = new PdfSmartCopy(document, outputStream)) {
+                document.open();
+
+                ByteArrayOutputStream baos = new ByteArrayOutputStream();
+                Document tempDocument = new Document();
+                PdfWriter tempWriter = PdfWriter.getInstance(tempDocument, baos);
+                tempDocument.open();
+                tempDocument.add(new Phrase("Front page"));
+                tempDocument.close();
+                PdfReader tempReader = new PdfReader(baos.toByteArray());
+                PdfImportedPage page = copy.getImportedPage(tempReader, 1);
+                copy.addPage(page);
+                copy.freeReader(tempReader);
+
+                document.newPage();
+                document.add(new Paragraph("Last page"));
+            }
+        }
+        Files.write(Path.of("/home/faber-espensenr/tmp/x3.pdf"), outputStream.toByteArray());
+
+    }
 }

--- a/openpdf/src/test/java/com/lowagie/text/pdf/PdfSmartCopyTest.java
+++ b/openpdf/src/test/java/com/lowagie/text/pdf/PdfSmartCopyTest.java
@@ -9,9 +9,7 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.nio.file.Files;
-import java.nio.file.Path;
 import java.time.Duration;
-import com.lowagie.text.Phrase;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 

--- a/openpdf/src/test/java/com/lowagie/text/pdf/PdfSmartCopyTest.java
+++ b/openpdf/src/test/java/com/lowagie/text/pdf/PdfSmartCopyTest.java
@@ -20,7 +20,7 @@ public class PdfSmartCopyTest {
     }
 
     @Test
-    void test1() {
+    public void test1() {
         File orig = new File("src/test/resources/pdfsmartcopy_bec.pdf");
         check(orig, 1);
     }


### PR DESCRIPTION
## Description of the new Feature/Bugfix

Remove unnecessary overridden methods from PdfCopy thus allowing it to be used to write new pages as well as copy them.

Related Issue: This fixes #1165 

## Unit-Tests for the new Feature/Bugfix

- [X] Unit-Tests added to reproduce the bug
- [X] Unit-Tests added to the added feature

## Compatibilities Issues

The behavior of `PdfCopy` is of course changed, since it now actually adds new pages if requested. I would expect that anyone that does that, actually intended to do it.

## Your real name
Rasmus Faber-Espensen

## Testing details

See unit test.
