### PR TITLE
Set original type to images within ImageLoader for OpenRTF support

### DIFF
--- a/openpdf/src/main/java/com/lowagie/text/ImageLoader.java
+++ b/openpdf/src/main/java/com/lowagie/text/ImageLoader.java
@@ -47,6 +47,7 @@ package com.lowagie.text;
 
 import java.awt.image.BufferedImage;
 import java.io.ByteArrayInputStream;
+import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
 import javax.imageio.ImageIO;
@@ -73,7 +74,7 @@ public class ImageLoader {
     public static Image getPngImage(URL url) {
         try (InputStream is = url.openStream()) {
             BufferedImage bufferedImage = ImageIO.read(is);
-            return Image.getInstance(bufferedImage, null, false);
+            return getImage(bufferedImage, Image.ORIGINAL_PNG);
         } catch (Exception e) {
             throw new ExceptionConverter(e);
         }
@@ -82,7 +83,7 @@ public class ImageLoader {
     public static Image getGifImage(URL url) {
         try (InputStream is = url.openStream()) {
             BufferedImage bufferedImage = ImageIO.read(is);
-            return Image.getInstance(bufferedImage, null, false);
+            return getImage(bufferedImage, Image.ORIGINAL_GIF);
         } catch (Exception e) {
             throw new ExceptionConverter(e);
         }
@@ -91,7 +92,7 @@ public class ImageLoader {
     public static Image getTiffImage(URL url) {
         try (InputStream is = url.openStream()) {
             BufferedImage bufferedImage = ImageIO.read(is);
-            return Image.getInstance(bufferedImage, null, false);
+            return getImage(bufferedImage, Image.ORIGINAL_TIFF);
         } catch (Exception e) {
             throw new ExceptionConverter(e);
         }
@@ -101,7 +102,7 @@ public class ImageLoader {
     public static Image getBmpImage(URL url) {
         try (InputStream is = url.openStream()) {
             BufferedImage bufferedImage = ImageIO.read(is);
-            return Image.getInstance(bufferedImage, null, false);
+            return getImage(bufferedImage, Image.ORIGINAL_BMP);
         } catch (Exception e) {
             throw new ExceptionConverter(e);
         }
@@ -134,7 +135,7 @@ public class ImageLoader {
     public static Image getGifImage(byte[] imageData) {
         try (InputStream is = new ByteArrayInputStream(imageData)) {
             BufferedImage bufferedImage = ImageIO.read(is);
-            return Image.getInstance(bufferedImage, null, false);
+            return getImage(bufferedImage, Image.ORIGINAL_GIF);
         } catch (Exception e) {
             throw new ExceptionConverter(e);
         }
@@ -143,8 +144,7 @@ public class ImageLoader {
     public static Image getPngImage(byte[] imageData) {
         try (InputStream is = new ByteArrayInputStream(imageData)) {
             BufferedImage bufferedImage = ImageIO.read(is);
-            return Image.getInstance(bufferedImage, null, false);
-
+            return getImage(bufferedImage, Image.ORIGINAL_PNG);
         } catch (Exception e) {
             throw new ExceptionConverter(e);
         }
@@ -153,8 +153,7 @@ public class ImageLoader {
     public static Image getBmpImage(byte[] imageData) {
         try (InputStream is = new ByteArrayInputStream(imageData)) {
             BufferedImage bufferedImage = ImageIO.read(is);
-            return Image.getInstance(bufferedImage, null, false);
-
+            return getImage(bufferedImage, Image.ORIGINAL_BMP);
         } catch (Exception e) {
             throw new ExceptionConverter(e);
         }
@@ -169,8 +168,7 @@ public class ImageLoader {
     public static Image getTiffImage(byte[] imageData) {
         try (InputStream is = new ByteArrayInputStream(imageData)) {
             BufferedImage bufferedImage = ImageIO.read(is);
-            return Image.getInstance(bufferedImage, null, false);
-
+            return getImage(bufferedImage, Image.ORIGINAL_TIFF);
         } catch (Exception e) {
             throw new ExceptionConverter(e);
         }
@@ -200,4 +198,9 @@ public class ImageLoader {
         }
     }
 
+    private static Image getImage(BufferedImage bufferedImage, int originalType) throws IOException {
+        Image image = Image.getInstance(bufferedImage, null, false);
+        image.setOriginalType(originalType);
+        return image;
+    }
 }


### PR DESCRIPTION
## Description of the new Feature/Bugfix

This fix has been made to solve an issue with OpenRTF expecting an original type to be set for an Image to use it for a cell / document.

Related Issue: see https://github.com/LibrePDF/OpenRTF/issues/15

## Your real name
Olivier Delierre

## Testing details

You would need to clone OpenRTF and use OpenPDF with this patch as a dependency, then, to generate a RTF file with anything but a JPG file.
