### PR TITLE
Bugfix/issue 1274 - HTML export - When image and text divs are rendered one …

### DIFF
--- a/openpdf/src/main/java/com/lowagie/text/html/HtmlWriter.java
+++ b/openpdf/src/main/java/com/lowagie/text/html/HtmlWriter.java
@@ -667,6 +667,7 @@ public class HtmlWriter extends DocWriter {
             case Element.PHRASE: {
                 Phrase phrase = (Phrase) element;
                 styleAttributes = new Properties();
+                styleAttributes.setProperty(Markup.CSS_KEY_DISPLAY, Markup.CSS_VALUE_GRID);
                 if (phrase.hasLeading()) {
                     styleAttributes.setProperty(Markup.CSS_KEY_LINEHEIGHT, phrase.getLeading() + "pt");
                 }
@@ -691,6 +692,7 @@ public class HtmlWriter extends DocWriter {
             case Element.ANCHOR: {
                 Anchor anchor = (Anchor) element;
                 styleAttributes = new Properties();
+                styleAttributes.setProperty(Markup.CSS_KEY_DISPLAY, Markup.CSS_VALUE_GRID);
                 if (anchor.hasLeading()) {
                     styleAttributes.setProperty(Markup.CSS_KEY_LINEHEIGHT, anchor.getLeading() + "pt");
                 }
@@ -721,9 +723,11 @@ public class HtmlWriter extends DocWriter {
             case Element.PARAGRAPH: {
                 Paragraph paragraph = (Paragraph) element;
                 styleAttributes = new Properties();
+                styleAttributes.setProperty(Markup.CSS_KEY_DISPLAY, Markup.CSS_VALUE_GRID);
                 if (paragraph.hasLeading()) {
                     styleAttributes.setProperty(Markup.CSS_KEY_LINEHEIGHT, paragraph.getTotalLeading() + "pt");
                 }
+
                 // start tag
                 addTabs(indent);
                 writeStart(HtmlTags.DIV);
@@ -990,6 +994,7 @@ public class HtmlWriter extends DocWriter {
                 depth = 5;
             }
             Properties styleAttributes = new Properties();
+            styleAttributes.setProperty(Markup.CSS_KEY_DISPLAY, Markup.CSS_VALUE_GRID);
             if (section.getTitle().hasLeading()) {
                 styleAttributes.setProperty(Markup.CSS_KEY_LINEHEIGHT, section.getTitle().getTotalLeading() + "pt");
             }

--- a/openpdf/src/main/java/com/lowagie/text/html/Markup.java
+++ b/openpdf/src/main/java/com/lowagie/text/html/Markup.java
@@ -321,6 +321,11 @@ public class Markup {
     public static final String CSS_VALUE_BLOCK = "block";
 
     /**
+     * A possible value for the DISPLAY key
+     */
+    public static final String CSS_VALUE_GRID = "grid";
+
+    /**
      * a CSS value for text font weight
      */
     public static final String CSS_VALUE_BOLD = "bold";


### PR DESCRIPTION
…after the other, they are placed NEXT TO each other, instead of one AFTER the other - Fixed.

## Description of the new Feature/Bugfix

I've added "display: grid" to the rendered divs so that they will be shown correctly.

Related Issue: #1274

## Unit-Tests for the new Feature/Bugfix

Cannot write unit-test as this issue is visual

- [ ] Unit-Tests added to reproduce the bug
- [ ] Unit-Tests added to the added feature

## Compatibilities Issues

Is anything broken because of the new code? Any changes in method signatures? No.

## Your real name
Maayan Bin Nun

## Testing details

Testing code available in the bug description. 
I've tested it also in my lab with loads of data and verified that the HTML exports look good with the grid display setting.
