### PR TITLE
Register font only once in static block instead on every constructor …

### DIFF
--- a/openpdf/src/main/java/com/lowagie/text/pdf/FontSelector.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/FontSelector.java
@@ -67,8 +67,11 @@ public class FontSelector {
 
     protected ArrayList<Font> fonts = new ArrayList<>();
 
-    public FontSelector() {
+    static {
         FontFactory.register("font-fallback/LiberationSans-Regular.ttf", "sans");
+    }
+
+    public FontSelector() {
         Font font = FontFactory.getFont("sans", BaseFont.IDENTITY_H);
         fonts.add(font);
     }


### PR DESCRIPTION
…call and degrade performance

Fix regarding issues #1372 & #1257.
Register font only once
