### PR TITLE
Modernize encryption and signature support; post-quantum signatures, SHA-3 digests.

### DIFF
--- a/openpdf-core/src/main/java/org/openpdf/text/pdf/PdfEncryption.java
+++ b/openpdf-core/src/main/java/org/openpdf/text/pdf/PdfEncryption.java
@@ -59,6 +59,7 @@ import java.io.OutputStream;
 import java.math.BigInteger;
 import java.security.GeneralSecurityException;
 import java.security.MessageDigest;
+import java.security.SecureRandom;
 import java.security.cert.Certificate;
 import java.util.Arrays;
 import javax.crypto.Cipher;
@@ -79,6 +80,11 @@ public class PdfEncryption {
     public static final int AES_128 = 4;
 
     public static final int AES_256_V3 = 6;
+
+    /**
+     * Cryptographically strong random source used for generating document IDs and IVs.
+     */
+    private static final SecureRandom SECURE_RANDOM = new SecureRandom();
 
     private static final byte[] pad = {(byte) 0x28, (byte) 0xBF, (byte) 0x4E,
             (byte) 0x5E, (byte) 0x4E, (byte) 0x75, (byte) 0x8A, (byte) 0x41,
@@ -195,16 +201,11 @@ public class PdfEncryption {
     }
 
     public static byte[] createDocumentId() {
-        MessageDigest md5;
-        try {
-            md5 = MessageDigest.getInstance("MD5");
-        } catch (Exception e) {
-            throw new ExceptionConverter(e);
-        }
-        long time = System.currentTimeMillis();
-        long mem = Runtime.getRuntime().freeMemory();
-        String s = time + "+" + mem + "+" + (seq++);
-        return md5.digest(s.getBytes());
+        // 16 bytes of cryptographically strong random data, replacing
+        // the previous MD5(time+memory+seq) construction.
+        byte[] id = new byte[16];
+        SECURE_RANDOM.nextBytes(id);
+        return id;
     }
 
     public static PdfObject createInfoId(byte[] id) {

--- a/openpdf-core/src/main/java/org/openpdf/text/pdf/PdfPKCS7.java
+++ b/openpdf-core/src/main/java/org/openpdf/text/pdf/PdfPKCS7.java
@@ -158,14 +158,20 @@ public class PdfPKCS7 {
         digestNames.put("1.2.840.113549.1.1.11", "SHA256");
         digestNames.put("1.2.840.113549.1.1.12", "SHA384");
         digestNames.put("1.2.840.113549.1.1.13", "SHA512");
-        digestNames.put("1.2.840.10040.4.3", "SHA1");    // TODO: bug - duplicate key - overwrites this with DSA
-        digestNames.put("2.16.840.1.101.3.4.3.1", "SHA224");  // TODO: bug - duplicate key - overwrites this with DSA
+        digestNames.put("1.2.840.10040.4.3", "SHA1");
+        digestNames.put("2.16.840.1.101.3.4.3.1", "SHA224");
         digestNames.put("2.16.840.1.101.3.4.3.2", "SHA256");
         digestNames.put("2.16.840.1.101.3.4.3.3", "SHA384");
         digestNames.put("2.16.840.1.101.3.4.3.4", "SHA512");
         digestNames.put("1.3.36.3.3.1.3", "RIPEMD128");
         digestNames.put("1.3.36.3.3.1.2", "RIPEMD160");
         digestNames.put("1.3.36.3.3.1.4", "RIPEMD256");
+        // SHA-3 family (FIPS 202)
+        digestNames.put("2.16.840.1.101.3.4.2.8", "SHA3-256");
+        digestNames.put("2.16.840.1.101.3.4.2.10", "SHA3-512");
+        // RSASSA-PKCS1-v1_5 with SHA-3
+        digestNames.put("2.16.840.1.101.3.4.3.14", "SHA3-256");
+        digestNames.put("2.16.840.1.101.3.4.3.16", "SHA3-512");
 
         algorithmNames.put("1.2.840.113549.1.1.1", "RSA");
         algorithmNames.put("1.2.840.10040.4.1", "DSA");
@@ -189,6 +195,9 @@ public class PdfPKCS7 {
         algorithmNames.put("1.2.840.10045.4.3.3", "ECDSA");
         algorithmNames.put("1.2.840.10045.4.3.4", "ECDSA");
         algorithmNames.put("1.2.840.113549.1.1.10", "RSAandMGF1");
+        // RSASSA-PKCS1-v1_5 with SHA-3 family (FIPS 202)
+        algorithmNames.put("2.16.840.1.101.3.4.3.14", "RSA");
+        algorithmNames.put("2.16.840.1.101.3.4.3.16", "RSA");
         allowedDigests.put("MD5", "1.2.840.113549.2.5");
         allowedDigests.put("MD2", "1.2.840.113549.2.2");
         allowedDigests.put("SHA1", "1.3.14.3.2.26");
@@ -209,6 +218,9 @@ public class PdfPKCS7 {
         allowedDigests.put("RIPEMD-160", "1.3.36.3.2.1");
         allowedDigests.put("RIPEMD256", "1.3.36.3.2.3");
         allowedDigests.put("RIPEMD-256", "1.3.36.3.2.3");
+        // SHA-3 family (FIPS 202)
+        allowedDigests.put("SHA3-256", "2.16.840.1.101.3.4.2.8");
+        allowedDigests.put("SHA3-512", "2.16.840.1.101.3.4.2.10");
     }
 
     private final List<Certificate> certs;
@@ -267,8 +279,9 @@ public class PdfPKCS7 {
             signCerts = certs;
             signCert = (X509Certificate) certs.iterator().next();
             crls = new ArrayList<>();
-            ASN1InputStream in = new ASN1InputStream(new ByteArrayInputStream(contentsKey));
-            digest = ((DEROctetString) in.readObject()).getOctets();
+            try (ASN1InputStream in = new ASN1InputStream(new ByteArrayInputStream(contentsKey))) {
+                digest = ((DEROctetString) in.readObject()).getOctets();
+            }
             if (provider == null) {
                 sig = Signature.getInstance("SHA1withRSA");
             } else {
@@ -290,15 +303,11 @@ public class PdfPKCS7 {
     public PdfPKCS7(byte[] contentsKey, String provider) {
         try {
             this.provider = provider;
-            ASN1InputStream din = new ASN1InputStream(new ByteArrayInputStream(
-                    contentsKey));
-
-            //
-            // Basic checks to make sure it's a PKCS#7 SignedData Object
-            //
             ASN1Primitive pkcs;
-
-            try {
+            try (ASN1InputStream din = new ASN1InputStream(new ByteArrayInputStream(contentsKey))) {
+                //
+                // Basic checks to make sure it's a PKCS#7 SignedData Object
+                //
                 pkcs = din.readObject();
             } catch (IOException e) {
                 throw new IllegalArgumentException(

--- a/openpdf-core/src/main/java/org/openpdf/text/pdf/PdfPKCS7.java
+++ b/openpdf-core/src/main/java/org/openpdf/text/pdf/PdfPKCS7.java
@@ -140,6 +140,8 @@ public class PdfPKCS7 {
     private static final String ID_MESSAGE_DIGEST = "1.2.840.113549.1.9.4";
     private static final String ID_SIGNING_TIME = "1.2.840.113549.1.9.5";
     private static final String ID_ADBE_REVOCATION = "1.2.840.113583.1.1.8";
+    private static final String DIGEST_SHA3_256 = "SHA3-256";
+    private static final String DIGEST_SHA3_512 = "SHA3-512";
     private static final Map<String, String> digestNames = new HashMap<>();
     private static final Map<String, String> algorithmNames = new HashMap<>();
     private static final Map<String, String> allowedDigests = new HashMap<>();
@@ -171,11 +173,11 @@ public class PdfPKCS7 {
         digestNames.put("1.3.36.3.3.1.2", "RIPEMD160");
         digestNames.put("1.3.36.3.3.1.4", "RIPEMD256");
         // SHA-3 family (FIPS 202)
-        digestNames.put("2.16.840.1.101.3.4.2.8", "SHA3-256");
-        digestNames.put("2.16.840.1.101.3.4.2.10", "SHA3-512");
+        digestNames.put("2.16.840.1.101.3.4.2.8", DIGEST_SHA3_256);
+        digestNames.put("2.16.840.1.101.3.4.2.10", DIGEST_SHA3_512);
         // RSASSA-PKCS1-v1_5 with SHA-3
-        digestNames.put("2.16.840.1.101.3.4.3.14", "SHA3-256");
-        digestNames.put("2.16.840.1.101.3.4.3.16", "SHA3-512");
+        digestNames.put("2.16.840.1.101.3.4.3.14", DIGEST_SHA3_256);
+        digestNames.put("2.16.840.1.101.3.4.3.16", DIGEST_SHA3_512);
 
         algorithmNames.put("1.2.840.113549.1.1.1", "RSA");
         algorithmNames.put("1.2.840.10040.4.1", "DSA");
@@ -227,8 +229,8 @@ public class PdfPKCS7 {
         allowedDigests.put("RIPEMD256", "1.3.36.3.2.3");
         allowedDigests.put("RIPEMD-256", "1.3.36.3.2.3");
         // SHA-3 family (FIPS 202)
-        allowedDigests.put("SHA3-256", "2.16.840.1.101.3.4.2.8");
-        allowedDigests.put("SHA3-512", "2.16.840.1.101.3.4.2.10");
+        allowedDigests.put(DIGEST_SHA3_256, "2.16.840.1.101.3.4.2.8");
+        allowedDigests.put(DIGEST_SHA3_512, "2.16.840.1.101.3.4.2.10");
     }
 
     private final List<Certificate> certs;

--- a/openpdf-core/src/main/java/org/openpdf/text/pdf/PdfPKCS7.java
+++ b/openpdf-core/src/main/java/org/openpdf/text/pdf/PdfPKCS7.java
@@ -132,6 +132,10 @@ public class PdfPKCS7 {
     private static final String ID_RSA = "1.2.840.113549.1.1.1";
     private static final String ID_DSA = "1.2.840.10040.4.1";
     private static final String ID_ECDSA = "1.2.840.10045.2.1";
+    // ML-DSA (NIST FIPS 204) signature algorithm OIDs. See RFC draft-ietf-lamps-dilithium-certificates.
+    private static final String ID_ML_DSA_44 = "2.16.840.1.101.3.4.3.17";
+    private static final String ID_ML_DSA_65 = "2.16.840.1.101.3.4.3.18";
+    private static final String ID_ML_DSA_87 = "2.16.840.1.101.3.4.3.19";
     private static final String ID_CONTENT_TYPE = "1.2.840.113549.1.9.3";
     private static final String ID_MESSAGE_DIGEST = "1.2.840.113549.1.9.4";
     private static final String ID_SIGNING_TIME = "1.2.840.113549.1.9.5";
@@ -198,6 +202,10 @@ public class PdfPKCS7 {
         // RSASSA-PKCS1-v1_5 with SHA-3 family (FIPS 202)
         algorithmNames.put("2.16.840.1.101.3.4.3.14", "RSA");
         algorithmNames.put("2.16.840.1.101.3.4.3.16", "RSA");
+        // ML-DSA (NIST FIPS 204) post-quantum signature algorithms
+        algorithmNames.put(ID_ML_DSA_44, "ML-DSA-44");
+        algorithmNames.put(ID_ML_DSA_65, "ML-DSA-65");
+        algorithmNames.put(ID_ML_DSA_87, "ML-DSA-87");
         allowedDigests.put("MD5", "1.2.840.113549.2.5");
         allowedDigests.put("MD2", "1.2.840.113549.2.2");
         allowedDigests.put("SHA1", "1.3.14.3.2.26");
@@ -531,6 +539,8 @@ public class PdfPKCS7 {
                 digestEncryptionAlgorithm = ID_DSA;
             } else if (digestEncryptionAlgorithm.equals("EC") || digestEncryptionAlgorithm.equals("ECDSA")) {
                 digestEncryptionAlgorithm = ID_ECDSA;
+            } else if (isMlDsaName(digestEncryptionAlgorithm)) {
+                digestEncryptionAlgorithm = mlDsaOid(digestEncryptionAlgorithm);
             } else {
                 throw new NoSuchAlgorithmException(
                         MessageLocalization.getComposedMessage("unknown.key.algorithm.1",
@@ -590,6 +600,30 @@ public class PdfPKCS7 {
      */
     public static String getDigestOid(String digestName) {
         return digestName != null ? allowedDigests.get(digestName) : null;
+    }
+
+    /**
+     * Tests whether the given JCE key/signature algorithm name refers to an
+     * ML-DSA (NIST FIPS 204) post-quantum signature algorithm. The legacy
+     * Bouncy Castle "Dilithium" names are accepted as aliases.
+     */
+    private static boolean isMlDsaName(String name) {
+        return name != null && (name.startsWith("ML-DSA") || name.startsWith("Dilithium"));
+    }
+
+    /**
+     * Maps a JCE ML-DSA / Dilithium key or signature algorithm name to the
+     * corresponding NIST OID. Defaults to ML-DSA-65 when the parameter set is
+     * not explicitly encoded in the name.
+     */
+    private static String mlDsaOid(String name) {
+        if ("ML-DSA-44".equals(name) || "Dilithium2".equals(name)) {
+            return ID_ML_DSA_44;
+        }
+        if ("ML-DSA-87".equals(name) || "Dilithium5".equals(name)) {
+            return ID_ML_DSA_87;
+        }
+        return ID_ML_DSA_65;
     }
 
     /**
@@ -1163,6 +1197,12 @@ public class PdfPKCS7 {
         if (dea == null) {
             dea = digestEncryptionAlgorithm;
         }
+        // ML-DSA (NIST FIPS 204) is a single-shot signature scheme whose JCE
+        // service name (e.g. "ML-DSA-65") is not combined with a separate
+        // message-digest algorithm.
+        if (dea.startsWith("ML-DSA")) {
+            return dea;
+        }
 
         return getHashAlgorithm() + "with" + dea;
     }
@@ -1257,6 +1297,8 @@ public class PdfPKCS7 {
                 this.digestEncryptionAlgorithm = ID_DSA;
             } else if (digestEncryptionAlgorithm.equals("EC")) {
                 digestEncryptionAlgorithm = ID_ECDSA;
+            } else if (isMlDsaName(digestEncryptionAlgorithm)) {
+                this.digestEncryptionAlgorithm = mlDsaOid(digestEncryptionAlgorithm);
             } else {
                 throw new ExceptionConverter(new NoSuchAlgorithmException(
                         MessageLocalization.getComposedMessage("unknown.key.algorithm.1",

--- a/openpdf-core/src/main/java/org/openpdf/text/pdf/PdfSignatureAppearance.java
+++ b/openpdf-core/src/main/java/org/openpdf/text/pdf/PdfSignatureAppearance.java
@@ -1414,7 +1414,7 @@ public class PdfSignatureAppearance {
         loc.add(new PdfNumber(0));
         loc.add(new PdfNumber(0));
         reference.put(new PdfName("DigestLocation"), loc);
-        reference.put(new PdfName("DigestMethod"), new PdfName("MD5"));
+        reference.put(new PdfName("DigestMethod"), new PdfName("SHA256"));
         reference.put(PdfName.DATA, writer.reader.getTrailer().get(PdfName.ROOT));
         PdfArray types = new PdfArray();
         types.add(reference);

--- a/openpdf-core/src/main/java/org/openpdf/text/pdf/TSAClientBouncyCastle.java
+++ b/openpdf-core/src/main/java/org/openpdf/text/pdf/TSAClientBouncyCastle.java
@@ -59,10 +59,11 @@ import java.net.URL;
 import java.net.URLConnection;
 import java.security.GeneralSecurityException;
 import java.security.MessageDigest;
+import java.security.SecureRandom;
 import java.util.Base64;
 import org.bouncycastle.asn1.ASN1ObjectIdentifier;
 import org.bouncycastle.asn1.cmp.PKIFailureInfo;
-import org.bouncycastle.asn1.x509.X509ObjectIdentifiers;
+import org.bouncycastle.asn1.nist.NISTObjectIdentifiers;
 import org.bouncycastle.tsp.TimeStampRequest;
 import org.bouncycastle.tsp.TimeStampRequestGenerator;
 import org.bouncycastle.tsp.TimeStampResponse;
@@ -152,15 +153,14 @@ public class TSAClientBouncyCastle implements TSAClient {
     }
 
     /**
-     * Get the MessageDigest. Default algorithm `SHA-1` used as per algorithm used without tsaClient
+     * Get the MessageDigest. Default algorithm is {@code SHA-256}; SHA-1 is no longer
+     * recommended for time-stamp imprints.
      *
-     * @return SHA-1 MessageDigest
-     * @see org.openpdf.text.pdf.PdfPKCS7#getEncodedPKCS7(byte[], java.util.Calendar, TSAClient, byte[]) (upto 1.3.11)
-     * or check status of https://github.com/LibrePDF/OpenPDF/issues/320
+     * @return SHA-256 (or configured) MessageDigest
      */
     @Override
     public MessageDigest getMessageDigest() throws GeneralSecurityException {
-        return MessageDigest.getInstance(isNotEmpty(digestName) ? digestName : "SHA-1");
+        return MessageDigest.getInstance(isNotEmpty(digestName) ? digestName : "SHA-256");
     }
 
     /**
@@ -194,8 +194,8 @@ public class TSAClientBouncyCastle implements TSAClient {
             if (isNotEmpty(policy)) {
                 tsqGenerator.setReqPolicy(new ASN1ObjectIdentifier(policy));
             }
-            BigInteger nonce = BigInteger.valueOf(System.currentTimeMillis());
-            ASN1ObjectIdentifier digestOid = X509ObjectIdentifiers.id_SHA1;
+            BigInteger nonce = new BigInteger(64, new SecureRandom());
+            ASN1ObjectIdentifier digestOid = NISTObjectIdentifiers.id_sha256;
             if (isNotEmpty(digestName)) {
                 digestOid = new ASN1ObjectIdentifier(PdfPKCS7.getDigestOid(digestName));
             }

--- a/pdf-swing/pom.xml
+++ b/pdf-swing/pom.xml
@@ -23,8 +23,9 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>org.swinglabs</groupId>
-      <artifactId>pdf-renderer</artifactId>
+      <groupId>com.github.librepdf</groupId>
+      <artifactId>openpdf-renderer</artifactId>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>org.dom4j</groupId>

--- a/pdf-swing/src/main/java/org/openpdf/rups/model/PageLoader.java
+++ b/pdf-swing/src/main/java/org/openpdf/rups/model/PageLoader.java
@@ -20,16 +20,16 @@
 
 package org.openpdf.rups.model;
 
-import com.sun.pdfview.PDFFile;
-import com.sun.pdfview.PDFPage;
+import org.openpdf.renderer.PDFFile;
+import org.openpdf.renderer.PDFPage;
 
 /**
- * Loads all the PDFPage objects for SUN's PDF Renderer in Background.
+ * Loads all the PDFPage objects for OpenPDF Renderer in the background.
  */
 public class PageLoader extends BackgroundTask {
 
     /**
-     * The PDFFile (SUN's PDF Renderer class)
+     * The PDFFile from OpenPDF Renderer.
      */
     protected PDFFile file;
     /**
@@ -48,7 +48,7 @@ public class PageLoader extends BackgroundTask {
     /**
      * Creates a new page loader.
      *
-     * @param file the PDFFile (SUN's PDF Renderer)
+     * @param file the PDFFile from OpenPDF Renderer
      */
     public PageLoader(PDFFile file) {
         super();

--- a/pom.xml
+++ b/pom.xml
@@ -93,7 +93,6 @@
     <jakarta.servlet-api.version>6.1.0</jakarta.servlet-api.version>
     <jcommon.version>1.0.24</jcommon.version>
     <jfreechart.version>1.5.6</jfreechart.version>
-    <pdf-renderer.version>1.0.5</pdf-renderer.version>
     <error_prone.version>2.49.0</error_prone.version>
     <slf4j.version>2.0.17</slf4j.version>
 
@@ -136,11 +135,6 @@
         <groupId>org.jfree</groupId>
         <artifactId>jcommon</artifactId>
         <version>${jcommon.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.swinglabs</groupId>
-        <artifactId>pdf-renderer</artifactId>
-        <version>${pdf-renderer.version}</version>
       </dependency>
       <dependency>
         <groupId>org.dom4j</groupId>


### PR DESCRIPTION
## Description of the new Feature/Bugfix

Encryption & signature modernization

- PdfEncryption: document IDs are now generated from SecureRandom (16 bytes) instead of an MD5 hash of time/memory/sequence, removing the last non-spec-mandated MD5 use in the encryption module.
- TSAClientBouncyCastle: default TSA imprint digest changed from SHA-1 to SHA-256, and the RFC 3161 nonce is now a 64-bit SecureRandom value instead of System.currentTimeMillis().
- PdfSignatureAppearance: DocMDP DigestMethod changed from MD5 to SHA256 (PDF 2.0 / ISO 32000-2 disallows MD5).
- PdfPKCS7: added support for SHA3-256 and SHA3-512 (FIPS 202) as signature digest algorithms, both for creation and verification.
- PdfPKCS7: wrapped ASN1InputStream usages in try-with-resources and removed stale "duplicate key" TODO comments that referred to entries in a different map.
- Add initial support for ML-DSA (NIST FIPS 204) post-quantum signatures in PdfPKCS7 via the Bouncy Castle provider (parameter sets ML-DSA-44, ML-DSA-65, ML-DSA-87).


No public API changes, no new tests.

I spent some "research" and innovation time to try improving and modernizing encryption and signature support using AI copilot.

## Your real name
Andreas Røsdal