### PR TITLE
Added check/error in PdfPTable.addCell

### DIFF
--- a/openpdf/src/main/java/com/lowagie/text/pdf/PdfPTable.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/PdfPTable.java
@@ -656,6 +656,9 @@ public class PdfPTable implements LargeElement {
      * @param table the table to be added to the cell
      */
     public PdfPCell addCell(PdfPTable table) {
+        if(table == this) {
+    		throw new DocumentException("unable.to.add.self.to.table.contents");
+    	}
         defaultCell.setTable(table);
         addCell(defaultCell);
         defaultCell.setTable(null);

--- a/openpdf/src/main/java/com/lowagie/text/pdf/PdfPTable.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/PdfPTable.java
@@ -654,11 +654,12 @@ public class PdfPTable implements LargeElement {
      * Adds a nested table.
      *
      * @param table the table to be added to the cell
+     * @throws DocumentException if table tries to add itself
      */
-    public PdfPCell addCell(PdfPTable table) {
-        if(table == this) {
-    		throw new DocumentException("unable.to.add.self.to.table.contents");
-    	}
+    public PdfPCell addCell(PdfPTable table) throws DocumentException {
+        if (table == this) {
+            throw new DocumentException("unable.to.add.self.to.table.contents");
+        }
         defaultCell.setTable(table);
         addCell(defaultCell);
         defaultCell.setTable(null);


### PR DESCRIPTION
## Description of the new Feature/Bugfix

I added a custom error message to PdfPTable.addCell(PdfPTable table) if the user called addCell with itself as the parameter.

Related Issue: Previously, the error would grow in the terminal, which made it a nightmare to troubleshoot. The error was also not descriptive, makin it even harder to troubleshoot. 

## Unit-Tests for the new Feature/Bugfix

## Compatibilities Issues

The PdfPTable.addCell method signature was changed - now it can throw a DocumentException, but no repository code should be impacted..

## Your real name
Steven Streasick

## Testing details
