### PR TITLE
Clean byte buffers on close

### DIFF
--- a/openpdf-core/src/main/java/org/openpdf/text/pdf/MappedRandomAccessFile.java
+++ b/openpdf-core/src/main/java/org/openpdf/text/pdf/MappedRandomAccessFile.java
@@ -199,8 +199,12 @@ public class MappedRandomAccessFile implements AutoCloseable {
      * @throws IOException on error
      * @see java.io.RandomAccessFile#close()
      */
+    @Override
     public void close() throws IOException {
-        mappedByteBuffer = null;
+        if (mappedByteBuffer != null) {
+            mappedByteBuffer.close();
+            mappedByteBuffer = null;
+        }
         if (channel != null) {
             channel.close();
         }

--- a/openpdf-core/src/test/java/org/openpdf/text/pdf/SmallPdfReadTest.java
+++ b/openpdf-core/src/test/java/org/openpdf/text/pdf/SmallPdfReadTest.java
@@ -44,13 +44,5 @@ public class SmallPdfReadTest {
             // BUG: This currently throws IndexOutOfBoundsException instead of returning -1
             Assertions.assertEquals(-1, result, "Expected -1 at EOF, but read returned: " + result);
         }
-
-        System.gc();
-        try {
-            Thread.sleep(100); // give GC time to release mapped file
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt(); // best practice: restore interrupt flag
-            throw new IllegalStateException("Sleep was interrupted", e);
-        }
     }
 }


### PR DESCRIPTION
## Description of the new Feature/Bugfix

Restore (and fix) byte buffer cleaning that was removed by f4f80a4644e3a8c872ea15d7e5a23d9165073513, in order to deterministically deallocate the memory regions backing `LongMappedByteBuffer` instead of waiting for the garbage collector to do so.

Related Issue: #1112 (see https://github.com/LibrePDF/OpenPDF/issues/1112#issuecomment-3328994258 in particular)

## Unit-Tests for the new Feature/Bugfix

- [ ] Unit-Tests added to reproduce the bug
- [ ] Unit-Tests added to the added feature

## Compatibilities Issues

None that I can think of

## Your real name

Cosmin Selagea-Popov

## Testing details

It is sufficient to remove `System.gc()` from `SmallPdfReadTest` to reproduce #1112. Once you apply the code changes I've proposed herein, the test will consistently pass.