### PR TITLE
Replace renderer's in-tree PDF parser with openpdf-core

### DIFF
--- a/openpdf-renderer/README.md
+++ b/openpdf-renderer/README.md
@@ -1,6 +1,6 @@
 # OpenPDF-renderer
 
-OpenPDF-renderer is a pure Java library for rendering PDF files as images using Java2D. It provides a lightweight, dependency-free way to convert PDF pages into BufferedImage objects suitable for display in Swing applications or saving to image files.
+OpenPDF-renderer is a pure Java library for rendering PDF files as images using Java2D. It provides a lightweight way to convert PDF pages into BufferedImage objects suitable for display in Swing applications or saving to image files. Since 3.0.5 it uses `openpdf-core` (`com.github.librepdf:openpdf`) as its PDF parser.
 
 ## Features
 

--- a/openpdf-renderer/README.md
+++ b/openpdf-renderer/README.md
@@ -1,5 +1,4 @@
-OpenPDF-renderer
-============
+# OpenPDF-renderer
 
 OpenPDF-renderer is a pure Java library for rendering PDF files as images using Java2D. It provides a lightweight, dependency-free way to convert PDF pages into BufferedImage objects suitable for display in Swing applications or saving to image files.
 
@@ -148,7 +147,8 @@ try (OpenPdfCoreRenderer renderer = new OpenPdfCoreRenderer(new File("document.p
     var metadata      = renderer.getMetadata();      // unmodifiable Map<String,String>
     String title      = renderer.getMetadata("Title");
     String pageText   = renderer.getTextFromPage(1); // openpdf-core text extraction
-    var operators     = renderer.getContentOperators(1); // List<String>, e.g. [q, BT, Tf, Td, Tj, ET, Q]
+    // List<String>, e.g. [q, BT, Tf, Td, Tj, ET, Q]
+    var operators     = renderer.getContentOperators(1);
 }
 ```
 
@@ -315,7 +315,9 @@ mvn javadoc:javadoc
 - **Encryption**: PDF decryption features have been removed from this module
 - **Page Indexing**: Page numbers are 1-based (first page is index 1, not 0)
 - **Thread Safety**: PDFFile and PDFPage objects are not thread-safe; synchronize access if needed
-- **Deprecated APIs**: `PDFFile`, `PDFPage`, `PDFParser`, and `org.openpdf.renderer.decode.PDFDecoder` are deprecated in favor of `org.openpdf.renderer.core.OpenPdfCoreRenderer`. Existing code continues to work for now &mdash; see the "Migration to openpdf-core parser" section above.
+- **Deprecated APIs**: `PDFFile`, `PDFPage`, `PDFParser`, and `org.openpdf.renderer.decode.PDFDecoder`
+  are deprecated in favor of `org.openpdf.renderer.core.OpenPdfCoreRenderer`.
+  Existing code continues to work for now &mdash; see the "Migration to openpdf-core parser" section above.
 
 ## Supported PDF Features
 

--- a/openpdf-renderer/README.md
+++ b/openpdf-renderer/README.md
@@ -1,6 +1,9 @@
 # OpenPDF-renderer
 
-OpenPDF-renderer is a pure Java library for rendering PDF files as images using Java2D. It provides a lightweight way to convert PDF pages into BufferedImage objects suitable for display in Swing applications or saving to image files. Since 3.0.5 it uses `openpdf-core` (`com.github.librepdf:openpdf`) as its PDF parser.
+OpenPDF-renderer is a pure Java library for rendering PDF files as images using Java2D.
+It provides a lightweight way to convert PDF pages into BufferedImage objects suitable for
+display in Swing applications or saving to image files.
+Since 3.0.5 it uses `openpdf-core` (`com.github.librepdf:openpdf`) as its PDF parser.
 
 ## Features
 

--- a/openpdf-renderer/README.md
+++ b/openpdf-renderer/README.md
@@ -26,9 +26,153 @@ Add OpenPDF Renderer to your project:
 </dependency>
 ```
 
+## Migration to openpdf-core parser
+
+Starting in **3.0.5**, `openpdf-renderer` depends on `openpdf-core`
+(`com.github.librepdf:openpdf`) and exposes a new bridge entry point,
+[`org.openpdf.renderer.core.OpenPdfCoreRenderer`](src/main/java/org/openpdf/renderer/core/OpenPdfCoreRenderer.java),
+which uses `org.openpdf.text.pdf.PdfReader` to parse PDF documents.
+
+The legacy in-tree parser is now `@Deprecated`:
+
+- `org.openpdf.renderer.PDFFile`
+- `org.openpdf.renderer.PDFPage`
+- `org.openpdf.renderer.PDFParser`
+- `org.openpdf.renderer.decode.PDFDecoder`
+
+These classes will remain for at least one release to ease migration and are
+not yet scheduled for removal.
+
+### Why?
+
+- **Consistency** &mdash; identical PDF interpretation between the core library
+  and the renderer.
+- **Maintenance** &mdash; one parser to fix bugs and apply security patches in.
+- **Reliability** &mdash; leverages the battle-tested parsing engine in
+  `openpdf-core`.
+- **Focus** &mdash; rendering development can concentrate on the Java2D / Swing
+  integration rather than re-implementing PDF parsing.
+
+### Recommended new usage
+
+```java
+import org.openpdf.renderer.core.OpenPdfCoreRenderer;
+import javax.imageio.ImageIO;
+import java.awt.geom.Rectangle2D;
+import java.awt.image.BufferedImage;
+import java.io.File;
+import java.util.Map;
+
+try (OpenPdfCoreRenderer renderer = new OpenPdfCoreRenderer(new File("document.pdf"))) {
+    int pages          = renderer.getNumPages();
+    Rectangle2D size   = renderer.getPageSize(1);     // 1-based
+    int rotation       = renderer.getPageRotation(1);
+    Map<String,String> metadata = renderer.getMetadata();
+    String title       = renderer.getMetadata("Title");
+    String pageText    = renderer.getTextFromPage(1);  // openpdf-core text extraction
+
+    BufferedImage img  = renderer.renderPage(1, 150f); // 150 DPI, ARGB
+    ImageIO.write(img, "png", new File("page1.png"));
+}
+```
+
+### Status
+
+`openpdf-renderer` now uses `openpdf-core` for **all** PDF parsing, including
+the per-operator content-stream walking that drives Java2D rasterization. The
+in-tree legacy parser (`PDFFile`, `PDFPage`, `PDFParser`,
+`decode.PDFDecoder`) is no longer used by `OpenPdfCoreRenderer`.
+
+| Capability | Backend |
+|---|---|
+| Open file / `Path` / `InputStream` / `byte[]` | `openpdf-core` (`PdfReader`) |
+| Page count, page size, rotation | `openpdf-core` (`PdfReader`) |
+| Document metadata (`getMetadata`) | `openpdf-core` (`PdfReader#getInfo`) |
+| Page text extraction (`getTextFromPage`) | `openpdf-core` (`PdfTextExtractor`) |
+| Decoded page content stream (`getPageContent`) | `openpdf-core` (`PdfReader#getPageContent`) |
+| Content-stream operator listing (`getContentOperators`) | `openpdf-core` (`PdfContentParser`) |
+| Page rasterization (`renderPage`) | `openpdf-core` (`PdfContentParser`) → Java2D via `OpenPdfCorePageRenderer` |
+
+The Java2D rasterizer (`OpenPdfCorePageRenderer`) supports the standard subset
+of PDF operators needed for typical text + simple-vector PDFs: graphics state
+(`q`/`Q`/`cm`), path construction (`m`/`l`/`c`/`v`/`y`/`re`/`h`), path
+painting (`S`/`s`/`f`/`f*`/`B`/`B*`/`b`/`b*`/`n`), line width (`w`),
+DeviceGray/DeviceRGB colors (`g`/`G`/`rg`/`RG`), and the full text-object
+machinery (`BT`/`ET`/`Tf`/`Tc`/`Tw`/`TL`/`Tz`/`Td`/`TD`/`Tm`/`T*`/`Tj`/`TJ`/`'`/`"`).
+Operators outside this subset (extended graphics state `gs`, CMYK / pattern /
+shading colors, XObject `Do`, inline images, marked content, clipping
+`W`/`W*`, ...) are parsed but currently ignored — pages that rely heavily on
+them may render with missing content. Adding more operators is a localized
+change in `OpenPdfCorePageRenderer`.
+
+For pages that exercise features outside the supported subset and need
+pixel-perfect output today, the deprecated `PDFFile` / `PDFPage.getImage(...)`
+API still works.
+
 ## Quick Start
 
 ### Basic PDF to Image Conversion
+
+`org.openpdf.renderer.core.OpenPdfCoreRenderer` is the recommended entry point.
+It uses `openpdf-core` (`PdfReader`) for parsing and the existing Java2D engine
+for rasterization.
+
+```java
+import org.openpdf.renderer.core.OpenPdfCoreRenderer;
+
+import javax.imageio.ImageIO;
+import java.awt.image.BufferedImage;
+import java.io.File;
+import java.io.IOException;
+
+public class PdfToImageExample {
+
+    public static void main(String[] args) throws IOException {
+        try (OpenPdfCoreRenderer renderer = new OpenPdfCoreRenderer(new File("document.pdf"))) {
+            // Render the first page (1-based) at 150 DPI as TYPE_INT_ARGB.
+            BufferedImage page = renderer.renderPage(1, 150f);
+            ImageIO.write(page, "png", new File("output.png"));
+            System.out.println("PDF page rendered successfully!");
+        }
+    }
+}
+```
+
+### Document inspection
+
+```java
+try (OpenPdfCoreRenderer renderer = new OpenPdfCoreRenderer(new File("document.pdf"))) {
+    int pages         = renderer.getNumPages();
+    var size          = renderer.getPageSize(1);     // 1-based
+    int rotation      = renderer.getPageRotation(1);
+    var metadata      = renderer.getMetadata();      // unmodifiable Map<String,String>
+    String title      = renderer.getMetadata("Title");
+    String pageText   = renderer.getTextFromPage(1); // openpdf-core text extraction
+    var operators     = renderer.getContentOperators(1); // List<String>, e.g. [q, BT, Tf, Td, Tj, ET, Q]
+}
+```
+
+## Using the legacy `PDFFile` / `PDFPage` API (deprecated)
+
+The pre-3.0.5 entry point still works but is now `@Deprecated`. New code should
+prefer `OpenPdfCoreRenderer` (see above). The legacy API is kept for one or
+more releases to ease migration, and may still be useful for pages that
+exercise PDF features outside the supported subset of the new
+`OpenPdfCorePageRenderer` (extended graphics state `gs`, CMYK / pattern /
+shading colors, XObject `Do`, inline images, marked content, clipping, ...),
+since the legacy renderer has broader operator coverage.
+
+The legacy classes live in `org.openpdf.renderer`:
+
+- `org.openpdf.renderer.PDFFile`
+- `org.openpdf.renderer.PDFPage`
+- `org.openpdf.renderer.PDFParser`
+- `org.openpdf.renderer.decode.PDFDecoder`
+
+> ⚠️ Expect deprecation warnings at compile time. These classes are scheduled
+> to be removed in a future major release.
+
+### Legacy: Basic PDF to Image Conversion
 
 ```java
 import org.openpdf.renderer.PDFFile;
@@ -43,25 +187,25 @@ import java.io.RandomAccessFile;
 import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
 
-public class PdfToImageExample {
-    
+public class LegacyPdfToImageExample {
+
     public static void main(String[] args) throws IOException {
         // Load PDF file
         File pdfFile = new File("document.pdf");
         try (RandomAccessFile raf = new RandomAccessFile(pdfFile, "r");
              FileChannel channel = raf.getChannel()) {
-            
+
             ByteBuffer buf = channel.map(FileChannel.MapMode.READ_ONLY, 0, channel.size());
             PDFFile pdf = new PDFFile(buf);
-            
+
             // Get first page (1-based index)
             PDFPage page = pdf.getPage(1);
-            
+
             // Create image from page
             Rectangle rect = new Rectangle(0, 0,
                     (int) page.getBBox().getWidth(),
                     (int) page.getBBox().getHeight());
-            
+
             Image img = page.getImage(
                     rect.width, rect.height,  // image size
                     rect,                      // clip rectangle
@@ -69,21 +213,75 @@ public class PdfToImageExample {
                     true,                      // fill background
                     true                       // block until done
             );
-            
+
             // Convert to BufferedImage and save
             BufferedImage bufferedImage = new BufferedImage(
-                    rect.width, rect.height, 
+                    rect.width, rect.height,
                     BufferedImage.TYPE_INT_ARGB);
             Graphics2D g2 = bufferedImage.createGraphics();
             g2.drawImage(img, 0, 0, null);
             g2.dispose();
-            
+
             ImageIO.write(bufferedImage, "png", new File("output.png"));
             System.out.println("PDF page rendered successfully!");
         }
     }
 }
 ```
+
+### Legacy: Rendering with Custom Resolution
+
+```java
+import org.openpdf.renderer.PDFFile;
+import org.openpdf.renderer.PDFPage;
+
+import java.awt.*;
+import java.awt.image.BufferedImage;
+import java.io.IOException;
+
+public class LegacyHighResolutionRenderingExample {
+
+    public static BufferedImage renderPageAtDPI(PDFFile pdf, int pageNum, int dpi)
+            throws IOException {
+        PDFPage page = pdf.getPage(pageNum);
+
+        // Calculate dimensions at desired DPI (default is 72 DPI)
+        double scale = dpi / 72.0;
+        int width = (int) (page.getBBox().getWidth() * scale);
+        int height = (int) (page.getBBox().getHeight() * scale);
+
+        Rectangle rect = new Rectangle(0, 0, width, height);
+        Image img = page.getImage(width, height, rect, null, true, true);
+
+        // Convert to BufferedImage
+        BufferedImage bufferedImage = new BufferedImage(
+                width, height, BufferedImage.TYPE_INT_RGB);
+        Graphics2D g2 = bufferedImage.createGraphics();
+
+        // Enable antialiasing for better quality
+        g2.setRenderingHint(RenderingHints.KEY_ANTIALIASING,
+                            RenderingHints.VALUE_ANTIALIAS_ON);
+        g2.setRenderingHint(RenderingHints.KEY_TEXT_ANTIALIASING,
+                            RenderingHints.VALUE_TEXT_ANTIALIAS_ON);
+
+        g2.drawImage(img, 0, 0, null);
+        g2.dispose();
+
+        return bufferedImage;
+    }
+}
+```
+
+### Legacy: Migration tips
+
+| Legacy API | Replacement on `OpenPdfCoreRenderer` |
+|---|---|
+| `new PDFFile(ByteBuffer)` | `new OpenPdfCoreRenderer(File \| Path \| InputStream \| byte[])` |
+| `pdf.getNumPages()` | `renderer.getNumPages()` |
+| `pdf.getPage(n).getBBox()` | `renderer.getPageSize(n)` |
+| `page.getImage(w, h, rect, ...)` | `renderer.renderPage(n, dpi)` |
+| Manual DPI scaling via `getBBox()` | Pass `dpi` directly to `renderPage` |
+| (no equivalent) | `renderer.getMetadata()`, `getTextFromPage(n)`, `getContentOperators(n)` |
 
 ## Examples
 
@@ -117,6 +315,7 @@ mvn javadoc:javadoc
 - **Encryption**: PDF decryption features have been removed from this module
 - **Page Indexing**: Page numbers are 1-based (first page is index 1, not 0)
 - **Thread Safety**: PDFFile and PDFPage objects are not thread-safe; synchronize access if needed
+- **Deprecated APIs**: `PDFFile`, `PDFPage`, `PDFParser`, and `org.openpdf.renderer.decode.PDFDecoder` are deprecated in favor of `org.openpdf.renderer.core.OpenPdfCoreRenderer`. Existing code continues to work for now &mdash; see the "Migration to openpdf-core parser" section above.
 
 ## Supported PDF Features
 
@@ -166,49 +365,23 @@ Solution: Increase JVM heap size with -Xmx flag (e.g., -Xmx2g)
 ### Advanced: Rendering with Custom Resolution
 
 ```java
-import org.openpdf.renderer.PDFFile;
-import org.openpdf.renderer.PDFPage;
+import org.openpdf.renderer.core.OpenPdfCoreRenderer;
 
-import java.awt.*;
+import javax.imageio.ImageIO;
 import java.awt.image.BufferedImage;
 import java.io.File;
-import java.io.IOException;
-import java.io.RandomAccessFile;
-import java.nio.ByteBuffer;
-import java.nio.channels.FileChannel;
 
-public class HighResolutionRenderingExample {
-    
-    public static BufferedImage renderPageAtDPI(PDFFile pdf, int pageNum, int dpi) 
-            throws IOException {
-        PDFPage page = pdf.getPage(pageNum);
-        
-        // Calculate dimensions at desired DPI (default is 72 DPI)
-        double scale = dpi / 72.0;
-        int width = (int) (page.getBBox().getWidth() * scale);
-        int height = (int) (page.getBBox().getHeight() * scale);
-        
-        Rectangle rect = new Rectangle(0, 0, width, height);
-        Image img = page.getImage(width, height, rect, null, true, true);
-        
-        // Convert to BufferedImage
-        BufferedImage bufferedImage = new BufferedImage(
-                width, height, BufferedImage.TYPE_INT_RGB);
-        Graphics2D g2 = bufferedImage.createGraphics();
-        
-        // Enable antialiasing for better quality
-        g2.setRenderingHint(RenderingHints.KEY_ANTIALIASING, 
-                            RenderingHints.VALUE_ANTIALIAS_ON);
-        g2.setRenderingHint(RenderingHints.KEY_TEXT_ANTIALIASING, 
-                            RenderingHints.VALUE_TEXT_ANTIALIAS_ON);
-        
-        g2.drawImage(img, 0, 0, null);
-        g2.dispose();
-        
-        return bufferedImage;
+try (OpenPdfCoreRenderer renderer = new OpenPdfCoreRenderer(new File("document.pdf"))) {
+    for (int i = 1; i <= renderer.getNumPages(); i++) {
+        BufferedImage img = renderer.renderPage(i, 300f); // 300 DPI
+        ImageIO.write(img, "png", new File("page-" + i + ".png"));
     }
 }
 ```
+
+The returned image is a `BufferedImage` of type `TYPE_INT_ARGB` whose dimensions
+are the page size (in PDF user space units, i.e. 1/72 inch) scaled by
+`dpi / 72`. Antialiasing for shapes and text is enabled by default.
 
 ## License
 

--- a/openpdf-renderer/pom.xml
+++ b/openpdf-renderer/pom.xml
@@ -101,6 +101,13 @@
 	</build>
 
   <dependencies>
+    <!-- Core PDF parser: replaces the legacy in-tree parser (PDFFile / PDFParser / PDFDecoder). -->
+    <dependency>
+      <groupId>com.github.librepdf</groupId>
+      <artifactId>openpdf</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
     <!-- Test dependencies -->
     <dependency>
       <groupId>org.junit.jupiter</groupId>

--- a/openpdf-renderer/src/main/java/org/openpdf/renderer/PDFFile.java
+++ b/openpdf-renderer/src/main/java/org/openpdf/renderer/PDFFile.java
@@ -49,7 +49,14 @@ import org.openpdf.renderer.decrypt.UnsupportedEncryptionException;
  * a new PDFFile, ask it for the number of pages, and then
  * request one or more PDFPages.
  * @author Mike Wessler
+ *
+ * @deprecated since 3.0.5. The in-tree PDF parser is being replaced by
+ * {@code openpdf-core} ({@link org.openpdf.text.pdf.PdfReader}). Use
+ * {@link org.openpdf.renderer.core.OpenPdfCoreRenderer} instead. This class
+ * will remain for at least one release to ease migration; it is not yet
+ * scheduled for removal.
  */
+@Deprecated
 public class PDFFile {
 
     public final static int             NUL_CHAR = 0;

--- a/openpdf-renderer/src/main/java/org/openpdf/renderer/PDFPage.java
+++ b/openpdf-renderer/src/main/java/org/openpdf/renderer/PDFPage.java
@@ -49,7 +49,14 @@ import org.openpdf.renderer.annotation.PDFAnnotation;
 * classes.
 *
 * @author Mike Wessler
+*
+* @deprecated since 3.0.5. The in-tree PDF parser is being replaced by
+* {@code openpdf-core} ({@link org.openpdf.text.pdf.PdfReader}). Use
+* {@link org.openpdf.renderer.core.OpenPdfCoreRenderer} instead. This class
+* will remain for at least one release to ease migration; it is not yet
+* scheduled for removal.
 */
+@Deprecated
 public class PDFPage {
     /**
     * the array of commands. The length of this array will always

--- a/openpdf-renderer/src/main/java/org/openpdf/renderer/PDFParser.java
+++ b/openpdf-renderer/src/main/java/org/openpdf/renderer/PDFParser.java
@@ -46,7 +46,15 @@ import org.openpdf.renderer.colorspace.PatternSpace;
 * its own thread.
 *
 * @author Mike Wessler
+*
+* @deprecated since 3.0.5. The in-tree PDF parser is being replaced by
+* {@code openpdf-core} ({@link org.openpdf.text.pdf.PdfReader} and
+* {@code org.openpdf.text.pdf.parser.PdfContentStreamHandler}). Use
+* {@link org.openpdf.renderer.core.OpenPdfCoreRenderer} instead. This class
+* will remain for at least one release to ease migration; it is not yet
+* scheduled for removal.
 */
+@Deprecated
 public class PDFParser extends BaseWatchable {
     private int mDebugCommandIndex;
     // ---- parsing variables

--- a/openpdf-renderer/src/main/java/org/openpdf/renderer/core/OpenPdfCorePageRenderer.java
+++ b/openpdf-renderer/src/main/java/org/openpdf/renderer/core/OpenPdfCorePageRenderer.java
@@ -86,12 +86,19 @@ final class OpenPdfCorePageRenderer {
     private GState state;
 
     private Path2D.Float currentPath = new Path2D.Float();
+    // These fields maintain path state across consecutive dispatch() calls and cannot be local.
+    @SuppressWarnings("PMD.SingularField")
     private float pathStartX;
+    @SuppressWarnings("PMD.SingularField")
     private float pathStartY;
+    @SuppressWarnings("PMD.SingularField")
     private float pathCurX;
+    @SuppressWarnings("PMD.SingularField")
     private float pathCurY;
 
-    /** Text object state (between {@code BT} and {@code ET}). */
+    /**
+     * Text object state (between {@code BT} and {@code ET}).
+     */
     private boolean inTextObject;
     private AffineTransform textMatrix;
     private AffineTransform textLineMatrix;

--- a/openpdf-renderer/src/main/java/org/openpdf/renderer/core/OpenPdfCorePageRenderer.java
+++ b/openpdf-renderer/src/main/java/org/openpdf/renderer/core/OpenPdfCorePageRenderer.java
@@ -469,10 +469,10 @@ final class OpenPdfCorePageRenderer {
             g2.setTransform(saved);
         }
 
-        // Advance text matrix by the displayed width so following Tj's continue inline.
-        float displayed = estimateTextAdvance(text);
+        // Advance text matrix using actual PDF font widths + char/word spacing.
+        float advance = computeTextAdvance(text);
         AffineTransform adv = new AffineTransform(textMatrix);
-        adv.translate(displayed, 0);
+        adv.translate(advance, 0);
         textMatrix = adv;
     }
 
@@ -503,10 +503,24 @@ final class OpenPdfCorePageRenderer {
         return raw.toUnicodeString();
     }
 
-    private float estimateTextAdvance(String text) {
-        // We don't have access to per-glyph widths from CMapAwareDocumentFont in a
-        // package-public way, so fall back to a Java2D measurement at the current font.
-        return (float) g2.getFontMetrics().getStringBounds(text, g2).getWidth();
+    private float computeTextAdvance(String text) {
+        float fontAdvance;
+        if (state.font != null) {
+            // Use the PDF font's own width table so inter-character spacing is accurate.
+            fontAdvance = state.font.getWidthPoint(text, state.fontSize);
+        } else {
+            // No PDF font info: fall back to Java2D measurement (less accurate).
+            return (float) g2.getFontMetrics().getStringBounds(text, g2).getWidth();
+        }
+        int spaces = 0;
+        for (int i = 0; i < text.length(); i++) {
+            if (text.charAt(i) == ' ') {
+                spaces++;
+            }
+        }
+        // PDF spec: tx = (fontWidth + Tc * n + Tw * spaces) * Th
+        return (fontAdvance + state.charSpacing * text.length() + state.wordSpacing * spaces)
+                * state.horizontalScaling;
     }
 
     private Font mapFont(CMapAwareDocumentFont docFont, float size) {
@@ -612,6 +626,4 @@ final class OpenPdfCorePageRenderer {
         }
     }
 }
-
-
 

--- a/openpdf-renderer/src/main/java/org/openpdf/renderer/core/OpenPdfCorePageRenderer.java
+++ b/openpdf-renderer/src/main/java/org/openpdf/renderer/core/OpenPdfCorePageRenderer.java
@@ -23,6 +23,8 @@ import java.util.Deque;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 import org.openpdf.text.pdf.CMapAwareDocumentFont;
 import org.openpdf.text.pdf.PRIndirectReference;
@@ -75,6 +77,8 @@ import org.openpdf.text.pdf.PdfString;
  */
 final class OpenPdfCorePageRenderer {
 
+    private static final Logger LOG = Logger.getLogger(OpenPdfCorePageRenderer.class.getName());
+
     /** Default user-space resolution of a PDF, in DPI. */
     private static final float PDF_USER_SPACE_DPI = 72f;
 
@@ -83,6 +87,7 @@ final class OpenPdfCorePageRenderer {
     private final Map<String, CMapAwareDocumentFont> fontCache = new HashMap<>();
 
     private final Deque<GState> stateStack = new ArrayDeque<>();
+    private final Deque<AffineTransform> ctmStack = new ArrayDeque<>();
     private GState state;
 
     private Path2D.Float currentPath = new Path2D.Float();
@@ -185,8 +190,10 @@ final class OpenPdfCorePageRenderer {
             PdfLiteral op = (PdfLiteral) operands.get(operands.size() - 1);
             try {
                 dispatch(op.toString(), operands);
-            } catch (RuntimeException ignored) {
-                // Robustness: a malformed individual operator must not abort the whole page.
+            } catch (RuntimeException e) {
+                // A malformed operator must not abort the whole page; log for diagnostics.
+                LOG.log(Level.FINE, "Skipping operator ''{0}'' due to: {1}",
+                        new Object[]{op, e});
             }
         }
     }
@@ -197,11 +204,13 @@ final class OpenPdfCorePageRenderer {
             // --- Graphics state ---
             case "q":
                 stateStack.push(state);
+                ctmStack.push(g2.getTransform());
                 state = new GState(state);
                 break;
             case "Q":
                 if (!stateStack.isEmpty()) {
                     state = stateStack.pop();
+                    g2.setTransform(ctmStack.pop());
                 }
                 break;
             case "cm":
@@ -485,9 +494,10 @@ final class OpenPdfCorePageRenderer {
     private String decodeString(PdfString raw) {
         if (state.font != null) {
             try {
-                return state.font.decode(raw.getBytes(), 0, raw.getBytes().length);
+                byte[] bytes = raw.getBytes();
+                return state.font.decode(bytes, 0, bytes.length);
             } catch (RuntimeException ignored) {
-                // Fall through.
+                // Fall through to unicode fallback.
             }
         }
         return raw.toUnicodeString();

--- a/openpdf-renderer/src/main/java/org/openpdf/renderer/core/OpenPdfCorePageRenderer.java
+++ b/openpdf-renderer/src/main/java/org/openpdf/renderer/core/OpenPdfCorePageRenderer.java
@@ -1,0 +1,600 @@
+/*
+ * Copyright 2026 the OpenPDF contributors.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ */
+package org.openpdf.renderer.core;
+
+import java.awt.AlphaComposite;
+import java.awt.BasicStroke;
+import java.awt.Color;
+import java.awt.Font;
+import java.awt.Graphics2D;
+import java.awt.RenderingHints;
+import java.awt.geom.AffineTransform;
+import java.awt.geom.Path2D;
+import java.io.IOException;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.openpdf.text.pdf.CMapAwareDocumentFont;
+import org.openpdf.text.pdf.PRIndirectReference;
+import org.openpdf.text.pdf.PRTokeniser;
+import org.openpdf.text.pdf.PdfArray;
+import org.openpdf.text.pdf.PdfContentParser;
+import org.openpdf.text.pdf.PdfDictionary;
+import org.openpdf.text.pdf.PdfLiteral;
+import org.openpdf.text.pdf.PdfName;
+import org.openpdf.text.pdf.PdfNumber;
+import org.openpdf.text.pdf.PdfObject;
+import org.openpdf.text.pdf.PdfReader;
+import org.openpdf.text.pdf.PdfString;
+
+/**
+ * Renders a single PDF page to a {@link Graphics2D} surface, parsing the page's
+ * content stream with {@code openpdf-core}'s {@link PdfContentParser} and
+ * dispatching the resulting operators to Java2D drawing calls.
+ *
+ * <p>This is the {@code openpdf-core}-driven Java2D rasterizer that backs
+ * {@link OpenPdfCoreRenderer#renderPage(int, float)}.</p>
+ *
+ * <h2>Supported operator subset</h2>
+ * <ul>
+ *   <li>Graphics state: {@code q}, {@code Q}, {@code cm}</li>
+ *   <li>Path construction: {@code m}, {@code l}, {@code c}, {@code v}, {@code y},
+ *       {@code re}, {@code h}</li>
+ *   <li>Path painting: {@code S}, {@code s}, {@code f}, {@code F}, {@code f*},
+ *       {@code B}, {@code B*}, {@code b}, {@code b*}, {@code n}</li>
+ *   <li>Line width: {@code w}</li>
+ *   <li>Colors (DeviceGray and DeviceRGB): {@code g}, {@code G}, {@code rg}, {@code RG}</li>
+ *   <li>Text state: {@code BT}, {@code ET}, {@code Tf}, {@code Tc}, {@code Tw},
+ *       {@code TL}, {@code Tz}, {@code Td}, {@code TD}, {@code Tm}, {@code T*}</li>
+ *   <li>Text showing: {@code Tj}, {@code TJ}, {@code '}, {@code "}</li>
+ * </ul>
+ *
+ * <p>Other operators (extended graphics state {@code gs}, CMYK colors,
+ * {@code cs}/{@code CS}/{@code scn}/{@code SCN}, clipping {@code W}/{@code W*},
+ * XObject {@code Do}, inline images, shading patterns, marked content, ...)
+ * are silently ignored. Pages that rely heavily on those features may render
+ * with missing content; this renderer is intentionally a focused subset that
+ * handles typical text + simple-vector PDFs correctly.</p>
+ *
+ * <h2>Coordinates</h2>
+ * <p>The PDF user space has its origin at the bottom-left and Y growing up;
+ * the {@link Graphics2D} target has its origin at the top-left and Y growing
+ * down. The renderer applies an initial transform that flips Y and scales
+ * by {@code dpi / 72} so that calling code receives a correctly-oriented
+ * image of the requested resolution.</p>
+ */
+final class OpenPdfCorePageRenderer {
+
+    /** Default user-space resolution of a PDF, in DPI. */
+    private static final float PDF_USER_SPACE_DPI = 72f;
+
+    private final Graphics2D g2;
+    private final PdfDictionary resources;
+    private final Map<String, CMapAwareDocumentFont> fontCache = new HashMap<>();
+
+    private final Deque<GState> stateStack = new ArrayDeque<>();
+    private GState state;
+
+    private Path2D.Float currentPath = new Path2D.Float();
+    private float pathStartX;
+    private float pathStartY;
+    private float pathCurX;
+    private float pathCurY;
+
+    /** Text object state (between {@code BT} and {@code ET}). */
+    private boolean inTextObject;
+    private AffineTransform textMatrix;
+    private AffineTransform textLineMatrix;
+
+    private OpenPdfCorePageRenderer(Graphics2D g2, PdfDictionary resources) {
+        this.g2 = g2;
+        this.resources = resources;
+        this.state = new GState();
+    }
+
+    /**
+     * Renders the given page to {@code g2}, sized to {@code targetWidth x targetHeight}
+     * pixels at the requested DPI.
+     *
+     * @param reader       the open PDF
+     * @param pageNumber   1-based page number
+     * @param g2           the destination graphics; will be transformed
+     * @param targetWidth  destination width in pixels
+     * @param targetHeight destination height in pixels
+     * @param dpi          target resolution
+     * @throws IOException if the page content cannot be read
+     */
+    static void render(PdfReader reader, int pageNumber, Graphics2D g2,
+            int targetWidth, int targetHeight, float dpi) throws IOException {
+
+        PdfDictionary pageDict = reader.getPageN(pageNumber);
+        PdfDictionary resources = pageDict == null ? null : pageDict.getAsDict(PdfName.RESOURCES);
+
+        // Background: opaque white, matching legacy behavior.
+        g2.setComposite(AlphaComposite.SrcOver);
+        g2.setColor(Color.WHITE);
+        g2.fillRect(0, 0, targetWidth, targetHeight);
+        g2.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
+        g2.setRenderingHint(RenderingHints.KEY_TEXT_ANTIALIASING,
+                RenderingHints.VALUE_TEXT_ANTIALIAS_ON);
+        g2.setRenderingHint(RenderingHints.KEY_FRACTIONALMETRICS,
+                RenderingHints.VALUE_FRACTIONALMETRICS_ON);
+
+        // Map PDF user space (origin bottom-left, Y up) to image pixels (origin top-left, Y down),
+        // applying page rotation and DPI scaling.
+        org.openpdf.text.Rectangle pageSize = reader.getPageSizeWithRotation(pageNumber);
+        float scale = dpi / PDF_USER_SPACE_DPI;
+        int rotation = reader.getPageRotation(pageNumber) % 360;
+        if (rotation < 0) {
+            rotation += 360;
+        }
+
+        AffineTransform initial = new AffineTransform();
+        initial.scale(scale, scale);
+        // Place origin at bottom-left of the (rotated) page and flip Y so that
+        // PDF user space (Y up) maps onto image pixel space (Y down).
+        switch (rotation) {
+            case 90:
+                initial.translate(pageSize.getHeight(), pageSize.getWidth());
+                initial.scale(1, -1);
+                initial.rotate(Math.toRadians(90));
+                break;
+            case 180:
+                initial.translate(pageSize.getWidth(), 0);
+                initial.scale(-1, 1);
+                initial.translate(0, pageSize.getHeight());
+                initial.scale(1, -1);
+                break;
+            case 270:
+                initial.rotate(Math.toRadians(-90));
+                initial.scale(1, -1);
+                break;
+            case 0:
+            default:
+                initial.translate(0, pageSize.getHeight());
+                initial.scale(1, -1);
+                break;
+        }
+        g2.transform(initial);
+
+        OpenPdfCorePageRenderer renderer = new OpenPdfCorePageRenderer(g2, resources);
+        renderer.processContent(reader.getPageContent(pageNumber));
+    }
+
+    private void processContent(byte[] contentBytes) throws IOException {
+        PdfContentParser parser = new PdfContentParser(new PRTokeniser(contentBytes));
+        List<PdfObject> operands = new ArrayList<>();
+        while (!parser.parse(operands).isEmpty()) {
+            PdfLiteral op = (PdfLiteral) operands.get(operands.size() - 1);
+            try {
+                dispatch(op.toString(), operands);
+            } catch (RuntimeException ignored) {
+                // Robustness: a malformed individual operator must not abort the whole page.
+            }
+        }
+    }
+
+    /** Dispatches one operator. Operands include the trailing operator literal at index size-1. */
+    private void dispatch(String op, List<PdfObject> operands) throws IOException {
+        switch (op) {
+            // --- Graphics state ---
+            case "q":
+                stateStack.push(state);
+                state = new GState(state);
+                break;
+            case "Q":
+                if (!stateStack.isEmpty()) {
+                    state = stateStack.pop();
+                }
+                break;
+            case "cm":
+                concatCtm(num(operands, 0), num(operands, 1), num(operands, 2),
+                        num(operands, 3), num(operands, 4), num(operands, 5));
+                break;
+
+            // --- Line width ---
+            case "w":
+                state.lineWidth = num(operands, 0);
+                break;
+
+            // --- Colors ---
+            case "g":
+                state.fillColor = gray(num(operands, 0));
+                break;
+            case "G":
+                state.strokeColor = gray(num(operands, 0));
+                break;
+            case "rg":
+                state.fillColor = rgb(num(operands, 0), num(operands, 1), num(operands, 2));
+                break;
+            case "RG":
+                state.strokeColor = rgb(num(operands, 0), num(operands, 1), num(operands, 2));
+                break;
+
+            // --- Path construction ---
+            case "m":
+                pathCurX = num(operands, 0);
+                pathCurY = num(operands, 1);
+                pathStartX = pathCurX;
+                pathStartY = pathCurY;
+                currentPath.moveTo(pathCurX, pathCurY);
+                break;
+            case "l":
+                pathCurX = num(operands, 0);
+                pathCurY = num(operands, 1);
+                currentPath.lineTo(pathCurX, pathCurY);
+                break;
+            case "c":
+                currentPath.curveTo(num(operands, 0), num(operands, 1),
+                        num(operands, 2), num(operands, 3),
+                        num(operands, 4), num(operands, 5));
+                pathCurX = num(operands, 4);
+                pathCurY = num(operands, 5);
+                break;
+            case "v":
+                currentPath.curveTo(pathCurX, pathCurY,
+                        num(operands, 0), num(operands, 1),
+                        num(operands, 2), num(operands, 3));
+                pathCurX = num(operands, 2);
+                pathCurY = num(operands, 3);
+                break;
+            case "y":
+                currentPath.curveTo(num(operands, 0), num(operands, 1),
+                        num(operands, 2), num(operands, 3),
+                        num(operands, 2), num(operands, 3));
+                pathCurX = num(operands, 2);
+                pathCurY = num(operands, 3);
+                break;
+            case "re": {
+                float x = num(operands, 0);
+                float y = num(operands, 1);
+                float w = num(operands, 2);
+                float h = num(operands, 3);
+                currentPath.moveTo(x, y);
+                currentPath.lineTo(x + w, y);
+                currentPath.lineTo(x + w, y + h);
+                currentPath.lineTo(x, y + h);
+                currentPath.closePath();
+                pathStartX = x;
+                pathStartY = y;
+                pathCurX = x;
+                pathCurY = y;
+                break;
+            }
+            case "h":
+                currentPath.closePath();
+                pathCurX = pathStartX;
+                pathCurY = pathStartY;
+                break;
+
+            // --- Path painting ---
+            case "S":
+                strokePath();
+                resetPath();
+                break;
+            case "s":
+                currentPath.closePath();
+                strokePath();
+                resetPath();
+                break;
+            case "f":
+            case "F":
+                fillPath(Path2D.WIND_NON_ZERO);
+                resetPath();
+                break;
+            case "f*":
+                fillPath(Path2D.WIND_EVEN_ODD);
+                resetPath();
+                break;
+            case "B":
+                fillPath(Path2D.WIND_NON_ZERO);
+                strokePath();
+                resetPath();
+                break;
+            case "B*":
+                fillPath(Path2D.WIND_EVEN_ODD);
+                strokePath();
+                resetPath();
+                break;
+            case "b":
+                currentPath.closePath();
+                fillPath(Path2D.WIND_NON_ZERO);
+                strokePath();
+                resetPath();
+                break;
+            case "b*":
+                currentPath.closePath();
+                fillPath(Path2D.WIND_EVEN_ODD);
+                strokePath();
+                resetPath();
+                break;
+            case "n":
+                resetPath();
+                break;
+
+            // --- Text state ---
+            case "BT":
+                inTextObject = true;
+                textMatrix = new AffineTransform();
+                textLineMatrix = new AffineTransform();
+                break;
+            case "ET":
+                inTextObject = false;
+                textMatrix = null;
+                textLineMatrix = null;
+                break;
+            case "Tf": {
+                PdfObject nameOperand = operands.get(0);
+                if (nameOperand instanceof PdfName name) {
+                    String fontKey = name.toString().substring(1); // strip leading '/'
+                    state.font = lookupFont(fontKey);
+                }
+                state.fontSize = num(operands, 1);
+                break;
+            }
+            case "Tc":
+                state.charSpacing = num(operands, 0);
+                break;
+            case "Tw":
+                state.wordSpacing = num(operands, 0);
+                break;
+            case "TL":
+                state.leading = num(operands, 0);
+                break;
+            case "Tz":
+                state.horizontalScaling = num(operands, 0) / 100f;
+                break;
+            case "Td":
+                textMoveTo(num(operands, 0), num(operands, 1));
+                break;
+            case "TD":
+                state.leading = -num(operands, 1);
+                textMoveTo(num(operands, 0), num(operands, 1));
+                break;
+            case "Tm":
+                if (textMatrix != null) {
+                    textMatrix.setTransform(num(operands, 0), num(operands, 1),
+                            num(operands, 2), num(operands, 3),
+                            num(operands, 4), num(operands, 5));
+                    textLineMatrix.setTransform(textMatrix);
+                }
+                break;
+            case "T*":
+                textMoveTo(0, -state.leading);
+                break;
+
+            // --- Text showing ---
+            case "Tj":
+                showText(decodeString((PdfString) operands.get(0)));
+                break;
+            case "TJ":
+                showTextArray((PdfArray) operands.get(0));
+                break;
+            case "'":
+                textMoveTo(0, -state.leading);
+                showText(decodeString((PdfString) operands.get(0)));
+                break;
+            case "\"":
+                state.wordSpacing = num(operands, 0);
+                state.charSpacing = num(operands, 1);
+                textMoveTo(0, -state.leading);
+                showText(decodeString((PdfString) operands.get(2)));
+                break;
+
+            default:
+                // Unsupported operator: ignore quietly so partial pages still render.
+                break;
+        }
+    }
+
+    // ---------- Path painting helpers ----------
+
+    private void strokePath() {
+        g2.setColor(state.strokeColor);
+        g2.setStroke(new BasicStroke(Math.max(state.lineWidth, 0.001f)));
+        g2.draw(currentPath);
+    }
+
+    private void fillPath(int windingRule) {
+        Path2D.Float p = (Path2D.Float) currentPath.clone();
+        p.setWindingRule(windingRule);
+        g2.setColor(state.fillColor);
+        g2.fill(p);
+    }
+
+    private void resetPath() {
+        currentPath = new Path2D.Float();
+    }
+
+    private void concatCtm(float a, float b, float c, float d, float e, float f) {
+        AffineTransform m = new AffineTransform(a, b, c, d, e, f);
+        g2.transform(m);
+    }
+
+    // ---------- Text helpers ----------
+
+    private void textMoveTo(float tx, float ty) {
+        if (textLineMatrix == null) {
+            return;
+        }
+        AffineTransform m = new AffineTransform(textLineMatrix);
+        m.translate(tx, ty);
+        textLineMatrix = m;
+        textMatrix = new AffineTransform(m);
+    }
+
+    private void showText(String text) {
+        if (!inTextObject || text == null || text.isEmpty()) {
+            return;
+        }
+        Font awtFont = mapFont(state.font, state.fontSize);
+        g2.setFont(awtFont);
+        g2.setColor(state.fillColor);
+
+        AffineTransform saved = g2.getTransform();
+        try {
+            // Text matrix maps text-space to user space; we then need a Y-flip
+            // because Graphics2D's font baseline is drawn in image-Y orientation.
+            g2.transform(textMatrix);
+            g2.scale(state.horizontalScaling, 1.0);
+            g2.scale(1, -1);
+            g2.drawString(text, 0f, 0f);
+        } finally {
+            g2.setTransform(saved);
+        }
+
+        // Advance text matrix by the displayed width so following Tj's continue inline.
+        float displayed = estimateTextAdvance(text);
+        AffineTransform adv = new AffineTransform(textMatrix);
+        adv.translate(displayed, 0);
+        textMatrix = adv;
+    }
+
+    private void showTextArray(PdfArray array) {
+        for (PdfObject obj : array.getElements()) {
+            if (obj instanceof PdfString s) {
+                showText(decodeString(s));
+            } else if (obj instanceof PdfNumber n) {
+                // Negative number = leftward shift in thousandths of font size.
+                float adj = n.floatValue();
+                float shift = -adj / 1000f * state.fontSize * state.horizontalScaling;
+                AffineTransform m = new AffineTransform(textMatrix);
+                m.translate(shift, 0);
+                textMatrix = m;
+            }
+        }
+    }
+
+    private String decodeString(PdfString raw) {
+        if (state.font != null) {
+            try {
+                return state.font.decode(raw.getBytes(), 0, raw.getBytes().length);
+            } catch (RuntimeException ignored) {
+                // Fall through.
+            }
+        }
+        return raw.toUnicodeString();
+    }
+
+    private float estimateTextAdvance(String text) {
+        // We don't have access to per-glyph widths from CMapAwareDocumentFont in a
+        // package-public way, so fall back to a Java2D measurement at the current font.
+        return (float) g2.getFontMetrics().getStringBounds(text, g2).getWidth();
+    }
+
+    private Font mapFont(CMapAwareDocumentFont docFont, float size) {
+        String family = Font.SERIF;
+        int style = Font.PLAIN;
+        if (docFont != null) {
+            String name = docFont.getPostscriptFontName();
+            if (name != null) {
+                String lower = name.toLowerCase();
+                if (lower.contains("mono") || lower.contains("courier")) {
+                    family = Font.MONOSPACED;
+                } else if (lower.contains("sans") || lower.contains("helvetica")
+                        || lower.contains("arial")) {
+                    family = Font.SANS_SERIF;
+                }
+                if (lower.contains("bold")) {
+                    style |= Font.BOLD;
+                }
+                if (lower.contains("italic") || lower.contains("oblique")) {
+                    style |= Font.ITALIC;
+                }
+            }
+        }
+        return new Font(family, style, 1).deriveFont(Math.max(size, 0.1f));
+    }
+
+    private CMapAwareDocumentFont lookupFont(String name) {
+        if (resources == null) {
+            return null;
+        }
+        CMapAwareDocumentFont cached = fontCache.get(name);
+        if (cached != null) {
+            return cached;
+        }
+        PdfDictionary fontDict = resources.getAsDict(PdfName.FONT);
+        if (fontDict == null) {
+            return null;
+        }
+        PdfObject ref = fontDict.get(new PdfName(name));
+        if (!(ref instanceof PRIndirectReference indirect)) {
+            return null;
+        }
+        try {
+            CMapAwareDocumentFont font = new CMapAwareDocumentFont(indirect);
+            fontCache.put(name, font);
+            return font;
+        } catch (RuntimeException ignored) {
+            return null;
+        }
+    }
+
+    // ---------- Operand helpers ----------
+
+    private static float num(List<PdfObject> operands, int index) {
+        return ((PdfNumber) operands.get(index)).floatValue();
+    }
+
+    private static Color gray(float v) {
+        float c = clamp01(v);
+        return new Color(c, c, c);
+    }
+
+    private static Color rgb(float r, float g, float b) {
+        return new Color(clamp01(r), clamp01(g), clamp01(b));
+    }
+
+    private static float clamp01(float v) {
+        if (v < 0f) {
+            return 0f;
+        }
+        if (v > 1f) {
+            return 1f;
+        }
+        return v;
+    }
+
+    /** Mutable per-graphics-state snapshot. Not thread-safe. */
+    private static final class GState {
+        Color fillColor = Color.BLACK;
+        Color strokeColor = Color.BLACK;
+        float lineWidth = 1.0f;
+
+        CMapAwareDocumentFont font;
+        float fontSize;
+        float charSpacing;
+        float wordSpacing;
+        float leading;
+        float horizontalScaling = 1.0f;
+
+        GState() {
+        }
+
+        GState(GState other) {
+            this.fillColor = other.fillColor;
+            this.strokeColor = other.strokeColor;
+            this.lineWidth = other.lineWidth;
+            this.font = other.font;
+            this.fontSize = other.fontSize;
+            this.charSpacing = other.charSpacing;
+            this.wordSpacing = other.wordSpacing;
+            this.leading = other.leading;
+            this.horizontalScaling = other.horizontalScaling;
+        }
+    }
+}
+
+
+

--- a/openpdf-renderer/src/main/java/org/openpdf/renderer/core/OpenPdfCoreRenderer.java
+++ b/openpdf-renderer/src/main/java/org/openpdf/renderer/core/OpenPdfCoreRenderer.java
@@ -1,0 +1,309 @@
+/*
+ * Copyright 2026 the OpenPDF contributors.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ */
+package org.openpdf.renderer.core;
+
+import java.awt.Graphics2D;
+import java.awt.geom.Rectangle2D;
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayOutputStream;
+import java.io.Closeable;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import org.openpdf.text.pdf.PdfContentParser;
+import org.openpdf.text.pdf.PdfLiteral;
+import org.openpdf.text.pdf.PdfObject;
+import org.openpdf.text.pdf.PdfReader;
+import org.openpdf.text.pdf.PRTokeniser;
+import org.openpdf.text.pdf.parser.PdfTextExtractor;
+
+/**
+ * Bridge entry point that uses {@code openpdf-core} ({@link PdfReader}) as the
+ * underlying PDF parser <em>and</em> as the source of operators driving Java2D
+ * rendering for the renderer module.
+ *
+ * <p>This class is the recommended replacement for the legacy in-tree parser
+ * stack made up of {@link org.openpdf.renderer.PDFFile PDFFile},
+ * {@link org.openpdf.renderer.PDFPage PDFPage},
+ * {@link org.openpdf.renderer.PDFParser PDFParser} and
+ * {@link org.openpdf.renderer.decode.PDFDecoder PDFDecoder}, which are all
+ * deprecated as of 3.0.5.</p>
+ *
+ * <h2>Implementation</h2>
+ * <p>All public methods are now backed entirely by {@code openpdf-core}:</p>
+ * <ul>
+ *   <li>Document open / page count / page geometry: {@link PdfReader}.</li>
+ *   <li>Document metadata: {@link PdfReader#getInfo()}.</li>
+ *   <li>Page text extraction: {@link PdfTextExtractor}.</li>
+ *   <li>Decoded page content stream: {@link PdfReader#getPageContent(int)}.</li>
+ *   <li>Content-stream operator listing: {@link PdfContentParser}.</li>
+ *   <li>Page rasterization: {@link OpenPdfCorePageRenderer}, which parses the
+ *       page content stream with {@link PdfContentParser} and dispatches PDF
+ *       operators directly to a {@link Graphics2D}.</li>
+ * </ul>
+ *
+ * <p>The legacy in-tree parser is no longer used by this class.</p>
+ *
+ * <h2>Usage</h2>
+ * <pre>{@code
+ * try (OpenPdfCoreRenderer renderer = new OpenPdfCoreRenderer(new File("document.pdf"))) {
+ *     int pages = renderer.getNumPages();
+ *     String title = renderer.getMetadata("Title");
+ *     String text  = renderer.getTextFromPage(1);
+ *     BufferedImage img = renderer.renderPage(1, 150f); // 150 DPI
+ * }
+ * }</pre>
+ *
+ * <p>Page numbers are <strong>1-based</strong>. Instances are not thread-safe.</p>
+ *
+ * @since 3.0.5
+ */
+public class OpenPdfCoreRenderer implements Closeable {
+
+    /** Default user-space resolution of a PDF, in DPI. */
+    private static final float PDF_USER_SPACE_DPI = 72f;
+
+    private final PdfReader reader;
+    private boolean closed;
+
+    /**
+     * Opens the given PDF file using {@code openpdf-core}.
+     *
+     * @param file the PDF file to open; must exist and be readable
+     * @throws IOException if the file cannot be read or is not a valid PDF
+     */
+    public OpenPdfCoreRenderer(File file) throws IOException {
+        this(Files.readAllBytes(Objects.requireNonNull(file, "file").toPath()));
+    }
+
+    /**
+     * Opens the PDF at the given filesystem path.
+     *
+     * @param path the path to the PDF
+     * @throws IOException if the file cannot be read or is not a valid PDF
+     * @since 3.0.5
+     */
+    public OpenPdfCoreRenderer(Path path) throws IOException {
+        this(Files.readAllBytes(Objects.requireNonNull(path, "path")));
+    }
+
+    /**
+     * Opens a PDF from the given input stream. The stream is fully consumed
+     * but not closed.
+     *
+     * @param in the stream containing PDF bytes
+     * @throws IOException if the stream cannot be read or is not a valid PDF
+     */
+    public OpenPdfCoreRenderer(InputStream in) throws IOException {
+        this(toByteArray(Objects.requireNonNull(in, "in")));
+    }
+
+    /**
+     * Opens a PDF from the given byte array. The array is retained by
+     * reference; do not mutate it after passing it in.
+     *
+     * @param pdfBytes the raw PDF bytes
+     * @throws IOException if the bytes are not a valid PDF
+     */
+    public OpenPdfCoreRenderer(byte[] pdfBytes) throws IOException {
+        this.reader = new PdfReader(Objects.requireNonNull(pdfBytes, "pdfBytes"));
+    }
+
+    /**
+     * @return the number of pages in the document
+     */
+    public int getNumPages() {
+        return reader.getNumberOfPages();
+    }
+
+    /**
+     * Returns the visible size of the requested page in PDF user space units
+     * (1 unit = 1/72 inch), with the page rotation already applied so that
+     * width/height match what a viewer would display. The returned rectangle
+     * is anchored at the origin (0, 0).
+     *
+     * @param pageNumber 1-based page number
+     * @return the page size as a {@link Rectangle2D}
+     */
+    public Rectangle2D getPageSize(int pageNumber) {
+        org.openpdf.text.Rectangle r = reader.getPageSizeWithRotation(pageNumber);
+        return new Rectangle2D.Float(0f, 0f, r.getWidth(), r.getHeight());
+    }
+
+    /**
+     * @param pageNumber 1-based page number
+     * @return the page rotation in degrees, normalized to [0, 360)
+     */
+    public int getPageRotation(int pageNumber) {
+        return reader.getPageRotation(pageNumber);
+    }
+
+    /**
+     * Returns the document Info dictionary as an unmodifiable map of string
+     * entries (e.g. {@code Title}, {@code Author}, {@code Subject},
+     * {@code Producer}, {@code Creator}, {@code CreationDate}, {@code ModDate}).
+     *
+     * @return the document metadata; never {@code null}
+     * @since 3.0.5
+     */
+    public Map<String, String> getMetadata() {
+        Map<String, String> info = reader.getInfo();
+        return info == null ? Collections.emptyMap() : Collections.unmodifiableMap(info);
+    }
+
+    /**
+     * Returns a single entry from the document Info dictionary.
+     *
+     * @param key the metadata key (e.g. {@code "Title"}); must not be {@code null}
+     * @return the value, or {@code null} if missing
+     * @since 3.0.5
+     */
+    public String getMetadata(String key) {
+        Objects.requireNonNull(key, "key");
+        return getMetadata().get(key);
+    }
+
+    /**
+     * Extracts plain text from the requested page using {@link PdfTextExtractor}.
+     *
+     * @param pageNumber 1-based page number
+     * @return the extracted text (may be empty, never {@code null})
+     * @throws IOException if the page content cannot be parsed
+     * @since 3.0.5
+     */
+    public String getTextFromPage(int pageNumber) throws IOException {
+        return new PdfTextExtractor(reader).getTextFromPage(pageNumber);
+    }
+
+    /**
+     * Returns the decoded content stream bytes of the requested page,
+     * with all stream filters (Flate, LZW, ASCII85, ...) already applied
+     * by {@code openpdf-core}.
+     *
+     * @param pageNumber 1-based page number
+     * @return the decoded content stream bytes
+     * @throws IOException if the page content cannot be read
+     * @since 3.0.5
+     */
+    public byte[] getPageContent(int pageNumber) throws IOException {
+        return reader.getPageContent(pageNumber);
+    }
+
+    /**
+     * Returns the ordered list of PDF content-stream operator names that
+     * appear on the requested page, parsed by {@code openpdf-core}'s
+     * {@link PdfContentParser}.
+     *
+     * <p>Example: a typical text-only page might return
+     * {@code [q, BT, Tf, Td, Tj, ET, Q]}.</p>
+     *
+     * @param pageNumber 1-based page number
+     * @return the operator names in stream order; never {@code null}
+     * @throws IOException if the page content cannot be parsed
+     * @since 3.0.5
+     */
+    public List<String> getContentOperators(int pageNumber) throws IOException {
+        byte[] content = getPageContent(pageNumber);
+        List<String> operators = new ArrayList<>();
+        PdfContentParser parser = new PdfContentParser(new PRTokeniser(content));
+        List<PdfObject> operands = new ArrayList<>();
+        while (!parser.parse(operands).isEmpty()) {
+            PdfLiteral op = (PdfLiteral) operands.get(operands.size() - 1);
+            operators.add(op.toString());
+        }
+        return operators;
+    }
+
+    /**
+     * Renders the requested page to a {@link BufferedImage} at the given DPI,
+     * using {@link OpenPdfCorePageRenderer} to walk the page's content stream
+     * with {@code openpdf-core}'s {@link PdfContentParser} and dispatch PDF
+     * operators directly to Java2D.
+     *
+     * <p>The returned image is of type {@link BufferedImage#TYPE_INT_ARGB},
+     * filled with an opaque white background, with antialiasing enabled for
+     * shapes and text. Width and height are the page size (in PDF user space
+     * units, i.e. 1/72 inch) scaled by {@code dpi / 72}.</p>
+     *
+     * @param pageNumber 1-based page number
+     * @param dpi target resolution in dots per inch (e.g. 72, 150, 300)
+     * @return the rendered page image
+     * @throws IOException if reading the page fails
+     * @throws IllegalArgumentException if {@code dpi <= 0} or {@code pageNumber}
+     *         is out of range
+     * @throws IllegalStateException if this renderer has been closed
+     */
+    public BufferedImage renderPage(int pageNumber, float dpi) throws IOException {
+        if (dpi <= 0f) {
+            throw new IllegalArgumentException("dpi must be > 0, was " + dpi);
+        }
+        if (pageNumber < 1 || pageNumber > getNumPages()) {
+            throw new IllegalArgumentException(
+                    "pageNumber " + pageNumber + " out of range [1, " + getNumPages() + "]");
+        }
+        ensureOpen();
+
+        Rectangle2D size = getPageSize(pageNumber);
+        float scale = dpi / PDF_USER_SPACE_DPI;
+        int width = Math.max(1, Math.round((float) size.getWidth() * scale));
+        int height = Math.max(1, Math.round((float) size.getHeight() * scale));
+
+        BufferedImage out = new BufferedImage(width, height, BufferedImage.TYPE_INT_ARGB);
+        Graphics2D g2 = out.createGraphics();
+        try {
+            OpenPdfCorePageRenderer.render(reader, pageNumber, g2, width, height, dpi);
+        } finally {
+            g2.dispose();
+        }
+        return out;
+    }
+
+    /**
+     * @return the underlying {@link PdfReader}, for advanced callers that need
+     *         direct access to {@code openpdf-core} parsing APIs
+     *         (page dictionaries, content streams, info dictionary, etc.)
+     */
+    public PdfReader getReader() {
+        return reader;
+    }
+
+    @Override
+    public void close() {
+        if (closed) {
+            return;
+        }
+        closed = true;
+        reader.close();
+    }
+
+    private void ensureOpen() {
+        if (closed) {
+            throw new IllegalStateException("OpenPdfCoreRenderer is closed");
+        }
+    }
+
+    private static byte[] toByteArray(InputStream in) throws IOException {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        byte[] buf = new byte[8192];
+        int n;
+        while ((n = in.read(buf)) != -1) {
+            out.write(buf, 0, n);
+        }
+        return out.toByteArray();
+    }
+}
+

--- a/openpdf-renderer/src/main/java/org/openpdf/renderer/core/OpenPdfCoreRenderer.java
+++ b/openpdf-renderer/src/main/java/org/openpdf/renderer/core/OpenPdfCoreRenderer.java
@@ -127,6 +127,7 @@ public class OpenPdfCoreRenderer implements Closeable {
      * @return the number of pages in the document
      */
     public int getNumPages() {
+        ensureOpen();
         return reader.getNumberOfPages();
     }
 
@@ -140,6 +141,7 @@ public class OpenPdfCoreRenderer implements Closeable {
      * @return the page size as a {@link Rectangle2D}
      */
     public Rectangle2D getPageSize(int pageNumber) {
+        ensureOpen();
         org.openpdf.text.Rectangle r = reader.getPageSizeWithRotation(pageNumber);
         return new Rectangle2D.Float(0f, 0f, r.getWidth(), r.getHeight());
     }
@@ -149,6 +151,7 @@ public class OpenPdfCoreRenderer implements Closeable {
      * @return the page rotation in degrees, normalized to [0, 360)
      */
     public int getPageRotation(int pageNumber) {
+        ensureOpen();
         return reader.getPageRotation(pageNumber);
     }
 
@@ -161,6 +164,7 @@ public class OpenPdfCoreRenderer implements Closeable {
      * @since 3.0.5
      */
     public Map<String, String> getMetadata() {
+        ensureOpen();
         Map<String, String> info = reader.getInfo();
         return info == null ? Collections.emptyMap() : Collections.unmodifiableMap(info);
     }
@@ -186,6 +190,7 @@ public class OpenPdfCoreRenderer implements Closeable {
      * @since 3.0.5
      */
     public String getTextFromPage(int pageNumber) throws IOException {
+        ensureOpen();
         return new PdfTextExtractor(reader).getTextFromPage(pageNumber);
     }
 
@@ -200,6 +205,7 @@ public class OpenPdfCoreRenderer implements Closeable {
      * @since 3.0.5
      */
     public byte[] getPageContent(int pageNumber) throws IOException {
+        ensureOpen();
         return reader.getPageContent(pageNumber);
     }
 
@@ -217,6 +223,7 @@ public class OpenPdfCoreRenderer implements Closeable {
      * @since 3.0.5
      */
     public List<String> getContentOperators(int pageNumber) throws IOException {
+        ensureOpen();
         byte[] content = getPageContent(pageNumber);
         List<String> operators = new ArrayList<>();
         PdfContentParser parser = new PdfContentParser(new PRTokeniser(content));
@@ -248,14 +255,15 @@ public class OpenPdfCoreRenderer implements Closeable {
      * @throws IllegalStateException if this renderer has been closed
      */
     public BufferedImage renderPage(int pageNumber, float dpi) throws IOException {
+        ensureOpen();
         if (dpi <= 0f) {
             throw new IllegalArgumentException("dpi must be > 0, was " + dpi);
         }
-        if (pageNumber < 1 || pageNumber > getNumPages()) {
+        int numPages = getNumPages();
+        if (pageNumber < 1 || pageNumber > numPages) {
             throw new IllegalArgumentException(
-                    "pageNumber " + pageNumber + " out of range [1, " + getNumPages() + "]");
+                    "pageNumber " + pageNumber + " out of range [1, " + numPages + "]");
         }
-        ensureOpen();
 
         Rectangle2D size = getPageSize(pageNumber);
         float scale = dpi / PDF_USER_SPACE_DPI;
@@ -278,6 +286,7 @@ public class OpenPdfCoreRenderer implements Closeable {
      *         (page dictionaries, content streams, info dictionary, etc.)
      */
     public PdfReader getReader() {
+        ensureOpen();
         return reader;
     }
 

--- a/openpdf-renderer/src/main/java/org/openpdf/renderer/decode/PDFDecoder.java
+++ b/openpdf-renderer/src/main/java/org/openpdf/renderer/decode/PDFDecoder.java
@@ -34,7 +34,15 @@ import org.openpdf.renderer.PDFParseException;
  * <p>
  * You should use the decodeStream() method of this object rather than using
  * any of the decoders directly.
+ *
+ * @deprecated since 3.0.5. Stream-filter decoding is being replaced by the
+ * {@code openpdf-core} parser ({@link org.openpdf.text.pdf.PdfReader#decodeBytes}
+ * and the built-in filter pipeline). Use
+ * {@link org.openpdf.renderer.core.OpenPdfCoreRenderer} instead. This class
+ * will remain for at least one release to ease migration; it is not yet
+ * scheduled for removal.
  */
+@Deprecated
 public class PDFDecoder {
 
     public final static Set<String> DCT_FILTERS = new HashSet<String>(Arrays.asList("DCT", "DCTDecode"));

--- a/openpdf-renderer/src/test/java/org/openpdf/renderer/core/OpenPdfCoreRendererTest.java
+++ b/openpdf-renderer/src/test/java/org/openpdf/renderer/core/OpenPdfCoreRendererTest.java
@@ -1,0 +1,216 @@
+package org.openpdf.renderer.core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.awt.geom.Rectangle2D;
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.Map;
+
+import javax.imageio.ImageIO;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for the {@link OpenPdfCoreRenderer} bridge that uses
+ * {@code openpdf-core} as the underlying PDF parser.
+ */
+class OpenPdfCoreRendererTest {
+
+    private static byte[] pdfBytes;
+    private static Path pdfPath;
+
+    @BeforeAll
+    static void loadFixture() throws Exception {
+        URL url = OpenPdfCoreRendererTest.class.getClassLoader()
+                .getResource("HelloWorldMeta.pdf");
+        assertThat(url).as("HelloWorldMeta.pdf must be on the test classpath").isNotNull();
+        // Use toURI() so paths containing spaces or other URL-escaped chars resolve correctly.
+        pdfPath = Paths.get(url.toURI());
+        pdfBytes = Files.readAllBytes(pdfPath);
+    }
+
+    @Test
+    void opensFromByteArray_andReportsPageCount() throws IOException {
+        try (OpenPdfCoreRenderer r = new OpenPdfCoreRenderer(pdfBytes)) {
+            assertThat(r.getNumPages()).isGreaterThanOrEqualTo(1);
+        }
+    }
+
+    @Test
+    void opensFromFile_andReturnsPageGeometry() throws IOException {
+        try (OpenPdfCoreRenderer r = new OpenPdfCoreRenderer(pdfPath.toFile())) {
+            Rectangle2D size = r.getPageSize(1);
+            assertThat(size.getX()).isEqualTo(0d);
+            assertThat(size.getY()).isEqualTo(0d);
+            assertThat(size.getWidth()).isPositive();
+            assertThat(size.getHeight()).isPositive();
+            assertThat(r.getPageRotation(1)).isBetween(0, 359);
+        }
+    }
+
+    @Test
+    void opensFromPath_sameAsFile() throws IOException {
+        try (OpenPdfCoreRenderer r = new OpenPdfCoreRenderer(pdfPath)) {
+            assertThat(r.getNumPages()).isGreaterThanOrEqualTo(1);
+        }
+    }
+
+    @Test
+    void opensFromInputStream() throws IOException {
+        try (InputStream in = new ByteArrayInputStream(pdfBytes);
+             OpenPdfCoreRenderer r = new OpenPdfCoreRenderer(in)) {
+            assertThat(r.getNumPages()).isGreaterThanOrEqualTo(1);
+        }
+    }
+
+    @Test
+    void exposesMetadataViaOpenPdfCore() throws IOException {
+        try (OpenPdfCoreRenderer r = new OpenPdfCoreRenderer(pdfBytes)) {
+            Map<String, String> info = r.getMetadata();
+            assertThat(info).isNotNull();
+            // Spot-check: getMetadata(String) must agree with the bulk map.
+            for (Map.Entry<String, String> e : info.entrySet()) {
+                assertThat(r.getMetadata(e.getKey())).isEqualTo(e.getValue());
+            }
+            // The returned map must be unmodifiable.
+            assertThatThrownBy(() -> info.put("x", "y"))
+                    .isInstanceOf(UnsupportedOperationException.class);
+            // Null keys are rejected.
+            assertThatThrownBy(() -> r.getMetadata(null))
+                    .isInstanceOf(NullPointerException.class);
+        }
+    }
+
+    @Test
+    void extractsTextViaOpenPdfCore() throws IOException {
+        try (OpenPdfCoreRenderer r = new OpenPdfCoreRenderer(pdfBytes)) {
+            String text = r.getTextFromPage(1);
+            assertThat(text).isNotNull();
+        }
+    }
+
+    @Test
+    void exposesDecodedPageContentBytes() throws IOException {
+        try (OpenPdfCoreRenderer r = new OpenPdfCoreRenderer(pdfBytes)) {
+            byte[] content = r.getPageContent(1);
+            assertThat(content).isNotNull().isNotEmpty();
+        }
+    }
+
+    @Test
+    void parsesContentStreamOperatorsViaOpenPdfCore() throws IOException {
+        try (OpenPdfCoreRenderer r = new OpenPdfCoreRenderer(pdfBytes)) {
+            List<String> ops = r.getContentOperators(1);
+            assertThat(ops).isNotNull().isNotEmpty();
+            // A page that produced any text via PdfTextExtractor must contain
+            // the BT/ET text-object delimiters in its content stream.
+            if (!r.getTextFromPage(1).isEmpty()) {
+                assertThat(ops).contains("BT", "ET");
+            }
+            // All recorded tokens are non-empty operator names.
+            assertThat(ops).allSatisfy(op -> assertThat(op).isNotBlank());
+        }
+    }
+
+    @Test
+    void renderPageProducesImageOfExpectedSize() throws IOException {
+        try (OpenPdfCoreRenderer r = new OpenPdfCoreRenderer(pdfBytes)) {
+            Rectangle2D size = r.getPageSize(1);
+            float dpi = 144f; // 2x
+            BufferedImage img = r.renderPage(1, dpi);
+            assertThat(img).isNotNull();
+            int expectedW = Math.max(1, Math.round((float) size.getWidth() * (dpi / 72f)));
+            int expectedH = Math.max(1, Math.round((float) size.getHeight() * (dpi / 72f)));
+            assertThat(img.getWidth()).isEqualTo(expectedW);
+            assertThat(img.getHeight()).isEqualTo(expectedH);
+        }
+    }
+
+    @Test
+    void renderPageProducesNonBlankContentViaOpenPdfCore() throws IOException {
+        // Verify the openpdf-core-driven Java2D renderer actually drew something:
+        // the rendered page must contain pixels that are not the opaque-white background.
+        try (OpenPdfCoreRenderer r = new OpenPdfCoreRenderer(pdfBytes)) {
+            BufferedImage img = r.renderPage(1, 150f);
+
+            // Save for visual inspection.
+            File outDir = new File("target/test-outputs");
+            outDir.mkdirs();
+            File outFile = new File(outDir, "OpenPdfCoreRenderer-page1.png");
+            ImageIO.write(img, "png", outFile);
+            assertThat(outFile).exists();
+
+            int nonBackgroundPixels = 0;
+            int sampleCount = 0;
+            // Sample on a 4-px grid to keep this fast.
+            for (int y = 0; y < img.getHeight(); y += 4) {
+                for (int x = 0; x < img.getWidth(); x += 4) {
+                    sampleCount++;
+                    int argb = img.getRGB(x, y);
+                    int a = (argb >>> 24) & 0xFF;
+                    int rch = (argb >> 16) & 0xFF;
+                    int gch = (argb >> 8) & 0xFF;
+                    int bch = argb & 0xFF;
+                    boolean opaqueWhite = a == 0xFF && rch == 0xFF && gch == 0xFF && bch == 0xFF;
+                    if (!opaqueWhite) {
+                        nonBackgroundPixels++;
+                    }
+                }
+            }
+            assertThat(sampleCount).isPositive();
+            assertThat(nonBackgroundPixels)
+                    .as("openpdf-core-driven renderer must produce at least some non-background "
+                            + "pixels (saved to %s)", outFile.getAbsolutePath())
+                    .isPositive();
+        }
+    }
+
+    @Test
+    void renderPageRejectsBadArguments() throws IOException {
+        try (OpenPdfCoreRenderer r = new OpenPdfCoreRenderer(pdfBytes)) {
+            assertThatThrownBy(() -> r.renderPage(1, 0f))
+                    .isInstanceOf(IllegalArgumentException.class);
+            assertThatThrownBy(() -> r.renderPage(0, 72f))
+                    .isInstanceOf(IllegalArgumentException.class);
+            assertThatThrownBy(() -> r.renderPage(r.getNumPages() + 1, 72f))
+                    .isInstanceOf(IllegalArgumentException.class);
+        }
+    }
+
+    @Test
+    void closeIsIdempotent_andBlocksFurtherRendering() throws IOException {
+        OpenPdfCoreRenderer r = new OpenPdfCoreRenderer(pdfBytes);
+        r.close();
+        r.close(); // second close must be a no-op
+        assertThatThrownBy(() -> r.renderPage(1, 72f))
+                .isInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    void exposesUnderlyingPdfReader() throws IOException {
+        try (OpenPdfCoreRenderer r = new OpenPdfCoreRenderer(pdfBytes)) {
+            assertThat(r.getReader()).isNotNull();
+            assertThat(r.getReader().getNumberOfPages()).isEqualTo(r.getNumPages());
+        }
+    }
+}
+
+
+
+
+
+
+
+
+

--- a/openpdf-renderer/src/test/java/org/openpdf/renderer/core/OpenPdfCoreRendererTest.java
+++ b/openpdf-renderer/src/test/java/org/openpdf/renderer/core/OpenPdfCoreRendererTest.java
@@ -206,7 +206,3 @@ class OpenPdfCoreRendererTest {
     }
 }
 
-
-
-
-

--- a/openpdf-renderer/src/test/java/org/openpdf/renderer/core/OpenPdfCoreRendererTest.java
+++ b/openpdf-renderer/src/test/java/org/openpdf/renderer/core/OpenPdfCoreRendererTest.java
@@ -210,7 +210,3 @@ class OpenPdfCoreRendererTest {
 
 
 
-
-
-
-

--- a/openpdf-renderer/src/test/java/org/openpdf/renderer/core/OpenPdfCoreRendererTest.java
+++ b/openpdf-renderer/src/test/java/org/openpdf/renderer/core/OpenPdfCoreRendererTest.java
@@ -41,14 +41,14 @@ class OpenPdfCoreRendererTest {
     }
 
     @Test
-    void opensFromByteArray_andReportsPageCount() throws IOException {
+    void opensFromByteArrayAndReportsPageCount() throws IOException {
         try (OpenPdfCoreRenderer r = new OpenPdfCoreRenderer(pdfBytes)) {
             assertThat(r.getNumPages()).isGreaterThanOrEqualTo(1);
         }
     }
 
     @Test
-    void opensFromFile_andReturnsPageGeometry() throws IOException {
+    void opensFromFileAndReturnsPageGeometry() throws IOException {
         try (OpenPdfCoreRenderer r = new OpenPdfCoreRenderer(pdfPath.toFile())) {
             Rectangle2D size = r.getPageSize(1);
             assertThat(size.getX()).isEqualTo(0d);
@@ -60,7 +60,7 @@ class OpenPdfCoreRendererTest {
     }
 
     @Test
-    void opensFromPath_sameAsFile() throws IOException {
+    void opensFromPathSameAsFile() throws IOException {
         try (OpenPdfCoreRenderer r = new OpenPdfCoreRenderer(pdfPath)) {
             assertThat(r.getNumPages()).isGreaterThanOrEqualTo(1);
         }
@@ -189,7 +189,7 @@ class OpenPdfCoreRendererTest {
     }
 
     @Test
-    void closeIsIdempotent_andBlocksFurtherRendering() throws IOException {
+    void closeIsIdempotentAndBlocksFurtherRendering() throws IOException {
         OpenPdfCoreRenderer r = new OpenPdfCoreRenderer(pdfBytes);
         r.close();
         r.close(); // second close must be a no-op


### PR DESCRIPTION
#1559 Replace renderer's in-tree PDF parser with openpdf-core

Wire openpdf-renderer onto openpdf-core (PdfReader / PdfContentParser) for all PDF parsing, and add OpenPdfCoreRenderer as the recommended entry point.

- Add openpdf-core dependency to openpdf-renderer.
- OpenPdfCoreRenderer: back getPageSize/Rotation, metadata, page text, decoded page content and content-stream operators with openpdf-core; add Path constructor, idempotent close, argument validation and closed-state checks.
- Implement renderPage via OpenPdfCorePageRenderer, which walks the content stream with PdfContentParser and dispatches PDF operators (graphics state, paths, DeviceGray/RGB colors, text objects) to Java2D. Fix rotation=0 transform and clean up font/operand handling.
- Deprecate the legacy in-tree parser: PDFFile, PDFPage, PDFParser and decode.PDFDecoder (kept for one release for migration).
- Update README with migration guide, supported-operator matrix and new OpenPdfCoreRenderer examples; replace legacy quick-start snippets.
- Tests: cover Path/file/byte[] constructors, metadata null-key, decoded page bytes, operator listing, and verify renderPage produces non-blank output; resolve fixture URL via toURI() for spaced paths.

Note that this is a "research" and innovation time project where I have spent time trying to improve OpenPDF using AI tools such as Claude and Copilot.

## Your real name
Andreas Røsdal