### PR TITLE
Add HtmlPdfBuilder.kt Kotlin

### DIFF
--- a/openpdf-kotlin/pom.xml
+++ b/openpdf-kotlin/pom.xml
@@ -10,7 +10,7 @@
   </parent>
 
   <artifactId>openpdf-kotlin</artifactId>
-  <name>OpenPDF Kotlin Utilities</name>
+  <name>OpenPDF Kotlin</name>
   <description>Kotlin-friendly APIs and DSL for OpenPDF</description>
 
   <dependencies>
@@ -18,6 +18,12 @@
     <dependency>
       <groupId>com.github.librepdf</groupId>
       <artifactId>openpdf</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>com.github.librepdf</groupId>
+      <artifactId>openpdf-html</artifactId>
       <version>${project.version}</version>
     </dependency>
 

--- a/openpdf-kotlin/src/main/kotlin/com/github/librepdf/kotlin/HtmlPdfBuilder.kt
+++ b/openpdf-kotlin/src/main/kotlin/com/github/librepdf/kotlin/HtmlPdfBuilder.kt
@@ -1,0 +1,56 @@
+package com.github.librepdf.kotlin
+
+import org.openpdf.pdf.ITextRenderer
+import java.io.OutputStream
+
+/**
+ * A Kotlin DSL-style builder for creating PDFs from HTML using OpenPDF + Flying Saucer (openpdf-html).
+ */
+class HtmlPdfBuilder(private val outputStream: OutputStream) {
+  private var htmlContent: String? = null
+  private var baseUrl: String? = null
+  private var scaleToFit: Boolean = false
+  private var pdfVersion: Char? = null
+
+  /**
+   * Set the HTML content to render.
+   *
+   * @param html HTML string
+   * @param baseUrl Optional base URL for resolving relative paths (e.g., for images or CSS)
+   */
+  fun html(html: String, baseUrl: String? = null) {
+    this.htmlContent = html
+    this.baseUrl = baseUrl
+  }
+
+  /**
+   * Set the PDF version to use (optional).
+   *
+   * @param version One of PdfWriter.VERSION_1_2 through VERSION_1_7
+   */
+  fun pdfVersion(version: Char) {
+    this.pdfVersion = version
+  }
+
+  /**
+   * Enable or disable scale-to-fit behavior.
+   */
+  fun scaleToFit(enabled: Boolean = true) {
+    this.scaleToFit = enabled
+  }
+
+  /**
+   * Builds and writes the PDF to the output stream.
+   */
+  fun build() {
+    val content = htmlContent
+      ?: throw IllegalStateException("HTML content must be set before calling build()")
+
+    val renderer = ITextRenderer()
+    pdfVersion?.let { renderer.setPDFVersion(it) }
+    renderer.setScaleToFit(scaleToFit)
+    renderer.setDocumentFromString(content, baseUrl)
+    renderer.layout()
+    renderer.createPDF(outputStream)
+  }
+}


### PR DESCRIPTION
## Description of the new Feature/Bugfix
Add HtmlPdfBuilder.kt Kotlin


```
val outputStream = FileOutputStream("output.pdf")

HtmlPdfBuilder(outputStream).apply {
    html(
        """
        <html>
          <head><title>Example</title></head>
          <body>
            <h1>Hello from HTML</h1>
            <p>This PDF was generated using openpdf-html and Kotlin.</p>
          </body>
        </html>
        """.trimIndent()
    )
    scaleToFit(true)
    pdfVersion(com.lowagie.text.pdf.PdfWriter.VERSION_1_7)
    build()
}

```


## Your real name
Andreas Røsdal
