### PR TITLE
OpenPDF 3.0.x requires Java 24.

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -54,7 +54,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: 21
+          java-version: 24
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: [21, 24]
+        java: [24]
     name: Build with Java ${{ matrix.java }}
     steps:
       - uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -138,15 +138,14 @@ More details: [Contributing](CONTRIBUTING.md)
 - Generally try to preserve the coding style in the file you are modifying.
 
 
-## OpenPDF 3.0.0
+## OpenPDF 3.0.0 - Major Change, Futuristic Release of OpenPDF.
 
 - **Package name changed** from `com.lowagie` to `org.openpdf`. Source code that uses OpenPDF must
   update its import statements accordingly. Usually this can be done with a simple find-and-replace
-  operation in your IDE.
-
-- This change reflects the true identity of OpenPDF as a modern, community-driven PDF library
+  operation in your IDE. This change reflects the true identity of OpenPDF as a modern, community-driven PDF library
   independent of the original iText 2.x (`com.lowagie`). It avoids conflicts and
   clarifies project ownership going forward.
+- OpenPDF 3.0.x requires Java 24 or later.
 
 
 ## Dependencies
@@ -155,6 +154,7 @@ More details: [Contributing](CONTRIBUTING.md)
 
 We have now different versions of OpenPDF, and they require different versions of Java:
 
+- The 3.0.x Branch requires Java 24 or later. Package name changed** from `com.lowagie` to `org.openpdf`.
 - The 2.1.x Branch requires Java 21 or later.
 - The 2.0.x Branch requires Java 17 or later.
 - The 1.4.x Branch requires Java 11 or later.

--- a/changelogs/3.0.0.md
+++ b/changelogs/3.0.0.md
@@ -2,6 +2,8 @@
 
 ## Major Change
 
+- The 3.0.x Branch requires Java 24 or later. Package name changed** from `com.lowagie` to `org.openpdf`.
+
 - **Package name changed** from `com.lowagie` to `org.openpdf`.
 
   This change reflects the true identity of OpenPDF as a modern, community-driven PDF library 

--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
 
   <properties>
     <java-module-name>com.github.librepdf.openpdf.parent</java-module-name>
-    <java.version>21</java.version>
+    <java.version>24</java.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 


### PR DESCRIPTION
## Description of the new Feature/Bugfix

OpenPDF 3.0.x requires Java 24.

## Compatibilities Issues

Java 24.

## Your real name
Andreas Røsdal
