### PR TITLE
Support using PDF, in addition to images, as the signature graphic

### DIFF
--- a/openpdf/src/test/java/com/lowagie/text/pdf/PdfSignatureAppearanceTest.java
+++ b/openpdf/src/test/java/com/lowagie/text/pdf/PdfSignatureAppearanceTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import com.lowagie.text.DocumentException;
+import com.lowagie.text.Image;
 import com.lowagie.text.Rectangle;
 import com.lowagie.text.Utilities;
 import java.io.ByteArrayInputStream;
@@ -103,6 +104,8 @@ public class PdfSignatureAppearanceTest {
         byte[] expectedDigestClose = null;
 
         Calendar signDate = Calendar.getInstance();
+        Image sigImg = Image.getInstance(getClass().getClassLoader().getResource("GitHub-Mark-32px.png"));
+        PdfReader sigPdf = new PdfReader(getClass().getClassLoader().getResource("SimulatedBoldAndStrokeWidth.pdf"));
 
         byte[] originalDocId = null;
         PdfObject overrideFileId = new PdfLiteral("<123><123>".getBytes());
@@ -129,6 +132,17 @@ public class PdfSignatureAppearanceTest {
                 sap.setSignDate(signDate);
                 sap.setVisibleSignature(new Rectangle(100, 100), 1);
                 sap.setLayer2Text("Hello world");
+                if (i < 5) {
+                    // Test image signature in the first half of the tests
+                    sap.setSignatureGraphic(sigImg);
+                } else {
+                    // Test PDF signature in the second half of the tests
+                    if (i == 5) {
+                        expectedDigestPreClose = null;
+                        expectedDigestClose = null;
+                    }
+                    sap.setSignaturePDF(sigPdf, 1);
+                }
 
                 Map<PdfName, Integer> exc = new HashMap<>();
                 exc.put(PdfName.CONTENTS, 10);


### PR DESCRIPTION
## Description of the new Feature

Support using PDF (vector graphics), in addition to images (i.e., png, jpg) as the visible signature.
I implemented this feature by adding a new function `setSignaturePDF`. Then I copy a configurable page from the given PDF as the signature and render it to the proper place.

Related Issue: #777 

## Unit-Tests for the new Feature/Bugfix

- [x] Unit-Tests **changed** for the added feature

## Compatibilities Issues

Only added new methods. No existing method signature or functionality changes. Should have no compatibility issues.

## Your real name
No conflict of interest.
I am a jsignpdf user, who wants to embed vector signatures into pdf, just like the other user in #777.
Prefer to not provide real name unless maintainer insists.

## Testing details

Updated the PdfSignatureAppearance test to use both an image signature (old feature, never tested) and a PDF signature (new feature).
I also changed the jsignpdf application to make use of this new feature. Will update a reference here once the jsignpdf PR is created.