### PR TITLE
Fix #1584: mark brotli4j as an optional dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,7 +262,7 @@ PDF readers that do not yet implement ISO/TS 32001.
     on which algorithm you are using)
   - PKIX/CMS (`org.bouncycastle:bcpkix-jdk18on`)
 - Apache FOP (`org.apache.xmlgraphics:fop`)
-- Brotli4j (`com.aayushatharva.brotli4j:brotli4j`) for Brotli stream compression (`/BrotliDecode`)
+* Brotli4j (`com.aayushatharva.brotli4j:brotli4j`) for Brotli stream compression (`/BrotliDecode`)
 - Please refer to our [pom.xml](pom.xml) to see what version is needed.
 
 ## Credits

--- a/README.md
+++ b/README.md
@@ -196,8 +196,17 @@ and use the class `org.librepdf.openpdf.fonts.Liberation`.
 
 ### Brotli4j
 
-Brotli4j is a required dependency for Brotli stream compression support.
-<https://github.com/hyperxpro/Brotli4j/>
+[Brotli4j](https://github.com/hyperxpro/Brotli4j/) is an optional dependency, only needed for
+Brotli stream compression support (`/BrotliDecode`). It is not pulled in transitively, so add it
+to your project if you want to read or write Brotli-compressed PDF streams:
+
+```xml
+<dependency>
+  <groupId>com.aayushatharva.brotli4j</groupId>
+  <artifactId>brotli4j</artifactId>
+  <version>${brotli4j.version}</version>
+</dependency>
+```
 
 ### Supporting complex glyph substitution/ Ligature substitution
 
@@ -217,9 +226,9 @@ OpenPDF can read and write PDF streams compressed with
 [Brotli](https://github.com/google/brotli) — exposed in the PDF as the
 `/BrotliDecode` filter, which is being standardised for PDF 2.0 (ISO 32000-2)
 through [ISO/TS 32001](https://www.iso.org/standard/45874.html). The codec is
-backed by [brotli4j](https://github.com/hyperxpro/Brotli4j) (a required
+backed by [brotli4j](https://github.com/hyperxpro/Brotli4j) (an optional
 dependency, with native binaries shipped for Linux / macOS / Windows on x86_64
-and aarch64).
+and aarch64) — see [Brotli4j](#brotli4j) above for the Maven coordinates.
 
 Enable Brotli for the page content streams produced by a writer:
 
@@ -253,6 +262,7 @@ PDF readers that do not yet implement ISO/TS 32001.
     on which algorithm you are using)
   - PKIX/CMS (`org.bouncycastle:bcpkix-jdk18on`)
 - Apache FOP (`org.apache.xmlgraphics:fop`)
+- Brotli4j (`com.aayushatharva.brotli4j:brotli4j`) for Brotli stream compression (`/BrotliDecode`)
 - Please refer to our [pom.xml](pom.xml) to see what version is needed.
 
 ## Credits

--- a/README.md
+++ b/README.md
@@ -256,14 +256,14 @@ PDF readers that do not yet implement ISO/TS 32001.
 
 ### Optional
 
-- [BouncyCastle](https://www.bouncycastle.org/) (BouncyCastle is used to sign PDF files, so it's a recommended
+* [BouncyCastle](https://www.bouncycastle.org/) (BouncyCastle is used to sign PDF files, so it's a recommended
   dependency)
-  - Provider (`org.bouncycastle:bcprov-jdk18on` or `org.bouncycastle:bcprov-ext-jdk18on` depending
+  * Provider (`org.bouncycastle:bcprov-jdk18on` or `org.bouncycastle:bcprov-ext-jdk18on` depending
     on which algorithm you are using)
-  - PKIX/CMS (`org.bouncycastle:bcpkix-jdk18on`)
-- Apache FOP (`org.apache.xmlgraphics:fop`)
+  * PKIX/CMS (`org.bouncycastle:bcpkix-jdk18on`)
+* Apache FOP (`org.apache.xmlgraphics:fop`)
 * Brotli4j (`com.aayushatharva.brotli4j:brotli4j`) for Brotli stream compression (`/BrotliDecode`)
-- Please refer to our [pom.xml](pom.xml) to see what version is needed.
+* Please refer to our [pom.xml](pom.xml) to see what version is needed.
 
 ## Credits
 

--- a/openpdf-core/pom.xml
+++ b/openpdf-core/pom.xml
@@ -43,6 +43,7 @@
       <groupId>com.aayushatharva.brotli4j</groupId>
       <artifactId>brotli4j</artifactId>
       <version>${brotli4j.version}</version>
+      <optional>true</optional>
     </dependency>
 
     <!-- Test Deps -->

--- a/openpdf-core/src/main/java/org/openpdf/text/pdf/codec/BrotliFilter.java
+++ b/openpdf-core/src/main/java/org/openpdf/text/pdf/codec/BrotliFilter.java
@@ -37,9 +37,12 @@ public final class BrotliFilter {
     public static void ensureAvailable() throws IOException {
         try {
             Brotli4jLoader.ensureAvailability();
-        } catch (Exception e) {
-            throw new IOException("Brotli native library could not be loaded. "
-                    + "Add a brotli4j native dependency for your platform.", e);
+        } catch (Exception | LinkageError e) {
+            // LinkageError covers NoClassDefFoundError when the optional brotli4j
+            // dependency is not on the classpath at all.
+            throw new IOException("Brotli support is not available. Add the optional "
+                    + "com.aayushatharva.brotli4j:brotli4j dependency (including the native "
+                    + "library for your platform) to use the /BrotliDecode filter.", e);
         }
     }
 


### PR DESCRIPTION
## Summary

Fixes #1584.

brotli4j was declared as a regular compile-scope dependency, so every project depending on OpenPDF got it transitively. Libraries that detect brotli4j at runtime — e.g. Apache HttpClient 5, which registers a Brotli decompressor when it finds brotli4j on the classpath — would then try to use it and fail with `UnsatisfiedLinkError` because the JNI native library is not bundled.

## Changes

- **`openpdf-core/pom.xml`**: brotli4j is now `<optional>true</optional>`, matching the other optional dependencies (BouncyCastle, FOP, ICU4J). Brotli support in OpenPDF is opt-in anyway: `Document.useBrotliCompression` defaults to `false`, and `BrotliFilter` is only class-loaded when a PDF actually uses `/BrotliDecode` or the writer enables Brotli — consumers that never touch Brotli pay no cost and need no dependency.
- **`BrotliFilter.ensureAvailable()`**: now also catches `LinkageError`. Without this, an absent (now optional) brotli4j would surface as a raw `NoClassDefFoundError` instead of the documented `IOException`. With it, users get a clear message with the Maven coordinates to add, and `PdfWriter.setUseBrotliCompression(true)` keeps its graceful fallback to Flate.
- **`README.md`**: Brotli4j documented as optional, with the dependency snippet to add for Brotli support.

## Tests

`BrotliPDFTest` still passes (the module's own test classpath is unaffected by `<optional>`). Consumers without brotli4j now get a descriptive `IOException` / Flate fallback instead of `NoClassDefFoundError` when touching the Brotli API, and are simply unaffected otherwise.

