### PR TITLE
Remove hamcrest dependency

### DIFF
--- a/openpdf/pom.xml
+++ b/openpdf/pom.xml
@@ -61,11 +61,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.hamcrest</groupId>
-      <artifactId>hamcrest</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
       <scope>test</scope>

--- a/openpdf/src/test/java/com/lowagie/text/factories/RomanNumberFactoryTest.java
+++ b/openpdf/src/test/java/com/lowagie/text/factories/RomanNumberFactoryTest.java
@@ -1,8 +1,6 @@
 package com.lowagie.text.factories;
 
 import static com.lowagie.text.factories.RomanNumberFactory.getString;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -63,7 +61,7 @@ class RomanNumberFactoryTest {
     @MethodSource("numeralTestProvider")
     void shouldConvertRomanNumeralRepresentation(int input, String expected) {
         assertAll(
-                () -> assertThat(getString(input), is(expected)),
-                () -> assertThat(getString(input, false), is(expected.toUpperCase())));
+                () -> assertEquals(expected, getString(input)),
+                () -> assertEquals(expected.toUpperCase(), getString(input, false)));
     }
 }

--- a/openpdf/src/test/java/com/lowagie/text/pdf/PdfDocumentTest.java
+++ b/openpdf/src/test/java/com/lowagie/text/pdf/PdfDocumentTest.java
@@ -1,7 +1,6 @@
 package com.lowagie.text.pdf;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.lowagie.text.Element;
 import com.lowagie.text.Paragraph;
@@ -34,21 +33,23 @@ class PdfDocumentTest {
 
         PdfPTable result = PdfDocument.createInOneCell(mainParagraph);
         return Arrays.asList(
-                DynamicTest.dynamicTest("row size should be 1", () -> assertThat(result.getRows().size(), equalTo(1))),
+                DynamicTest.dynamicTest("row size should be 1",
+                        () -> assertEquals(1, result.getRows().size())),
                 DynamicTest.dynamicTest("cell size should be 1", () -> {
                     final PdfPCell[] cells = result.getRows().get(0).getCells();
-                    assertThat(cells.length, equalTo(1));
+                    assertEquals(1, cells.length);
                 }),
                 DynamicTest.dynamicTest("elements in cell should be 5",
-                        () -> assertThat(getCellElements(result).size(), equalTo(5))),
+                        () -> assertEquals(5, getCellElements(result).size())),
                 DynamicTest.dynamicTest("element text should be '" + PARAGRAPH_TEXT_1 + "'",
-                        () -> assertThat(getCellElements(result).get(0).getChunks().toString(),
-                                equalTo(paragraph1.toString()))),
+                        () -> assertEquals(paragraph1.toString(),
+                                getCellElements(result).get(0).getChunks().toString())),
                 DynamicTest.dynamicTest("element should be table",
-                        () -> assertThat(getCellElements(result).get(2), equalTo(table))),
+                        () -> assertEquals(table, getCellElements(result).get(2))),
                 DynamicTest.dynamicTest("element text should be '" + PARAGRAPH_TEXT_2 + "'",
-                        () -> assertThat(getCellElements(result).get(3).getChunks().toString(),
-                                equalTo(paragraph2.toString()))));
+                        () -> assertEquals(paragraph2.toString(),
+                                getCellElements(result).get(3).getChunks().toString()
+                                )));
     }
 
     private List<Element> getCellElements(PdfPTable result) {

--- a/openpdf/src/test/java/com/lowagie/text/pdf/parser/PdfTextExtractorTest.java
+++ b/openpdf/src/test/java/com/lowagie/text/pdf/parser/PdfTextExtractorTest.java
@@ -1,11 +1,7 @@
 package com.lowagie.text.pdf.parser;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.Matchers.emptyString;
-import static org.hamcrest.Matchers.equalToCompressingWhiteSpace;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.not;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -26,7 +22,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
 import java.nio.file.Files;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 
@@ -68,12 +63,12 @@ class PdfTextExtractorTest {
 
     @Test
     void testPageExceeded() throws Exception {
-        assertThat(getString("HelloWorldMeta.pdf", 5), is(emptyString()));
+        assertEquals("", getString("HelloWorldMeta.pdf", 5));
     }
 
     @Test
     void testInvalidPageNumber() throws Exception {
-        assertThat(getString("HelloWorldMeta.pdf", 0), is(emptyString()));
+        assertEquals("", getString("HelloWorldMeta.pdf", 0));
     }
 
     @Test
@@ -88,7 +83,7 @@ class PdfTextExtractorTest {
         document.add(new Chunk("Greek", new Font(Font.ZAPFDINGBATS)));
         document.close();
         PdfTextExtractor pdfTextExtractor = new PdfTextExtractor(new PdfReader(byteArrayOutputStream.toByteArray()));
-        Assertions.assertEquals("✧❒❅❅❋", pdfTextExtractor.getTextFromPage(1));
+        assertEquals("✧❒❅❅❋", pdfTextExtractor.getTextFromPage(1));
         Document.compress = true;
     }
 
@@ -105,7 +100,7 @@ class PdfTextExtractorTest {
         document.add(selector.process("ετε"));
         document.close();
         PdfTextExtractor pdfTextExtractor = new PdfTextExtractor(new PdfReader(byteArrayOutputStream.toByteArray()));
-        Assertions.assertEquals("ετε", pdfTextExtractor.getTextFromPage(1));
+        assertEquals("ετε", pdfTextExtractor.getTextFromPage(1));
         Document.compress = true;
     }
 
@@ -129,7 +124,7 @@ class PdfTextExtractorTest {
         // when
         final String extracted = new PdfTextExtractor(new PdfReader(pdfBytes)).getTextFromPage(1);
         // then
-        assertThat(extracted, is("trunked"));
+        assertEquals("trunked", extracted);
     }
 
     @Test
@@ -142,7 +137,7 @@ class PdfTextExtractorTest {
         // when
         final String extracted = new PdfTextExtractor(new PdfReader(pdfBytes)).getTextFromPage(1);
         // then
-        assertThat(extracted, is("Phrase begin. Phrase End."));
+        assertEquals("Phrase begin. Phrase End.", extracted);
     }
 
     @Test
@@ -159,8 +154,9 @@ class PdfTextExtractorTest {
         // when
         final String extracted = new PdfTextExtractor(new PdfReader(pdfBytes)).getTextFromPage(1);
         // then
-        assertThat(extracted, equalToCompressingWhiteSpace(expected));
-        assertThat(extracted, not(containsString("  ")));
+        assertFalse(extracted.contains("  "));
+        // ignore all white spaces
+        assertEquals(expected.replaceAll("\\s+", ""), extracted.replaceAll("\\s+", ""));
     }
 
     @Test
@@ -175,7 +171,7 @@ class PdfTextExtractorTest {
         // when
         final String extracted = new PdfTextExtractor(new PdfReader(pdfBytes)).getTextFromPage(1);
         // then
-        assertThat(extracted, is("One Two Three"));
+        assertEquals("One Two Three", extracted);
     }
 
     private String getString(String fileName, int pageNumber) throws Exception {

--- a/pom.xml
+++ b/pom.xml
@@ -97,7 +97,6 @@
     <!-- test-dependencies -->
     <assertj.version>3.27.3</assertj.version>
     <checkstyle.version>10.23.1</checkstyle.version>
-    <hamcrest.version>3.0</hamcrest.version>
     <jacoco-maven-plugin.version>0.8.13</jacoco-maven-plugin.version>
     <junit.version>5.12.2</junit.version>
     <mockito4.version>4.11.0</mockito4.version>
@@ -168,12 +167,6 @@
         <groupId>org.junit.jupiter</groupId>
         <artifactId>junit-jupiter-params</artifactId>
         <version>${junit.version}</version>
-        <scope>test</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.hamcrest</groupId>
-        <artifactId>hamcrest</artifactId>
-        <version>${hamcrest.version}</version>
         <scope>test</scope>
       </dependency>
     </dependencies>


### PR DESCRIPTION
## Description of the new Feature/Bugfix

This may be a controversial one, since I know that some people love hamcrest's matchers. However, in this project there's so little of Hamcrest that I see no point of having another dependency.

With JUnit 5 and modern Java, everything is very easily achievable without Hamcrest. There are **only three test classes** that depend on this library. I removed those dependencies without losing any readability (in my opinion of course).

Is this was a topic of discussion and my idea has already been rejected, I apologize for that. I can't find anything related to "Hamcrest" in the search.

## Unit-Tests for the new Feature/Bugfix

Test are updated and all of them are green.

## Compatibilities Issues

Can't find any. This depencency is only for testing. hamcrest in AssertJ is optional. All tests passes.

## Your real name
Hello, my name is Emil Sierżęga. This is also included in my github account, and I hope it's public :-)