### PR TITLE
Clarify the licensing policy

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -2,6 +2,11 @@
 
 ## Licenses of OpenPDF
 
+OpenPDF uses dual licensing: when using the library, you may choose either Mozilla Public License Version 2.0
+or GNU Lesser General Public License 2.1.
+
+The SPDX license identifier for OpenPDF licensing is `MPL-2.0 OR LGPL-2.1+`
+
 ### Mozilla Public License Version 2.0
 
 Please see https://www.mozilla.org/en-US/MPL/2.0/ or the attached file

--- a/README.md
+++ b/README.md
@@ -59,6 +59,11 @@ Add this to your pom.xml file to use the latest version of OpenPDF:
 
 ## License
 
+OpenPDF uses dual licensing: when using the library, you may choose either Mozilla Public License Version 2.0
+or GNU Lesser General Public License 2.1.
+
+The SPDX license identifier for OpenPDF licensing is `MPL-2.0 OR LGPL-2.1+`
+
 [GNU Lesser General Public License (LGPL), Version 2.1](https://www.gnu.org/licenses/old-licenses/lgpl-2.1)
 
 > For a short explanation see https://en.wikipedia.org/wiki/GNU_Lesser_General_Public_License

--- a/openpdf-fonts-extra/src/main/resources/META-INF/LICENSES.md
+++ b/openpdf-fonts-extra/src/main/resources/META-INF/LICENSES.md
@@ -2,6 +2,11 @@
 
 ## Licenses of OpenPDF
 
+OpenPDF uses dual licensing: when using the library, you may choose either Mozilla Public License Version 2.0
+or GNU Lesser General Public License 2.1.
+
+The SPDX license identifier for OpenPDF licensing is `MPL-2.0 OR LGPL-2.1+`
+
 ### Mozilla Public License Version 2.0
 
 Please see https://www.mozilla.org/en-US/MPL/2.0/ or the attached file

--- a/openpdf/src/main/resources/META-INF/LICENSES.md
+++ b/openpdf/src/main/resources/META-INF/LICENSES.md
@@ -2,6 +2,11 @@
 
 ## Licenses of OpenPDF
 
+OpenPDF uses dual licensing: when using the library, you may choose either Mozilla Public License Version 2.0
+or GNU Lesser General Public License 2.1.
+
+The SPDX license identifier for OpenPDF licensing is `MPL-2.0 OR LGPL-2.1+`
+
 ### Mozilla Public License Version 2.0
 
 Please see https://www.mozilla.org/en-US/MPL/2.0/ or the attached file

--- a/pdf-swing/src/main/resources/META-INF/LICENSES.md
+++ b/pdf-swing/src/main/resources/META-INF/LICENSES.md
@@ -2,6 +2,11 @@
 
 ## Licenses of OpenPDF
 
+OpenPDF uses dual licensing: when using the library, you may choose either Mozilla Public License Version 2.0
+or GNU Lesser General Public License 2.1.
+
+The SPDX license identifier for OpenPDF licensing is `MPL-2.0 OR LGPL-2.1+`
+
 ### Mozilla Public License Version 2.0
 
 Please see https://www.mozilla.org/en-US/MPL/2.0/ or the attached file

--- a/pdf-toolbox/src/main/resources/META-INF/LICENSES.md
+++ b/pdf-toolbox/src/main/resources/META-INF/LICENSES.md
@@ -2,6 +2,11 @@
 
 ## Licenses of OpenPDF
 
+OpenPDF uses dual licensing: when using the library, you may choose either Mozilla Public License Version 2.0
+or GNU Lesser General Public License 2.1.
+
+The SPDX license identifier for OpenPDF licensing is `MPL-2.0 OR LGPL-2.1+`
+
 ### Mozilla Public License Version 2.0
 
 Please see https://www.mozilla.org/en-US/MPL/2.0/ or the attached file


### PR DESCRIPTION
Today I've been asked by an acquaintance of mine to help with figuring out the licensing policy for OpenPDF. Their words were exact "hey, please help me to figure out what to do with a library that uses _two contradictory licenses at once_" — which is, of course, not correct w.r.t. OpenPDF, but this was the user's impression. I made sure to let them know of the real situation, after reading the license headers in the files, but for now I propose to state the requirements more clearly in the documentation, so nobody else is forced to deduce this from the sources again.

So, this PR clarifies the licensing. The fact that OpenPDF uses dual licensing, in particular `OR` in terms of SPDX, isn't well and formally documented by either the README file or the LICENSE files (or at least I was unable to find, if it is documented somewhere then please let me know), so I propose to update the wording in the documentation to include this information.

The particular wording I used in this PR I deduced from the license headers in the library source files.

Also, for now I decided that better (legally) safe that sorry, so I copy-pasted the same statement in every README or LICENSE file I was able to find; in my opinion, it makes sense.

Please note that, while I have some experience in open-source licensing, I am not a lawyer, and this PR is just a friendly suggestion/proposal, hopefully helping people to figure out the licensing policy better, and not is a legal requirement or something.

## Your real name
Please specify your full name here, so that we can verify your identity. 
If you have a conflict of interest describe this here also.

_Friedrich von Never_

## Testing details

Hopefully no :)