### PR TITLE
Fix 3 code quality issues

### DIFF
--- a/openpdf-html/src/main/java/org/openpdf/css/style/derived/FSLinearGradient.java
+++ b/openpdf-html/src/main/java/org/openpdf/css/style/derived/FSLinearGradient.java
@@ -53,8 +53,14 @@ public class FSLinearGradient
 
         @Nullable
         public Float getLength() {
+            return this.length;
+        }
+
+        @Nullable
+        public Float getDotsValue() {
             return this.dotsValue;
         }
+
 
         @Override
         public String toString()

--- a/openpdf-html/src/main/java/org/openpdf/swing/Java2DOutputDevice.java
+++ b/openpdf-html/src/main/java/org/openpdf/swing/Java2DOutputDevice.java
@@ -313,8 +313,8 @@ public class Java2DOutputDevice extends AbstractOutputDevice implements OutputDe
 		float[] fractions = new float[gradient.getStopPoints().size()];
 		Color[] colors = new Color[gradient.getStopPoints().size()];
 
-		float range = gradient.getStopPoints().get(gradient.getStopPoints().size() - 1).getLength() -
-				gradient.getStopPoints().get(0).getLength();
+		float range = gradient.getStopPoints().get(gradient.getStopPoints().size() - 1).getDotsValue() -
+				gradient.getStopPoints().get(0).getDotsValue();
 
 		int i = 0;
 		for (StopValue pt : gradient.getStopPoints())
@@ -326,7 +326,7 @@ public class Java2DOutputDevice extends AbstractOutputDevice implements OutputDe
 	        }
 
 	        if (range != 0)
-	        	fractions[i] = pt.getLength() / range;
+	        	fractions[i] = pt.getDotsValue() / range;
 
 	        i++;
 		}

--- a/openpdf-html/src/main/java/org/openpdf/swing/RootPanel.java
+++ b/openpdf-html/src/main/java/org/openpdf/swing/RootPanel.java
@@ -582,7 +582,7 @@ public class RootPanel extends JPanel implements Scrollable, UserInterface, FSCa
             if (!repaintRequestPending) {
                 XRLog.general(Level.FINE, "... Queueing new repaint request, el: " + el + " < " + maxRepaintRequestWaitMs);
                 repaintRequestPending = true;
-                new Thread(() -> {
+                Thread.startVirtualThread(() -> {
                     try {
                         Thread.sleep(Math.min(maxRepaintRequestWaitMs, Math.abs(maxRepaintRequestWaitMs - el)));
                         EventQueue.invokeLater(() -> {
@@ -593,7 +593,8 @@ public class RootPanel extends JPanel implements Scrollable, UserInterface, FSCa
                     } catch (InterruptedException ignore) {
                         Thread.currentThread().interrupt();
                     }
-                }).start();
+                });
+
             } else {
                 pendingRepaintCount++;
                 XRLog.general("hmm... repaint request, but already have one");

--- a/openpdf-html/src/main/resources/resources/css/XhtmlNamespaceHandler.css
+++ b/openpdf-html/src/main/resources/resources/css/XhtmlNamespaceHandler.css
@@ -4,7 +4,7 @@ body, dd, div,
 dl, dt, fieldset, form,
 frame, frameset,
 h1, h2, h3, h4,
-h5, h6, noframes,
+h5, h6,
 ol, p, ul, center,
 dir, hr, menu, pre, object   { display: block }
 li              { display: list-item }


### PR DESCRIPTION
Refactor the getLength() method to return the actual length field, replace raw thread usage with Thread.startVirtualThread() for sleeping operations, and remove the obsolete noframes selector from the CSS to ensure modern standards compliance.


## Your real name
Andreas Røsdal