### PR TITLE
Fix incorrect handling of line-height CSS in HTML → PDF conversion

### DIFF
--- a/openpdf/src/main/java/com/lowagie/text/html/simpleparser/FactoryProperties.java
+++ b/openpdf/src/main/java/com/lowagie/text/html/simpleparser/FactoryProperties.java
@@ -380,10 +380,6 @@ public class FactoryProperties {
                         actualFontSize = Markup.DEFAULT_FONT_SIZE;
                     }
                     float v = parseLength(prop.getProperty(key), actualFontSize);
-                    if (ss.endsWith("%")) {
-                        h.put("leading", "0," + (v / 100));
-                        return;
-                    }
                     if ("normal".equalsIgnoreCase(ss)) {
                         h.put("leading", "0,1.5");
                         return;

--- a/openpdf/src/test/java/com/lowagie/text/html/StylesTest.java
+++ b/openpdf/src/test/java/com/lowagie/text/html/StylesTest.java
@@ -3,6 +3,7 @@ package com.lowagie.text.html;
 import com.lowagie.text.Chunk;
 import com.lowagie.text.Document;
 import com.lowagie.text.Element;
+import com.lowagie.text.Font;
 import com.lowagie.text.Paragraph;
 import com.lowagie.text.html.simpleparser.HTMLWorker;
 import com.lowagie.text.html.simpleparser.StyleSheet;
@@ -126,4 +127,43 @@ class StylesTest {
         Chunk chunk10 = (Chunk) paragraph.get(18);
         Assertions.assertEquals(FontSize.LARGER.getScale() * 20f, chunk10.getFont().getSize());
     }
+
+    @Test
+    void testLineHeightPercentage() throws Exception {
+        List<Element> elements = htmlToPdf("stylesTest/lineHeightPercentage.html", "target/Line Height Percentage.pdf");
+        Paragraph paragraph = (Paragraph) elements.get(0);
+        Chunk chunk = (Chunk) paragraph.get(0);
+        float fontSize;
+        if (chunk.getFont() != null) {
+            fontSize = chunk.getFont().getSize();
+        } else {
+            fontSize = Font.DEFAULTSIZE;
+        }
+        float expectedMultiplier = 1.15f; // derived from <span style="line-height:115%"> in lineHeightPercentage.html
+        float expectedTotalLeading = fontSize * expectedMultiplier;
+        float totalLeading = paragraph.getTotalLeading();
+
+        Assertions.assertEquals(expectedTotalLeading, totalLeading, 0.1f,
+                "Total leading should be ~fontSize * " + expectedMultiplier);
+    }
+
+    @Test
+    void testDefaultLineHeight() throws Exception {
+        List<Element> elements = htmlToPdf("stylesTest/lineHeightDefault.html", "target/Line Height Default.pdf");
+        Paragraph paragraph = (Paragraph) elements.get(0);
+        Chunk chunk = (Chunk) paragraph.get(0);
+        float fontSize;
+        if (chunk.getFont() != null) {
+            fontSize = chunk.getFont().getSize();
+        } else {
+            fontSize = Font.DEFAULTSIZE;
+        }
+        float expectedMultiplier = 1.5f;
+        float expectedTotalLeading = fontSize * expectedMultiplier;
+        float totalLeading = paragraph.getTotalLeading();
+
+        Assertions.assertEquals(expectedTotalLeading, totalLeading, 0.1f,
+                "Total leading should be ~fontSize * " + expectedMultiplier);
+    }
+
 }

--- a/openpdf/src/test/resources/stylesTest/lineHeightDefault.html
+++ b/openpdf/src/test/resources/stylesTest/lineHeightDefault.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+</head>
+<body>
+<span>
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam eget hendrerit nulla.
+Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae.
+Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip.
+Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat.
+</span>
+</body>
+</html>

--- a/openpdf/src/test/resources/stylesTest/lineHeightPercentage.html
+++ b/openpdf/src/test/resources/stylesTest/lineHeightPercentage.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+</head>
+<body>
+<span style="line-height:115%">
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam eget hendrerit nulla.
+Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae.
+Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip.
+Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat.
+</span>
+</body>
+</html>


### PR DESCRIPTION
## Description of the new Feature/Bugfix

When parsing HTML with a span styled with line-height (e.g., <span "line-height:115%">), the generated Paragraph in OpenPDF 1.3.x computed the multiplied leading incorrectly, resulting in overlapping lines (see attached PDF file).

```java
paragraph.getLeading()           = 0.0
paragraph.getMultipliedLeading() = 0.138  // much too small
paragraph.getTotalLeading()      ≈ 1.656  // causes overlapping lines in the PDF
```
### Expected behavior:
For font size 12pt and line-height:115%, the total leading should be ≈ 13.8pt (12 × 1.15).

### Cause:
`FactoryProperties.insertStyle`, line 383 handles line-height in percentage (by dividing by 100) although the percentage handling is done already in `Markup.parseLength(String string, float actualFontSize)`, line 553.
The problem was most likely introduced by: #1059 When converting HTML to PDF, font size specified in % is interpreted as pixels

### Solution:
Adjusted `FactoryProperties.insertStyle` - removed handling line-height in percentage.

Added a JUnit test (`testLineHeightPercentage`) that parses a small HTML snippet with line-height:115% and asserts that `Paragraph.getTotalLeading()` matches the expected value.


## Unit-Tests for the Bugfix

- [x ] Unit-Tests added to reproduce the bug

## Compatibilities Issues
None


## Your real name
Radek Wikturna

## Testing details

Any other details about how to test the new feature or bugfix?

[Line Height Percentage.pdf](https://github.com/user-attachments/files/22298364/Line.Height.Percentage.pdf)
