### PR TITLE
fix: remove dead cmap05 fallback in TrueTypeFont.getMetricsTT (#1553)

### DIFF
--- a/openpdf-core/src/main/java/org/openpdf/text/pdf/TrueTypeFont.java
+++ b/openpdf-core/src/main/java/org/openpdf/text/pdf/TrueTypeFont.java
@@ -1501,9 +1501,6 @@ class TrueTypeFont extends BaseFont {
         if (cmap10 != null) {
             return cmap10.get(c);
         }
-        if (cmap05 != null) {
-            return cmap05.get(c);
-        }
         return null;
     }
 

--- a/openpdf-core/src/test/java/org/openpdf/text/pdf/TrueTypeFontTest.java
+++ b/openpdf-core/src/test/java/org/openpdf/text/pdf/TrueTypeFontTest.java
@@ -2,6 +2,7 @@ package org.openpdf.text.pdf;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.io.IOException;
 import org.junit.jupiter.api.Test;
 
 class TrueTypeFontTest {
@@ -20,5 +21,30 @@ class TrueTypeFontTest {
     @Test
     void testGetTtcName() {
         assertThat(TrueTypeFont.getTTCName("font.ttc,123456")).isEqualTo("font.ttc");
+    }
+
+    /**
+     * Regression test for issue #1553. PR #1482 added a fallback in
+     * {@link TrueTypeFont#getMetricsTT(int)} that called
+     * {@code cmap05.get(c)} where {@code cmap05} is a {@code Map<String, int[]>}
+     * but {@code c} is an {@code int}. The lookup was therefore guaranteed to
+     * miss and was flagged by SpotBugs as {@code GC_UNRELATED_TYPES}. The fix
+     * removes the dead fallback. This test exercises {@code getMetricsTT}
+     * on a TrueType font that loads a format-14 (IVS) {@code cmap05} table
+     * to ensure single-character lookups still resolve via the standard
+     * cmap subtables.
+     */
+    @Test
+    void getMetricsTTResolvesFromStandardCmapWhenCmap05Present() throws IOException {
+        String filename = "src/test/resources/fonts/ivs/Hei_MSCS.ttf";
+        BaseFont baseFont = BaseFont.createFont(filename, BaseFont.IDENTITY_H, BaseFont.NOT_EMBEDDED);
+        assertThat(baseFont).isInstanceOf(TrueTypeFontUnicode.class);
+        TrueTypeFont font = (TrueTypeFont) baseFont;
+        // CJK char '㛇' (U+36C7) is supported by the test font and is reachable
+        // via the standard cmap; the buggy cmap05 fallback (with String keys)
+        // could never satisfy this lookup.
+        int[] metrics = font.getMetricsTT(0x36C7);
+        assertThat(metrics).isNotNull().hasSize(2);
+        assertThat(metrics[1]).isPositive();
     }
 }


### PR DESCRIPTION
## Description of the new Feature/Bugfix

PR #1482 added a final fallback at the end of `TrueTypeFont.getMetricsTT(int c)`:

```java
if (cmap05 != null) {
    return cmap05.get(c);
}
```

`cmap05` is declared `HashMap<String, int[]>` (line 209) and is populated by `readFormat14` with keys built as `char1 + "_" + char2` (see `getFormat14MetricsTT`, line 942). Calling `get(int)` on a `Map<String, ...>` autoboxes to `Integer`, which can never equal any `String` key, so the lookup is guaranteed to return `null`. Eclipse JDT flags this as "Unlikely argument type int for get(Object) on a Map<String,int[]>" and SpotBugs flags it as `GC_UNRELATED_TYPES`.

The block is dead code. Format-14 (IVS) lookups are correctly performed via the two-argument `getFormat14MetricsTT(int, int)`, which builds the proper composite `String` key. Removing the unreachable fallback restores the pre-#1482 behaviour of `getMetricsTT(int)` (return `null` when the standard cmap subtables don't contain the codepoint).

Related Issue: #1553

## Unit-Tests for the new Feature/Bugfix

- [x] Unit-Tests added to reproduce the bug
- [ ] Unit-Tests added to the added feature

`TrueTypeFontTest#getMetricsTTResolvesFromStandardCmapWhenCmap05Present` loads the existing IVS test font `Hei_MSCS.ttf` (which causes `cmap05` to be populated) and asserts that a single-codepoint lookup still resolves through the standard cmap subtables.

## Compatibilities Issues

None. The deleted block was only reached when all of `cmapExt`, `cmap31`, and `cmap10` were `null` and `cmap05` was non-null. In that state, the lookup already returned `null` because of the type mismatch, so the observable behaviour (`return null`) is preserved.

## Your real name
Sai Asish Y

## Testing details

Run `./mvnw -pl openpdf-core test -Dtest=TrueTypeFontTest` (Java 21). On macOS, three pre-existing `FontTest` errors related to `/System/Library/Fonts/Courier.ttc` lacking an `OS/2` table are unrelated to this change and reproduce on master.