### PR TITLE
Update LayoutProcessor.java/ See #1159

### DIFF
--- a/openpdf/src/main/java/com/lowagie/text/pdf/LayoutProcessor.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/LayoutProcessor.java
@@ -270,6 +270,8 @@ public class LayoutProcessor {
 
     /**
      * Loads the AWT font needed for layout
+     * <p>
+     * If baseFont is not instanceof TrueTypeFontUnicode *no* font is loaded.
      *
      * @param baseFont OpenPdf base font
      * @param filename of the font file
@@ -279,7 +281,9 @@ public class LayoutProcessor {
         if (!enabled || awtFontMap.get(baseFont) != null) {
             return;
         }
-
+        if (!(baseFont instanceof TrueTypeFontUnicode)) {
+            return;
+        }
         java.awt.Font awtFont;
         InputStream inputStream = null;
         try {


### PR DESCRIPTION
Load only TrueTypeFontUnicode fonts
See #1159

## Description of the new Feature/Bugfix
Only TrueTypeFontUnicode are loaded in LayoutProcessor, other fonts are ignored 

Related Issue: #1159 

## Unit-Tests for the new Feature/Bugfix
-

## Compatibilities Issues

Is anything broken because of the new code? Any changes in method signatures?
-

## Your real name
Volker Kunert
## Testing details
See #1159

Any other details about how to test the new feature or bugfix?
