### PR TITLE
Remove maven profile "jdk21-plus"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -394,40 +394,6 @@
 
   <profiles>
     <profile>
-      <id>jdk21-plus</id>
-      <activation>
-        <jdk>[21,)</jdk>
-      </activation>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-compiler-plugin</artifactId>
-            <version>${maven.compiler.plugin.version}</version>
-            <configuration>
-              <release>21</release>
-            </configuration>
-            <executions>
-              <execution>
-                <id>compile-java-21</id>
-                <goals>
-                  <goal>compile</goal>
-                </goals>
-                <configuration>
-                  <release>21</release>
-                  <compileSourceRoots>
-                    <compileSourceRoot>${project.basedir}/src/main/java</compileSourceRoot>
-                  </compileSourceRoots>
-                  <multiReleaseOutput>true</multiReleaseOutput>
-                </configuration>
-              </execution>
-            </executions>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-
-    <profile>
       <id>release</id>
       <build>
         <plugins>


### PR DESCRIPTION
## Description of the new Feature/Bugfix

I created this change with Java 17 and in the meantime required Java has been changed to 21 :-)

This profile has no purpose if final build has one required Java version. `maven-compiler-plugin` is set with `<release>${java.version}</release>`, and `java.version` is set to 21. So this is minimal version.

So adding another profile with `maven-compiler-plugin` with `multiReleaseOutput` set to true has one effect. It duplicates *identical* java compiled class in jar.

If anyone "unpack" .jar you can see that there is additional director in META-INF. But if you diff base classes dir (`com`) with `META-INF/versions/21/com` you can find that all classes are the same (there are differences in other types of files, `META-INF/versions/21` does not contain files like cmap, properties, afm etc.)

Those files are identical, e.g:

    $ diff <(hexdump com/lowagie/text/SimpleTable.class) <(hexdump META-INF/versions/17/com/lowagie/text/SimpleTable.class)

When we delete this profile we lost nothing, but we reduce jar size from 3,6 MB to 2,2 MB :-)

## Unit-Tests for the new Feature/Bugfix

Only final jar changes.

## Your real name
Hi my name is Emil Sierżęga
