### PR TITLE
Fix setting margin on open document

### DIFF
--- a/openpdf/src/main/java/com/lowagie/text/pdf/PdfDocument.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/PdfDocument.java
@@ -871,6 +871,7 @@ public class PdfDocument extends Document {
         lastElementType = -1;
         if (isPageEmpty()) {
             setNewPageSizeAndMargins();
+            resetText(true);
             return false;
         }
         if (!open || close) {
@@ -1124,6 +1125,16 @@ public class PdfDocument extends Document {
 
 //    [C4] Page labels
 
+    private void resetText(boolean move) {
+        text = new PdfContentByte(writer);
+        text.reset();
+        text.beginText();
+        textEmptySize = text.size();
+        if (move) {
+            text.moveText(left(), top());
+        }
+    }
+
     /**
      * Initializes a page.
      * <p>
@@ -1141,10 +1152,7 @@ public class PdfDocument extends Document {
 
         writer.resetContent();
         graphics = new PdfContentByte(writer);
-        text = new PdfContentByte(writer);
-        text.reset();
-        text.beginText();
-        textEmptySize = text.size();
+        resetText(false);
 
         markPoint = 0;
         setNewPageSizeAndMargins();


### PR DESCRIPTION
## Description of the new Feature/Bugfix

Fixes #1282

## Your real name
Mikhail Mironov

## Testing details

After call setNewPageSizeAndMargins we must reset text and move to correct position. For this created new private method
