### PR TITLE
This code is compilable by Java 17

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: [21, 24]
+        java: [17, 21, 24]
     name: Build with Java ${{ matrix.java }}
     steps:
       - uses: actions/checkout@v4

--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
 
   <properties>
     <java-module-name>com.github.librepdf.openpdf.parent</java-module-name>
-    <java.version>21</java.version>
+    <java.version>17</java.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 


### PR DESCRIPTION
There is no technical reason to bump this to java 21. A lot of libraries from the up-coming maven 4 stack is perfectly buildable with source/target/release levels 17. I don't have any religion about this, but it is making sense not to bump if not needed.