### PR TITLE
Fix/Feature add for issue #1297

### DIFF
--- a/openpdf/src/main/java/com/lowagie/text/pdf/ColumnText.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/ColumnText.java
@@ -293,6 +293,12 @@ public class ColumnText {
     private boolean adjustFirstLine = true;
 
     /**
+     * Flag to enable strict word wrapping mode. When true, throws StrictWordWrapException
+     * instead of forcing line breaks when text doesn't fit within column width.
+     */
+    private boolean strictWordWrapping = false;
+
+    /**
      * Creates a <CODE>ColumnText</CODE>.
      *
      * @param canvas the place where the text will be written to. Can be a template.
@@ -502,6 +508,7 @@ public class ColumnText {
         useAscender = org.useAscender;
         filledWidth = org.filledWidth;
         adjustFirstLine = org.adjustFirstLine;
+        strictWordWrapping = org.strictWordWrapping;
     }
 
     private void addWaitingPhrase() {
@@ -1032,7 +1039,7 @@ public class ColumnText {
                     break;
                 }
                 line = bidiLine.processLine(leftX, rectangularWidth - firstIndent - rightIndent, alignment,
-                        localRunDirection, arabicOptions);
+                        localRunDirection, arabicOptions, strictWordWrapping);
                 if (line == null) {
                     status = NO_MORE_TEXT;
                     break;
@@ -1084,7 +1091,7 @@ public class ColumnText {
                     dirty = true;
                 }
                 line = bidiLine.processLine(x1, x2 - x1 - firstIndent - rightIndent, alignment, localRunDirection,
-                        arabicOptions);
+                        arabicOptions, strictWordWrapping);
                 if (line == null) {
                     status = NO_MORE_TEXT;
                     yLine = yTemp;
@@ -1737,5 +1744,24 @@ public class ColumnText {
      */
     public void setAdjustFirstLine(boolean adjustFirstLine) {
         this.adjustFirstLine = adjustFirstLine;
+    }
+
+    /**
+     * Gets the strict word wrapping flag.
+     *
+     * @return true if strict word wrapping is enabled, false otherwise
+     */
+    public boolean isStrictWordWrapping() {
+        return strictWordWrapping;
+    }
+
+    /**
+     * Sets the strict word wrapping flag. When enabled, throws StrictWordWrapException
+     * instead of forcing line breaks when text doesn't fit within column width.
+     *
+     * @param strictWordWrapping true to enable strict word wrapping, false to disable
+     */
+    public void setStrictWordWrapping(boolean strictWordWrapping) {
+        this.strictWordWrapping = strictWordWrapping;
     }
 }

--- a/openpdf/src/main/java/com/lowagie/text/pdf/StrictWordWrapException.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/StrictWordWrapException.java
@@ -1,0 +1,27 @@
+package com.lowagie.text.pdf;
+
+/**
+ * Exception thrown when strict word wrapping is enabled and text cannot fit
+ * within the specified column width without being forced to break mid-word.
+ */
+public class StrictWordWrapException extends RuntimeException {
+    
+    /**
+     * Constructs a new StrictWordWrapException with the specified detail message.
+     * 
+     * @param message the detail message
+     */
+    public StrictWordWrapException(String message) {
+        super(message);
+    }
+    
+    /**
+     * Constructs a new StrictWordWrapException with the specified detail message and cause.
+     * 
+     * @param message the detail message
+     * @param cause the cause of the exception
+     */
+    public StrictWordWrapException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}


### PR DESCRIPTION
## Feature to address issue #1297 Throw exception instead of arbitrarily chopping long words

I added a flag to ColumnText that defaults to current behavior, but if the flag setStrictWordWrapping(true) then it throws a StrictWordWrapException when this condition occurs.

## Unit-Tests for the new Feature/Bugfix
The following code can be used to reproduce the bug/feature.  Toggle column.setStrictWordWrapping() between true and false to test this issue.

```
import com.lowagie.text.Chunk;
import com.lowagie.text.Document;
import com.lowagie.text.pdf.ColumnText;
import com.lowagie.text.pdf.PdfContentByte;
import com.lowagie.text.pdf.PdfWriter;
import java.io.FileOutputStream;
import java.io.IOException;

public class BugTest {
    public static void main(String[] args) {
        try (Document document = new Document()) {
            FileOutputStream stream = new FileOutputStream("test.pdf");
            PdfWriter writer = PdfWriter.getInstance(document, stream);
            document.open();
            PdfContentByte canvas = writer.getDirectContent();

            canvas.saveState();
            canvas.rectangle(10, 10, 100, 200);
            canvas.setLineWidth(0.1f);
            canvas.stroke();
            canvas.restoreState();

            canvas.saveState();
            ColumnText column = new ColumnText(canvas);
            column.setStrictWordWrapping(true);
            column.setSimpleColumn(10, 10, 110, 210);
            column.addText(new Chunk("German is a language known for long word compositions. One such example is 'ABCDEFGHIJKLMNOPQRSTUVWXYZ', which is German for deoxyribonucleic acid."));
            column.go();
            canvas.restoreState();

        } catch (IOException e) {
            e.printStackTrace();
        }
    }
}

```
## Compatibilities Issues

Is anything broken because of the new code? No
Any changes in method signatures? no, but in BidiLine I did have to overload processLine()


## Your real name
Please specify your full name here, so that we can verify your identity. - Chris Simoes
If you have a conflict of interest describe this here also. - no conflicts of interest

## Testing details

Any other details about how to test the new feature or bugfix? I believe the code above does a good job reproducing the issue.  
