### PR TITLE
#971: PDF/A1A & PDF/A1B invalid due to title => xmp.metadata missing language attribute at <dc:title><rdf:Alt><rdf:li>Title...

### DIFF
--- a/openpdf/src/main/java/com/lowagie/text/xml/xmp/DublinCoreSchema.java
+++ b/openpdf/src/main/java/com/lowagie/text/xml/xmp/DublinCoreSchema.java
@@ -136,25 +136,45 @@ public class DublinCoreSchema extends XmpSchema {
     }
 
     /**
-     * Adds a title.
+     * Adds a title for {@link LangAlt#DEFAULT default language}.
      *
      * @param title title
      */
     public void addTitle(String title) {
-        XmpArray array = new XmpArray(XmpArray.ALTERNATIVE);
-        array.add(title);
-        setProperty(TITLE, array);
+        addTitle(LangAlt.DEFAULT, title);
     }
 
     /**
-     * Adds a description.
+     * Adds a title for specified language.
+     *
+     * @param language language
+     * @param title title
+     */
+    public void addTitle(String language, String title) {
+        LangAlt langAlt = new LangAlt();
+        langAlt.addLanguage(language, title);
+        setProperty(TITLE, langAlt);
+    }
+
+    /**
+     * Adds a description for {@link LangAlt#DEFAULT default language}.
      *
      * @param desc description
      */
     public void addDescription(String desc) {
-        XmpArray array = new XmpArray(XmpArray.ALTERNATIVE);
-        array.add(desc);
-        setProperty(DESCRIPTION, array);
+        addDescription(LangAlt.DEFAULT, desc);
+    }
+
+    /**
+     * Adds a description for specified language.
+     *
+     * @param language language
+     * @param desc description
+     */
+    public void addDescription(String language, String desc) {
+        LangAlt langAlt = new LangAlt();
+        langAlt.addLanguage(language, desc);
+        setProperty(DESCRIPTION, langAlt);
     }
 
     /**

--- a/openpdf/src/main/java/com/lowagie/text/xml/xmp/PdfSchema.java
+++ b/openpdf/src/main/java/com/lowagie/text/xml/xmp/PdfSchema.java
@@ -67,7 +67,7 @@ public class PdfSchema extends XmpSchema {
     /**
      * Keywords.
      */
-    public static final String KEYWORDS = "pdf:keywords";
+    public static final String KEYWORDS = "pdf:Keywords";
     /**
      * The PDF file version (for example: 1.0, 1.3, and so on).
      */

--- a/openpdf/src/test/java/com/lowagie/text/validation/PDFValidationTest.java
+++ b/openpdf/src/test/java/com/lowagie/text/validation/PDFValidationTest.java
@@ -30,27 +30,24 @@ public class PDFValidationTest {
     public void testValidatePDFWithVera_Title() throws Exception {
         PdfDictionary info = new PdfDictionary(PdfName.METADATA);
         info.put(PdfName.TITLE, new PdfString("Test pdf"));
-
-        testValidatePDFWithVera(info);
+        Assertions.assertTrue(testValidatePDFWithVera(info));
     }
 
     @Test
     public void testValidatePDFWithVera_Subject() throws Exception {
         PdfDictionary info = new PdfDictionary(PdfName.METADATA);
         info.put(PdfName.SUBJECT, new PdfString("Test subject"));
-
-        testValidatePDFWithVera(info);
+        Assertions.assertTrue(testValidatePDFWithVera(info));
     }
 
     @Test
     public void testValidatePDFWithVera_Keywords() throws Exception {
         PdfDictionary info = new PdfDictionary(PdfName.METADATA);
         info.put(PdfName.KEYWORDS, new PdfString("k1, k2"));
-
-        testValidatePDFWithVera(info);
+        Assertions.assertTrue(testValidatePDFWithVera(info));
     }
 
-    private void testValidatePDFWithVera(PdfDictionary info) throws Exception {
+    private boolean testValidatePDFWithVera(PdfDictionary info) throws Exception {
         Document document = new Document(PageSize.A4);
         ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
         PdfWriter pdfWriter = PdfWriter.getInstance(document, byteArrayOutputStream);
@@ -85,10 +82,11 @@ public class PDFValidationTest {
                     }
 
                 }
-                Assertions.assertTrue(result.isCompliant());
+                return result.isCompliant();
             }
         } catch (ModelParsingException e) {
-            Assertions.fail(e);
+            e.printStackTrace();
+            return false;
         }
     }
 

--- a/openpdf/src/test/java/com/lowagie/text/validation/PDFValidationTest.java
+++ b/openpdf/src/test/java/com/lowagie/text/validation/PDFValidationTest.java
@@ -4,6 +4,9 @@ import com.lowagie.text.Annotation;
 import com.lowagie.text.Document;
 import com.lowagie.text.PageSize;
 import com.lowagie.text.Rectangle;
+import com.lowagie.text.pdf.PdfDictionary;
+import com.lowagie.text.pdf.PdfName;
+import com.lowagie.text.pdf.PdfString;
 import com.lowagie.text.pdf.PdfWriter;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -24,11 +27,35 @@ import org.verapdf.pdfa.validation.validators.ValidatorFactory;
 public class PDFValidationTest {
 
     @Test
-    public void testValidatePDFWithVera() throws Exception {
+    public void testValidatePDFWithVera_Title() throws Exception {
+        PdfDictionary info = new PdfDictionary(PdfName.METADATA);
+        info.put(PdfName.TITLE, new PdfString("Test pdf"));
+
+        testValidatePDFWithVera(info);
+    }
+
+    @Test
+    public void testValidatePDFWithVera_Subject() throws Exception {
+        PdfDictionary info = new PdfDictionary(PdfName.METADATA);
+        info.put(PdfName.SUBJECT, new PdfString("Test subject"));
+
+        testValidatePDFWithVera(info);
+    }
+
+    @Test
+    public void testValidatePDFWithVera_Keywords() throws Exception {
+        PdfDictionary info = new PdfDictionary(PdfName.METADATA);
+        info.put(PdfName.KEYWORDS, new PdfString("k1, k2"));
+
+        testValidatePDFWithVera(info);
+    }
+
+    private void testValidatePDFWithVera(PdfDictionary info) throws Exception {
         Document document = new Document(PageSize.A4);
         ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
         PdfWriter pdfWriter = PdfWriter.getInstance(document, byteArrayOutputStream);
         pdfWriter.setPDFXConformance(PdfWriter.PDFA1B);
+        pdfWriter.getInfo().putAll(info);
         pdfWriter.createXmpMetadata();
 
         try {
@@ -61,7 +88,7 @@ public class PDFValidationTest {
                 Assertions.assertTrue(result.isCompliant());
             }
         } catch (ModelParsingException e) {
-            e.printStackTrace();
+            Assertions.fail(e);
         }
     }
 

--- a/openpdf/src/test/java/com/lowagie/text/validation/PDFValidationTest.java
+++ b/openpdf/src/test/java/com/lowagie/text/validation/PDFValidationTest.java
@@ -27,21 +27,21 @@ import org.verapdf.pdfa.validation.validators.ValidatorFactory;
 public class PDFValidationTest {
 
     @Test
-    public void testValidatePDFWithVera_Title() throws Exception {
+    public void testValidateDcTitleWithVera() throws Exception {
         PdfDictionary info = new PdfDictionary(PdfName.METADATA);
         info.put(PdfName.TITLE, new PdfString("Test pdf"));
         Assertions.assertTrue(testValidatePDFWithVera(info));
     }
 
     @Test
-    public void testValidatePDFWithVera_Subject() throws Exception {
+    public void testValidateDcSubjectWithVera() throws Exception {
         PdfDictionary info = new PdfDictionary(PdfName.METADATA);
         info.put(PdfName.SUBJECT, new PdfString("Test subject"));
         Assertions.assertTrue(testValidatePDFWithVera(info));
     }
 
     @Test
-    public void testValidatePDFWithVera_Keywords() throws Exception {
+    public void testValidatePdfKeywordsWithVera() throws Exception {
         PdfDictionary info = new PdfDictionary(PdfName.METADATA);
         info.put(PdfName.KEYWORDS, new PdfString("k1, k2"));
         Assertions.assertTrue(testValidatePDFWithVera(info));


### PR DESCRIPTION
## Description of the new Feature/Bugfix

To fix the bug, I improved multilingual support by refining the handling of language-alternative (`LangAlt`) title and description in the Dublin Core Schema using the standard-conforming syntax with the required (at least for PDF/A-1) `xml:lang` attribute. Further I fixed a typo in the `pdf:Keywords` tag in the PDF Schema.

Related Issue: #971

## Unit-Tests for the new Feature/Bugfix

- [x] Unit-Tests added to reproduce the bug
- [x] Unit-Tests added to the added feature

## Compatibilities Issues

All existing methods behave as before. I only added two addtional methods for multilingual titles and descriptions. Even when using the existing API the output will slightly differ, because `xml:lang` is now always added to `dc:title` and `dc:description`.

## Your real name

Mikhail Stupnikov

## Testing details

I expanded `com.lowagie.text.validation.PDFValidationTest` to test the metadata fields in question.