### PR TITLE
Allow extra FF bytes preceding JPEG markers

### DIFF
--- a/openpdf/src/main/java/com/lowagie/text/Jpeg.java
+++ b/openpdf/src/main/java/com/lowagie/text/Jpeg.java
@@ -241,7 +241,10 @@ public class Jpeg extends Image {
                     throw new IOException(MessageLocalization.getComposedMessage("premature.eof.while.reading.jpg"));
                 }
                 if (v == 0xFF) {
-                    int marker = is.read();
+                    int marker;
+                    do {
+                        marker = is.read();
+                    } while (marker == 0xFF); // Skip extra FF bytes, per JPEG spec B.1.1.2
                     if (firstPass && marker == M_APP0) {
                         firstPass = false;
                         len = getShort(is);


### PR DESCRIPTION
We recently encountered a JPEG with extra FF bytes preceding an APPE marker. Most programs ignore those bytes, but they were causing OpenPDF to fail to parse the file.

From [the JPEG specification](https://www.w3.org/Graphics/JPEG/itu-t81.pdf), B.1.1.2: "Any marker may optionally be preceded by any number of fill bytes, which are bytes assigned code X'FF'."