### PR TITLE
Handle the case when resources was null

### DIFF
--- a/openpdf/src/main/java/com/lowagie/text/pdf/parser/PdfContentStreamHandler.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/parser/PdfContentStreamHandler.java
@@ -966,6 +966,10 @@ public class PdfContentStreamHandler {
                 PdfName subType = stream.getAsName(PdfName.SUBTYPE);
                 if (PdfName.FORM.equals(subType)) {
                     PdfDictionary resources2 = stream.getAsDict(PdfName.RESOURCES);
+                    if (resources2 == null)  {
+                        resources2 = resources;
+                    }
+
                     byte[] data;
                     try {
                         data = getContentBytesFromPdfObject(stream);


### PR DESCRIPTION
Hello,

This is a follow-up on #1210: I seem to have some pdf files where `resources2` is null and this triggers an NPE.
I'm honestly not sure if the fix makes sense (or what even is supposed to be `resources2`) but the changes fixes the NPE.
If this PR can be considered it would be great if it could also be backported to the 1.3 branch which I'm currently using.

In any case, thank you for maintaining OpenPDF! 