### PR TITLE
Use openpdf-renderer in pdf-swing, remove dependency to org.swinglabs.pdf-renderer.

### DIFF
--- a/pdf-swing/pom.xml
+++ b/pdf-swing/pom.xml
@@ -23,8 +23,9 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>org.swinglabs</groupId>
-      <artifactId>pdf-renderer</artifactId>
+      <groupId>com.github.librepdf</groupId>
+      <artifactId>openpdf-renderer</artifactId>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>org.dom4j</groupId>

--- a/pdf-swing/src/main/java/org/openpdf/rups/model/PageLoader.java
+++ b/pdf-swing/src/main/java/org/openpdf/rups/model/PageLoader.java
@@ -20,16 +20,16 @@
 
 package org.openpdf.rups.model;
 
-import com.sun.pdfview.PDFFile;
-import com.sun.pdfview.PDFPage;
+import org.openpdf.renderer.PDFFile;
+import org.openpdf.renderer.PDFPage;
 
 /**
- * Loads all the PDFPage objects for SUN's PDF Renderer in Background.
+ * Loads all the PDFPage objects for OpenPDF Renderer in the background.
  */
 public class PageLoader extends BackgroundTask {
 
     /**
-     * The PDFFile (SUN's PDF Renderer class)
+     * The PDFFile from OpenPDF Renderer.
      */
     protected PDFFile file;
     /**
@@ -48,7 +48,7 @@ public class PageLoader extends BackgroundTask {
     /**
      * Creates a new page loader.
      *
-     * @param file the PDFFile (SUN's PDF Renderer)
+     * @param file the PDFFile from OpenPDF Renderer
      */
     public PageLoader(PDFFile file) {
         super();

--- a/pom.xml
+++ b/pom.xml
@@ -93,7 +93,6 @@
     <jakarta.servlet-api.version>6.1.0</jakarta.servlet-api.version>
     <jcommon.version>1.0.24</jcommon.version>
     <jfreechart.version>1.5.6</jfreechart.version>
-    <pdf-renderer.version>1.0.5</pdf-renderer.version>
     <error_prone.version>2.49.0</error_prone.version>
     <slf4j.version>2.0.17</slf4j.version>
 
@@ -136,11 +135,6 @@
         <groupId>org.jfree</groupId>
         <artifactId>jcommon</artifactId>
         <version>${jcommon.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.swinglabs</groupId>
-        <artifactId>pdf-renderer</artifactId>
-        <version>${pdf-renderer.version}</version>
       </dependency>
       <dependency>
         <groupId>org.dom4j</groupId>


### PR DESCRIPTION
Use [openpdf-renderer](https://github.com/LibrePDF/OpenPDF/tree/master/openpdf-renderer) in pdf-swing, remove dependency to [org.swinglabs.pdf-renderer](https://github.com/katjas/PDFrenderer).


 [openpdf-renderer](https://github.com/LibrePDF/OpenPDF/tree/master/openpdf-renderer) is the maintained PDF renderer project inside the OpenPDF project, and is forked from [org.swinglabs.pdf-renderer](https://github.com/katjas/PDFrenderer).


## Your real name
Andreas Røsdal