### PR TITLE
Mockito cleanup and upgrade

### DIFF
--- a/openpdf/pom.xml
+++ b/openpdf/pom.xml
@@ -57,7 +57,6 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
-      <version>5.10.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -99,7 +99,7 @@
     <checkstyle.version>10.23.1</checkstyle.version>
     <jacoco-maven-plugin.version>0.8.13</jacoco-maven-plugin.version>
     <junit.version>5.12.2</junit.version>
-    <mockito5.version>5.9.0</mockito5.version>
+    <mockito5.version>5.10.0</mockito5.version>
   </properties>
 
   <dependencyManagement>
@@ -166,6 +166,12 @@
         <groupId>org.junit.jupiter</groupId>
         <artifactId>junit-jupiter-params</artifactId>
         <version>${junit.version}</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.mockito</groupId>
+        <artifactId>mockito-core</artifactId>
+        <version>${mockito5.version}</version>
         <scope>test</scope>
       </dependency>
     </dependencies>
@@ -389,15 +395,6 @@
       <activation>
         <jdk>[17,)</jdk>
       </activation>
-      <dependencyManagement>
-        <dependencies>
-          <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-core</artifactId>
-            <version>${mockito5.version}</version>
-          </dependency>
-        </dependencies>
-      </dependencyManagement>
       <build>
         <plugins>
           <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -99,7 +99,7 @@
     <checkstyle.version>10.23.1</checkstyle.version>
     <jacoco-maven-plugin.version>0.8.13</jacoco-maven-plugin.version>
     <junit.version>5.12.2</junit.version>
-    <mockito5.version>5.10.0</mockito5.version>
+    <mockito5.version>5.17.0</mockito5.version>
   </properties>
 
   <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -99,7 +99,6 @@
     <checkstyle.version>10.23.1</checkstyle.version>
     <jacoco-maven-plugin.version>0.8.13</jacoco-maven-plugin.version>
     <junit.version>5.12.2</junit.version>
-    <mockito4.version>4.11.0</mockito4.version>
     <mockito5.version>5.9.0</mockito5.version>
   </properties>
 


### PR DESCRIPTION
## Description of the new Feature/Bugfix

I've clean up mockito setup in pom. Changes:
* Remove unused mockito4.version from main POM (looks like this is some kind of leftover)
* Use one version of Mockito (main project had 5.9, OpenPDF had 5.10, this override was needed because mockito 5 was used in profile. This has no greater sense since in main pom dependencies are in `dependencyManagement` not like direct usage)
* Upgrade Mockito (5.10.0 -> 5.17.0) (no changes needed)

## Unit-Tests for the new Feature/Bugfix
This depencency is only for testing. All tests passes.

## Your real name
Hello, my name is Emil Sierżęga.