### PR TITLE
Add TU and ALT Fields to signature object

### DIFF
--- a/openpdf/src/main/java/com/lowagie/text/pdf/PdfFormField.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/PdfFormField.java
@@ -226,6 +226,8 @@ public class PdfFormField extends PdfAnnotation {
     public static PdfFormField createSignature(PdfWriter writer) {
         PdfFormField field = new PdfFormField(writer);
         field.put(PdfName.FT, PdfName.SIG);
+        field.put(PdfName.TU, new PdfString("Digital signature field (non-interactive)", PdfObject.TEXT_UNICODE));
+        field.put(PdfName.ALT, new PdfString("Digital signature field (non-interactive)", PdfObject.TEXT_UNICODE));
         return field;
     }
 

--- a/openpdf/src/main/java/com/lowagie/text/pdf/PdfFormField.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/PdfFormField.java
@@ -226,8 +226,6 @@ public class PdfFormField extends PdfAnnotation {
     public static PdfFormField createSignature(PdfWriter writer) {
         PdfFormField field = new PdfFormField(writer);
         field.put(PdfName.FT, PdfName.SIG);
-        field.put(PdfName.TU, new PdfString("Digital signature field (non-interactive)", PdfObject.TEXT_UNICODE));
-        field.put(PdfName.ALT, new PdfString("Digital signature field (non-interactive)", PdfObject.TEXT_UNICODE));
         return field;
     }
 

--- a/openpdf/src/main/java/com/lowagie/text/pdf/PdfSignatureAppearance.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/PdfSignatureAppearance.java
@@ -1100,6 +1100,10 @@ public class PdfSignatureAppearance {
             PdfFormField sigField = PdfFormField.createSignature(writer);
             sigField.setFieldName(name);
             sigField.put(PdfName.V, refSig);
+
+            sigField.put(PdfName.TU, new PdfString("Digital signature", PdfObject.TEXT_UNICODE));
+            sigField.put(PdfName.ALT, new PdfString("Non-interactive Digital signature field", PdfObject.TEXT_UNICODE));
+
             sigField.setFlags(PdfAnnotation.FLAGS_PRINT | PdfAnnotation.FLAGS_LOCKED);
 
             int pagen = getPage();


### PR DESCRIPTION
## Description of the new Feature/Bugfix

Added TU and ALT Fields to signature object.

Related Issue: 
#1308 

## Unit-Tests for the new Feature/Bugfix

- [ ] Unit-Tests added to the added feature

## Compatibilities Issues

No.

## Your real name
Marc Schmidt

## Testing details
Create a signed pdf, the PAC-Tool (https://pac.pdf-accessibility.org/en) should not flag for the error "Alternative Beschreibung (Alternative Description)" anymore.
