### PR TITLE
updating maven to 3.9.16, switching build to maven wrapper, adjusting enforcer plugin configuration

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -12,7 +12,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
         java: [21, 24, 25, 26, '27-ea'] 
-    name: Build with Java ${{ matrix.java }}
+    name: Build with Java ${{ matrix.java }} on ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v5
 

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -25,9 +25,9 @@ jobs:
       - name: Check Maven version and directory contents
         shell: bash
         run: |
-          mvn -v
+          ./mvnw -v
           echo "** ls **"
           pwd && ls -l
 
       - name: Build with Maven
-        run: mvn -B install --file pom.xml
+        run: ./mvnw -B install --file pom.xml

--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -1,3 +1,3 @@
 wrapperVersion=3.3.4
 distributionType=only-script
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.14/apache-maven-3.9.14-bin.zip
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.16/apache-maven-3.9.16-bin.zip

--- a/pom.xml
+++ b/pom.xml
@@ -262,10 +262,10 @@
                 </banDynamicVersions>
                 <banDuplicatePomDependencyVersions/>
                 <requireMavenVersion>
-                  <version>3.9.0</version>
+                  <version>[3.9,)</version>
                 </requireMavenVersion>
                 <requireJavaVersion>
-                  <version>${java.version}}</version>
+                  <version>[${java.version},)</version>
                 </requireJavaVersion>
                 <requireReleaseDeps>
                   <onlyWhenRelease>true</onlyWhenRelease>


### PR DESCRIPTION
## Description of the new Feature/Bugfix

-  maven updated  to 3.9.16 in wrapper configuration,
- CI build switched to  maven wrapper
- enforcer plugin configuration adjusted (JDK21+, maven 3.9+ required)
- 

Related Issue: #

none

## Compatibilities Issues

none

## Your real name
Sławomir Tomaszek

## Testing details

no additional testing needed