### PR TITLE
Fix for reading very small PDF files

### DIFF
--- a/openpdf/src/main/java/com/lowagie/text/pdf/MappedRandomAccessFile.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/MappedRandomAccessFile.java
@@ -52,7 +52,6 @@ import com.lowagie.text.utils.LongMappedByteBuffer;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
-import java.nio.BufferUnderflowException;
 import java.nio.channels.FileChannel;
 
 /**
@@ -114,19 +113,23 @@ public class MappedRandomAccessFile implements AutoCloseable {
     }
 
     /**
-     * @return int next integer or -1 on EOF
+     * @return int next byte value or -1 on EOF
      * @see java.io.RandomAccessFile#read()
      */
     public int read() {
-        try {
-            byte b = mappedByteBuffer.get();
-            int n = b & 0xff;
+        long pos = mappedByteBuffer.position();
+        long limit = mappedByteBuffer.limit();
 
-            return n;
-        } catch (BufferUnderflowException e) {
+        if (pos >= limit) {
             return -1; // EOF
         }
+
+        byte b = mappedByteBuffer.get(pos);
+        mappedByteBuffer.position(pos + 1);
+        return b & 0xFF;
     }
+
+
 
     /**
      * @param bytes byte[]

--- a/openpdf/src/main/java/com/lowagie/text/utils/LongMappedByteBuffer.java
+++ b/openpdf/src/main/java/com/lowagie/text/utils/LongMappedByteBuffer.java
@@ -50,6 +50,7 @@
 package com.lowagie.text.utils;
 
 import java.io.IOException;
+import java.nio.BufferUnderflowException;
 import java.nio.ByteBuffer;
 import java.nio.MappedByteBuffer;
 import java.nio.channels.FileChannel;
@@ -91,14 +92,15 @@ public class LongMappedByteBuffer {
     }
 
     public byte get(long pos) {
+        if (pos >= size) {
+            throw new BufferUnderflowException(); // triggers EOF handling in MappedRandomAccessFile
+        }
         int chunkIndex = (int) (pos / CHUNK_SIZE);
         int offset = (int) (pos % CHUNK_SIZE);
         MappedByteBuffer chunk = chunks[chunkIndex];
-        if (offset >= chunk.limit()) {
-            throw new IndexOutOfBoundsException("Offset " + offset + " >= chunk limit " + chunk.limit());
-        }
         return chunk.get(offset);
     }
+
 
 
     public void get(long pos, byte[] dst, int off, int len) {

--- a/openpdf/src/test/java/com/lowagie/text/pdf/SmallPdfReadTest.java
+++ b/openpdf/src/test/java/com/lowagie/text/pdf/SmallPdfReadTest.java
@@ -1,0 +1,55 @@
+package com.lowagie.text.pdf;
+
+import com.lowagie.text.Document;
+import com.lowagie.text.DocumentException;
+import com.lowagie.text.Paragraph;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+
+/**
+ * Test for small PDF files in MappedRandomAccessFile
+ */
+public class SmallPdfReadTest {
+
+    @Test
+    public void testEOFHandlingInMappedRandomAccessFile(@TempDir File tempDir) throws IOException, DocumentException {
+        File pdfFile = new File(tempDir, "tiny.pdf");
+        pdfFile.deleteOnExit();
+
+        // 1. Create a tiny PDF file
+        try (OutputStream outputStream = new FileOutputStream(pdfFile)) {
+            Document document = new Document();
+            PdfWriter.getInstance(document, outputStream);
+            document.open();
+            document.add(new Paragraph("Minimal content"));
+            document.close();
+        }
+
+        Assertions.assertTrue(pdfFile.length() < 1024, "PDF should be under 1KiB");
+
+        // 2. Open with MappedRandomAccessFile and seek to EOF
+        try (MappedRandomAccessFile raf = new MappedRandomAccessFile(pdfFile.getAbsolutePath(), "r")) {
+            long length = pdfFile.length();
+            raf.seek(length); // Seek to exactly EOF
+
+            // 3. Try to read past EOF — should return -1, not throw
+            int result = raf.read();
+
+            // BUG: This currently throws IndexOutOfBoundsException instead of returning -1
+            Assertions.assertEquals(-1, result, "Expected -1 at EOF, but read returned: " + result);
+        }
+
+        System.gc();
+        try {
+            Thread.sleep(100); // give GC time to release mapped file
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}


### PR DESCRIPTION
Fix for reading very small PDF files, in LongMappedByteBuffer and MappedRandomAccessFile, caused by adding support for reading very large PDF files https://github.com/LibrePDF/OpenPDF/pull/1319.

https://github.com/LibrePDF/OpenPDF/issues/1291#issuecomment-2898907708