### PR TITLE
Fix #1582: fixes to reading PDF files larger than 2 GB

### DIFF
--- a/openpdf-core/src/main/java/org/openpdf/text/pdf/CFFFont.java
+++ b/openpdf-core/src/main/java/org/openpdf/text/pdf/CFFFont.java
@@ -404,7 +404,8 @@ public class CFFFont {
 
     int getPosition() {
         try {
-            return buf.getFilePointer();
+            // CFF font data is always well below 2 GB, so the narrowing cast is safe
+            return (int) buf.getFilePointer();
         } catch (Exception e) {
             throw new ExceptionConverter(e);
         }

--- a/openpdf-core/src/main/java/org/openpdf/text/pdf/EnumerateTTC.java
+++ b/openpdf-core/src/main/java/org/openpdf/text/pdf/EnumerateTTC.java
@@ -102,7 +102,7 @@ class EnumerateTTC extends TrueTypeFont {
 
             int dirCount = rf.readInt();
             names = new String[dirCount];
-            int dirPos = rf.getFilePointer();
+            long dirPos = rf.getFilePointer();
             for (int dirIdx = 0; dirIdx < dirCount; ++dirIdx) {
                 tables.clear();
                 rf.seek(dirPos);

--- a/openpdf-core/src/main/java/org/openpdf/text/pdf/PRStream.java
+++ b/openpdf-core/src/main/java/org/openpdf/text/pdf/PRStream.java
@@ -61,7 +61,7 @@ import java.util.zip.DeflaterOutputStream;
 public class PRStream extends PdfStream {
 
     protected PdfReader reader;
-    protected int offset;
+    protected long offset;
     protected int length;
 
     //added by ujihara for decryption
@@ -90,7 +90,7 @@ public class PRStream extends PdfStream {
         this.reader = reader;
     }
 
-    public PRStream(PdfReader reader, int offset) {
+    public PRStream(PdfReader reader, long offset) {
         this.reader = reader;
         this.offset = offset;
     }
@@ -182,7 +182,7 @@ public class PRStream extends PdfStream {
         setData(data, true);
     }
 
-    public int getOffset() {
+    public long getOffset() {
         return offset;
     }
 

--- a/openpdf-core/src/main/java/org/openpdf/text/pdf/PRTokeniser.java
+++ b/openpdf-core/src/main/java/org/openpdf/text/pdf/PRTokeniser.java
@@ -170,11 +170,11 @@ public class PRTokeniser implements AutoCloseable {
         return null;
     }
 
-    public void seek(int pos) throws IOException {
+    public void seek(long pos) throws IOException {
         file.seek(pos);
     }
 
-    public int getFilePointer() throws IOException {
+    public long getFilePointer() throws IOException {
         return file.getFilePointer();
     }
 
@@ -182,7 +182,7 @@ public class PRTokeniser implements AutoCloseable {
         file.close();
     }
 
-    public int length() throws IOException {
+    public long length() throws IOException {
         return file.length();
     }
 
@@ -270,10 +270,10 @@ public class PRTokeniser implements AutoCloseable {
         file.setStartOffset(idx);
     }
 
-    public int getStartxref() throws IOException {
+    public long getStartxref() throws IOException {
         int step = 1024; // packet size to read the file from the end
         int delta = 8; // delta to provide packets overlapping in case 'startxref' appears split between two packets
-        int pos = file.length() - delta;
+        long pos = file.length() - delta;
         int idx;
         do {
             pos = Math.max(0, pos - step);
@@ -291,7 +291,7 @@ public class PRTokeniser implements AutoCloseable {
         int level = 0;
         String n1 = null;
         String n2 = null;
-        int ptr = 0;
+        long ptr = 0;
         while (nextToken() || level == 2) {
             if (type == TK_COMMENT) {
                 continue;
@@ -574,6 +574,15 @@ public class PRTokeniser implements AutoCloseable {
         return Integer.parseInt(stringValue);
     }
 
+    /**
+     * Returns the current token as a long. Needed for file offsets in PDF documents larger than 2 GB.
+     *
+     * @return the current token parsed as a long
+     */
+    public long longValue() {
+        return Long.parseLong(stringValue);
+    }
+
     public boolean readLineSegment(byte[] input) throws IOException {
         int c = -1;
         boolean eol = false;
@@ -595,7 +604,7 @@ public class PRTokeniser implements AutoCloseable {
                     break;
                 case '\r':
                     eol = true;
-                    int cur = getFilePointer();
+                    long cur = getFilePointer();
                     if ((read()) != '\n') {
                         seek(cur);
                     }
@@ -622,7 +631,7 @@ public class PRTokeniser implements AutoCloseable {
                         break;
                     case '\r':
                         eol = true;
-                        int cur = getFilePointer();
+                        long cur = getFilePointer();
                         if ((read()) != '\n') {
                             seek(cur);
                         }

--- a/openpdf-core/src/main/java/org/openpdf/text/pdf/PdfNumber.java
+++ b/openpdf-core/src/main/java/org/openpdf/text/pdf/PdfNumber.java
@@ -143,6 +143,15 @@ public class PdfNumber extends PdfObject implements Comparable<PdfNumber> {
     }
 
     /**
+     * Returns the primitive <CODE>long</CODE> value of this object.
+     *
+     * @return The value as <CODE>long</CODE>
+     */
+    public long longValue() {
+        return (long) value;
+    }
+
+    /**
      * Returns the primitive <CODE>double</CODE> value of this object.
      *
      * @return The value as <CODE>double</CODE>

--- a/openpdf-core/src/main/java/org/openpdf/text/pdf/PdfReader.java
+++ b/openpdf-core/src/main/java/org/openpdf/text/pdf/PdfReader.java
@@ -1970,14 +1970,14 @@ public class PdfReader implements PdfViewerPreferences, Closeable {
     }
 
     private void checkPRStreamLength(PRStream stream) throws IOException {
-        long fileLength = tokens.length();
+        long tokensLength = tokens.length();
         long start = stream.getOffset();
         boolean calc = false;
         int streamLength = 0;
         PdfObject obj = getPdfObjectRelease(stream.get(PdfName.LENGTH));
         if (obj != null && obj.type() == PdfObject.NUMBER) {
             streamLength = ((PdfNumber) obj).intValue();
-            if (streamLength + start > fileLength - 20) {
+            if (streamLength + start > tokensLength - 20) {
                 calc = true;
             } else {
                 tokens.seek(start + streamLength);
@@ -2275,49 +2275,7 @@ public class PdfReader implements PdfViewerPreferences, Closeable {
             int length = index.getAsNumber(idx + 1).intValue();
             ensureXrefSize((start + length) * 2);
             while (length-- > 0) {
-                int type = 1;
-                if (wc[0] > 0) {
-                    type = 0;
-                    for (int k = 0; k < wc[0]; ++k) {
-                        type = (type << 8) + (b[bptr++] & 0xff);
-                    }
-                }
-                long field2 = 0;
-                for (int k = 0; k < wc[1]; ++k) {
-                    field2 = (field2 << 8) + (b[bptr++] & 0xff);
-                }
-                int field3 = 0;
-                for (int k = 0; k < wc[2]; ++k) {
-                    field3 = (field3 << 8) + (b[bptr++] & 0xff);
-                }
-                int base = start * 2;
-                if (xref[base] == 0 && xref[base + 1] == 0) {
-                    switch (type) {
-                        case 0:
-                            xref[base] = -1;
-                            break;
-                        case 1:
-                            xref[base] = field2;
-                            break;
-                        case 2:
-                            xref[base] = field3;
-                            xref[base + 1] = field2;
-                            if (partial) {
-                                objStmToOffset.put((int) field2, 0L);
-                            } else {
-                                Integer on = (int) field2;
-                                IntHashtable seq = objStmMark.get(on);
-                                if (seq == null) {
-                                    seq = new IntHashtable();
-                                    seq.put(field3, 1);
-                                    objStmMark.put(on, seq);
-                                } else {
-                                    seq.put(field3, 1);
-                                }
-                            }
-                            break;
-                    }
-                }
+                bptr = readXRefStreamEntry(b, bptr, wc, start);
                 ++start;
             }
         }
@@ -2330,6 +2288,67 @@ public class PdfReader implements PdfViewerPreferences, Closeable {
             return true;
         }
         return readXRefStream(prev);
+    }
+
+    /**
+     * Decodes one cross-reference stream entry starting at {@code bptr} and stores it in the xref
+     * table, unless the object already has an entry from a newer section.
+     *
+     * @param b      the decoded bytes of the xref stream
+     * @param bptr   the position of this entry within {@code b}
+     * @param wc     the /W field widths of the three entry fields
+     * @param objNum the object number this entry describes
+     * @return the position within {@code b} right after this entry
+     */
+    private int readXRefStreamEntry(byte[] b, int bptr, int[] wc, int objNum) {
+        int type = 1;
+        if (wc[0] > 0) {
+            type = 0;
+            for (int k = 0; k < wc[0]; ++k) {
+                type = (type << 8) + (b[bptr++] & 0xff);
+            }
+        }
+        long field2 = 0;
+        for (int k = 0; k < wc[1]; ++k) {
+            field2 = (field2 << 8) + (b[bptr++] & 0xff);
+        }
+        int field3 = 0;
+        for (int k = 0; k < wc[2]; ++k) {
+            field3 = (field3 << 8) + (b[bptr++] & 0xff);
+        }
+        int base = objNum * 2;
+        if (xref[base] == 0 && xref[base + 1] == 0) {
+            switch (type) {
+                case 0:
+                    xref[base] = -1;
+                    break;
+                case 1:
+                    xref[base] = field2;
+                    break;
+                case 2:
+                    xref[base] = field3;
+                    xref[base + 1] = field2;
+                    markObjStmEntry((int) field2, field3);
+                    break;
+                default:
+                    // Per ISO 32000, unknown types shall be treated as references to the null object
+                    break;
+            }
+        }
+        return bptr;
+    }
+
+    /**
+     * Records that object stream {@code objStmNum} holds an object at index {@code idx}, in the
+     * bookkeeping structure matching the current (partial or full) read mode.
+     */
+    private void markObjStmEntry(int objStmNum, int idx) {
+        if (partial) {
+            objStmToOffset.put(objStmNum, 0L);
+        } else {
+            IntHashtable seq = objStmMark.computeIfAbsent(objStmNum, k -> new IntHashtable());
+            seq.put(idx, 1);
+        }
     }
 
     protected void rebuildXref() throws IOException {

--- a/openpdf-core/src/main/java/org/openpdf/text/pdf/PdfReader.java
+++ b/openpdf-core/src/main/java/org/openpdf/text/pdf/PdfReader.java
@@ -2208,31 +2208,11 @@ public class PdfReader implements PdfViewerPreferences, Closeable {
     }
 
     protected boolean readXRefStream(long ptr) throws IOException {
-        tokens.seek(ptr);
-        int thisStream;
-        if (!tokens.nextToken()) {
+        PRStream stm = readXRefStreamObject(ptr);
+        if (stm == null) {
             return false;
         }
-        if (tokens.getTokenType() != PRTokeniser.TK_NUMBER) {
-            return false;
-        }
-        thisStream = tokens.intValue();
-        if (!tokens.nextToken() || tokens.getTokenType() != PRTokeniser.TK_NUMBER) {
-            return false;
-        }
-        if (!tokens.nextToken() || !tokens.getStringValue().equals("obj")) {
-            return false;
-        }
-        PdfObject object = readPRObject();
-        PRStream stm;
-        if (object.isStream()) {
-            stm = (PRStream) object;
-            if (!PdfName.XREF.equals(stm.get(PdfName.TYPE))) {
-                return false;
-            }
-        } else {
-            return false;
-        }
+        int thisStream = stm.getObjNum();
         if (trailer == null) {
             trailer = new PdfDictionary();
             trailer.putAll(stm);
@@ -2288,6 +2268,34 @@ public class PdfReader implements PdfViewerPreferences, Closeable {
             return true;
         }
         return readXRefStream(prev);
+    }
+
+    /**
+     * Parses the indirect object at {@code ptr} and returns it if it is a cross-reference stream.
+     *
+     * @param ptr the file offset of the object
+     * @return the xref stream with its object number set, or {@code null} if the object at
+     *         {@code ptr} is not a valid cross-reference stream
+     */
+    private PRStream readXRefStreamObject(long ptr) throws IOException {
+        tokens.seek(ptr);
+        if (!tokens.nextToken() || tokens.getTokenType() != PRTokeniser.TK_NUMBER) {
+            return null;
+        }
+        int streamObjNum = tokens.intValue();
+        if (!tokens.nextToken() || tokens.getTokenType() != PRTokeniser.TK_NUMBER) {
+            return null;
+        }
+        if (!tokens.nextToken() || !tokens.getStringValue().equals("obj")) {
+            return null;
+        }
+        PdfObject object = readPRObject();
+        if (!object.isStream() || !PdfName.XREF.equals(((PRStream) object).get(PdfName.TYPE))) {
+            return null;
+        }
+        PRStream stm = (PRStream) object;
+        stm.setObjNum(streamObjNum, 0);
+        return stm;
     }
 
     /**

--- a/openpdf-core/src/main/java/org/openpdf/text/pdf/PdfReader.java
+++ b/openpdf-core/src/main/java/org/openpdf/text/pdf/PdfReader.java
@@ -105,9 +105,9 @@ public class PdfReader implements PdfViewerPreferences, Closeable {
     // type 0 -> -1, 0
     // type 1 -> offset, 0
     // type 2 -> index, obj num
-    protected int[] xref;
+    protected long[] xref;
     protected Map<Integer, IntHashtable> objStmMark;
-    protected IntHashtable objStmToOffset;
+    protected Map<Integer, Long> objStmToOffset;
     protected boolean newXrefType;
     protected PdfDictionary trailer;
     protected PdfDictionary catalog;
@@ -118,8 +118,8 @@ public class PdfReader implements PdfViewerPreferences, Closeable {
     protected boolean rebuilt = false;
     protected int freeXref;
     protected boolean tampered = false;
-    protected int lastXref;
-    protected int eofPos;
+    protected long lastXref;
+    protected long eofPos;
     protected String pdfVersion;
     protected PdfEncryption decrypt;
     protected byte[] password = null; // added by ujihara for decryption
@@ -143,7 +143,7 @@ public class PdfReader implements PdfViewerPreferences, Closeable {
     private boolean modificationAllowedWithoutOwnerPassword = true;
     private int objNum;
     private int objGen;
-    private int fileLength;
+    private long fileLength;
     private boolean hybridXref;
     private int lastXrefPartial = -1;
     private boolean partial;
@@ -1803,8 +1803,7 @@ public class PdfReader implements PdfViewerPreferences, Closeable {
         xrefObj.addAll(Collections.nCopies(xref.length / 2, null));
         readDecryptedDocObj();
         if (objStmToOffset != null) {
-            int[] keys = objStmToOffset.getKeys();
-            for (int n : keys) {
+            for (Integer n : new ArrayList<>(objStmToOffset.keySet())) {
                 objStmToOffset.put(n, xref[n * 2]);
                 xref[n * 2] = -1;
             }
@@ -1814,12 +1813,12 @@ public class PdfReader implements PdfViewerPreferences, Closeable {
     protected PdfObject readSingleObject(int k) throws IOException {
         strings.clear();
         int k2 = k * 2;
-        int pos = xref[k2];
+        long pos = xref[k2];
         if (pos < 0) {
             return null;
         }
         if (xref[k2 + 1] > 0) {
-            pos = objStmToOffset.get(xref[k2 + 1]);
+            pos = objStmToOffset.get((int) xref[k2 + 1]);
         }
         if (pos == 0) {
             return null;
@@ -1856,7 +1855,7 @@ public class PdfReader implements PdfViewerPreferences, Closeable {
             obj = null;
         }
         if (xref[k2 + 1] > 0) {
-            obj = readOneObjStm((PRStream) obj, xref[k2]);
+            obj = readOneObjStm((PRStream) obj, (int) xref[k2]);
         }
         xrefObj.set(k, obj);
         return obj;
@@ -1920,7 +1919,7 @@ public class PdfReader implements PdfViewerPreferences, Closeable {
         xrefObj = new ArrayList<>(xref.length / 2);
         xrefObj.addAll(Collections.nCopies(xref.length / 2, null));
         for (int k = 2; k < xref.length; k += 2) {
-            int pos = xref[k];
+            long pos = xref[k];
             if (pos <= 0 || ((xref.length > k + 1) && (xref[k + 1] > 0))) {
                 continue;
             }
@@ -1971,8 +1970,8 @@ public class PdfReader implements PdfViewerPreferences, Closeable {
     }
 
     private void checkPRStreamLength(PRStream stream) throws IOException {
-        int fileLength = tokens.length();
-        int start = stream.getOffset();
+        long fileLength = tokens.length();
+        long start = stream.getOffset();
         boolean calc = false;
         int streamLength = 0;
         PdfObject obj = getPdfObjectRelease(stream.get(PdfName.LENGTH));
@@ -1996,12 +1995,12 @@ public class PdfReader implements PdfViewerPreferences, Closeable {
             byte[] tline = new byte[16];
             tokens.seek(start);
             while (true) {
-                int pos = tokens.getFilePointer();
+                long pos = tokens.getFilePointer();
                 if (!tokens.readLineSegment(tline)) {
                     break;
                 }
                 if (equalsn(tline, endstreamBytes)) {
-                    streamLength = pos - start;
+                    streamLength = (int) (pos - start);
                     break;
                 }
                 if (equalsn(tline, endobj)) {
@@ -2011,7 +2010,7 @@ public class PdfReader implements PdfViewerPreferences, Closeable {
                     if (index >= 0) {
                         pos = pos - 16 + index;
                     }
-                    streamLength = pos - start;
+                    streamLength = (int) (pos - start);
                     break;
                 }
             }
@@ -2071,10 +2070,10 @@ public class PdfReader implements PdfViewerPreferences, Closeable {
             return;
         }
         if (xref == null) {
-            xref = new int[size];
+            xref = new long[size];
         } else {
             if (xref.length < size) {
-                int[] xref2 = new int[size];
+                long[] xref2 = new long[size];
                 System.arraycopy(xref, 0, xref2, 0, xref.length);
                 xref = xref2;
             }
@@ -2096,7 +2095,7 @@ public class PdfReader implements PdfViewerPreferences, Closeable {
                     MessageLocalization
                             .getComposedMessage("startxref.is.not.followed.by.a.number"));
         }
-        int startxref = tokens.intValue();
+        long startxref = tokens.longValue();
         lastXref = startxref;
         eofPos = tokens.getFilePointer();
         try {
@@ -2115,12 +2114,12 @@ public class PdfReader implements PdfViewerPreferences, Closeable {
             if (prev == null) {
                 break;
             }
-            if (prev.intValue() == startxref) {
+            if (prev.longValue() == startxref) {
                 throw new InvalidPdfException(
                         MessageLocalization
                                 .getComposedMessage("xref.infinite.loop"));
             }
-            tokens.seek(prev.intValue());
+            tokens.seek(prev.longValue());
             trailer2 = readXrefSection();
         }
     }
@@ -2133,7 +2132,7 @@ public class PdfReader implements PdfViewerPreferences, Closeable {
         }
         int start;
         int end;
-        int pos;
+        long pos;
         int gen;
         while (true) {
             tokens.nextValidToken();
@@ -2155,9 +2154,9 @@ public class PdfReader implements PdfViewerPreferences, Closeable {
             }
             end = tokens.intValue() + start;
             if (start == 1) { // fix incorrect start number
-                int back = tokens.getFilePointer();
+                long back = tokens.getFilePointer();
                 tokens.nextValidToken();
-                pos = tokens.intValue();
+                pos = tokens.longValue();
                 tokens.nextValidToken();
                 gen = tokens.intValue();
                 if (pos == 0 && gen == PdfWriter.GENERATION_MAX) {
@@ -2169,7 +2168,7 @@ public class PdfReader implements PdfViewerPreferences, Closeable {
             ensureXrefSize(end * 2);
             for (int k = start; k < end; ++k) {
                 tokens.nextValidToken();
-                pos = tokens.intValue();
+                pos = tokens.longValue();
                 tokens.nextValidToken();
                 tokens.nextValidToken();
                 int p = k * 2;
@@ -2195,7 +2194,7 @@ public class PdfReader implements PdfViewerPreferences, Closeable {
         ensureXrefSize(xrefSize.intValue() * 2);
         PdfObject xrs = trailer.get(PdfName.XREFSTM);
         if (xrs != null && xrs.isNumber()) {
-            int loc = ((PdfNumber) xrs).intValue();
+            long loc = ((PdfNumber) xrs).longValue();
             try {
                 readXRefStream(loc);
                 newXrefType = true;
@@ -2208,7 +2207,7 @@ public class PdfReader implements PdfViewerPreferences, Closeable {
         return trailer;
     }
 
-    protected boolean readXRefStream(int ptr) throws IOException {
+    protected boolean readXRefStream(long ptr) throws IOException {
         tokens.seek(ptr);
         int thisStream;
         if (!tokens.nextToken()) {
@@ -2249,10 +2248,10 @@ public class PdfReader implements PdfViewerPreferences, Closeable {
             index = (PdfArray) obj;
         }
         PdfArray w = (PdfArray) stm.get(PdfName.W);
-        int prev = -1;
+        long prev = -1;
         obj = stm.get(PdfName.PREV);
         if (obj != null) {
-            prev = ((PdfNumber) obj).intValue();
+            prev = ((PdfNumber) obj).longValue();
         }
         // Each xref pair is a position
         // type 0 -> -1, 0
@@ -2263,7 +2262,7 @@ public class PdfReader implements PdfViewerPreferences, Closeable {
             objStmMark = new HashMap<>();
         }
         if (objStmToOffset == null && partial) {
-            objStmToOffset = new IntHashtable();
+            objStmToOffset = new HashMap<>();
         }
         byte[] b = getStreamBytes(stm, tokens.getFile());
         int bptr = 0;
@@ -2283,7 +2282,7 @@ public class PdfReader implements PdfViewerPreferences, Closeable {
                         type = (type << 8) + (b[bptr++] & 0xff);
                     }
                 }
-                int field2 = 0;
+                long field2 = 0;
                 for (int k = 0; k < wc[1]; ++k) {
                     field2 = (field2 << 8) + (b[bptr++] & 0xff);
                 }
@@ -2304,9 +2303,9 @@ public class PdfReader implements PdfViewerPreferences, Closeable {
                             xref[base] = field3;
                             xref[base + 1] = field2;
                             if (partial) {
-                                objStmToOffset.put(field2, 0);
+                                objStmToOffset.put((int) field2, 0L);
                             } else {
-                                Integer on = field2;
+                                Integer on = (int) field2;
                                 IntHashtable seq = objStmMark.get(on);
                                 if (seq == null) {
                                     seq = new IntHashtable();
@@ -2337,12 +2336,12 @@ public class PdfReader implements PdfViewerPreferences, Closeable {
         hybridXref = false;
         newXrefType = false;
         tokens.seek(0);
-        int[][] xr = new int[1024][];
+        long[][] xr = new long[1024][];
         int top = 0;
         trailer = null;
         byte[] line = new byte[64];
         for (; ; ) {
-            int pos = tokens.getFilePointer();
+            long pos = tokens.getFilePointer();
             if (!tokens.readLineSegment(line)) {
                 break;
             }
@@ -2372,7 +2371,7 @@ public class PdfReader implements PdfViewerPreferences, Closeable {
                 int gen = obj[1];
                 if (num >= xr.length) {
                     int newLength = num * 2;
-                    int[][] xr2 = new int[newLength][];
+                    long[][] xr2 = new long[newLength][];
                     System.arraycopy(xr, 0, xr2, 0, top);
                     xr = xr2;
                 }
@@ -2380,17 +2379,16 @@ public class PdfReader implements PdfViewerPreferences, Closeable {
                     top = num + 1;
                 }
                 if (xr[num] == null || gen >= xr[num][1]) {
-                    obj[0] = pos;
-                    xr[num] = obj;
+                    xr[num] = new long[]{pos, gen};
                 }
             }
         }
         if (trailer == null) {
             throw new InvalidPdfException(MessageLocalization.getComposedMessage("trailer.not.found"));
         }
-        xref = new int[top * 2];
+        xref = new long[top * 2];
         for (int k = 0; k < top; ++k) {
-            int[] obj = xr[k];
+            long[] obj = xr[k];
             if (obj != null) {
                 xref[k * 2] = obj[0];
             }
@@ -2449,7 +2447,7 @@ public class PdfReader implements PdfViewerPreferences, Closeable {
                 ++readDepth;
                 PdfDictionary dic = readDictionary();
                 --readDepth;
-                int pos = tokens.getFilePointer();
+                long pos = tokens.getFilePointer();
                 // be careful in the trailer. May not be a "next" token.
                 boolean hasNext;
                 do {
@@ -2834,7 +2832,7 @@ public class PdfReader implements PdfViewerPreferences, Closeable {
      *
      * @return the byte address of the last xref table
      */
-    public int getLastXref() {
+    public long getLastXref() {
         return lastXref;
     }
 
@@ -2852,7 +2850,7 @@ public class PdfReader implements PdfViewerPreferences, Closeable {
      *
      * @return the byte address of the %%EOF marker
      */
-    public int getEofPos() {
+    public long getEofPos() {
         return eofPos;
     }
 
@@ -3713,7 +3711,7 @@ public class PdfReader implements PdfViewerPreferences, Closeable {
      *
      * @return Value of property fileLength.
      */
-    public int getFileLength() {
+    public long getFileLength() {
         return fileLength;
     }
 

--- a/openpdf-core/src/main/java/org/openpdf/text/pdf/PdfWriter.java
+++ b/openpdf-core/src/main/java/org/openpdf/text/pdf/PdfWriter.java
@@ -588,7 +588,7 @@ public class PdfWriter extends DocWriter implements
     /**
      * A number referring to the previous Cross-Reference Table.
      */
-    protected int prevxref = 0;
+    protected long prevxref = 0;
     protected List newBookmarks;
     /**
      * Stores the version information for the header and the catalog.
@@ -3263,7 +3263,7 @@ public class PdfWriter extends DocWriter implements
          */
 
         void writeCrossReferenceTable(OutputStream os, PdfIndirectReference root, PdfIndirectReference info,
-                PdfIndirectReference encryption, PdfObject fileID, int prevxref) throws IOException {
+                PdfIndirectReference encryption, PdfObject fileID, long prevxref) throws IOException {
             int refNumber = 0;
             // Old-style xref tables limit object offsets to 10 digits
             boolean useNewXrefFormat = writer.isFullCompression() || position > 9_999_999_999L;
@@ -3484,7 +3484,7 @@ public class PdfWriter extends DocWriter implements
          */
 
         PdfTrailer(int size, PdfIndirectReference root, PdfIndirectReference info, PdfIndirectReference encryption,
-                PdfObject fileID, int prevxref) {
+                PdfObject fileID, long prevxref) {
             put(PdfName.SIZE, new PdfNumber(size));
             put(PdfName.ROOT, root);
             if (info != null) {

--- a/openpdf-core/src/main/java/org/openpdf/text/pdf/RandomAccessFileOrArray.java
+++ b/openpdf-core/src/main/java/org/openpdf/text/pdf/RandomAccessFileOrArray.java
@@ -84,7 +84,7 @@ public class RandomAccessFileOrArray implements DataInput, Closeable {
     /**
      * Holds value of property startOffset.
      */
-    private int startOffset = 0;
+    private long startOffset = 0;
 
     public RandomAccessFileOrArray(String filename) throws IOException {
         this(filename, false, Document.plainRandomAccess);
@@ -246,10 +246,6 @@ public class RandomAccessFileOrArray implements DataInput, Closeable {
     }
 
     public long skip(long n) throws IOException {
-        return skipBytes((int) n);
-    }
-
-    public int skipBytes(int n) throws IOException {
         if (n <= 0) {
             return 0;
         }
@@ -263,9 +259,9 @@ public class RandomAccessFileOrArray implements DataInput, Closeable {
                 adj = 1;
             }
         }
-        int pos;
-        int len;
-        int newpos;
+        long pos;
+        long len;
+        long newpos;
 
         pos = getFilePointer();
         len = length();
@@ -277,6 +273,10 @@ public class RandomAccessFileOrArray implements DataInput, Closeable {
 
         /* return the actual number of bytes skipped */
         return newpos - pos + adj;
+    }
+
+    public int skipBytes(int n) throws IOException {
+        return (int) skip(n);
     }
 
     public void reOpen() throws IOException {
@@ -315,16 +315,20 @@ public class RandomAccessFileOrArray implements DataInput, Closeable {
         }
     }
 
-    public int length() throws IOException {
+    public long length() throws IOException {
         if (arrayIn == null) {
             insureOpen();
-            return (int) (plainRandomAccess ? trf.length() : rf.length()) - startOffset;
+            return (plainRandomAccess ? trf.length() : rf.length()) - startOffset;
         } else {
             return arrayIn.length - startOffset;
         }
     }
 
     public void seek(int pos) throws IOException {
+        seek((long) pos);
+    }
+
+    public void seek(long pos) throws IOException {
         pos += startOffset;
         isBack = false;
         if (arrayIn == null) {
@@ -335,19 +339,15 @@ public class RandomAccessFileOrArray implements DataInput, Closeable {
                 rf.seek(pos);
             }
         } else {
-            arrayInPtr = pos;
+            arrayInPtr = (int) pos;
         }
     }
 
-    public void seek(long pos) throws IOException {
-        seek((int) pos);
-    }
-
-    public int getFilePointer() throws IOException {
+    public long getFilePointer() throws IOException {
         insureOpen();
         int n = isBack ? 1 : 0;
         if (arrayIn == null) {
-            return (int) (plainRandomAccess ? trf.getFilePointer() : rf.getFilePointer()) - n - startOffset;
+            return (plainRandomAccess ? trf.getFilePointer() : rf.getFilePointer()) - n - startOffset;
         } else {
             return arrayInPtr - n - startOffset;
         }
@@ -595,7 +595,7 @@ public class RandomAccessFileOrArray implements DataInput, Closeable {
                     break;
                 case '\r':
                     eol = true;
-                    int cur = getFilePointer();
+                    long cur = getFilePointer();
                     if ((read()) != '\n') {
                         seek(cur);
                     }
@@ -621,7 +621,7 @@ public class RandomAccessFileOrArray implements DataInput, Closeable {
      *
      * @return Value of property startOffset.
      */
-    public int getStartOffset() {
+    public long getStartOffset() {
         return this.startOffset;
     }
 
@@ -630,7 +630,7 @@ public class RandomAccessFileOrArray implements DataInput, Closeable {
      *
      * @param startOffset New value of property startOffset.
      */
-    public void setStartOffset(int startOffset) {
+    public void setStartOffset(long startOffset) {
         this.startOffset = startOffset;
     }
 

--- a/openpdf-core/src/main/java/org/openpdf/text/pdf/RandomAccessFileOrArray.java
+++ b/openpdf-core/src/main/java/org/openpdf/text/pdf/RandomAccessFileOrArray.java
@@ -186,8 +186,7 @@ public class RandomAccessFileOrArray implements DataInput, Closeable {
             return back & 0xff;
         }
         if (arrayIn == null) {
-            insureOpen();
-            return plainRandomAccess ? trf.read() : rf.read();
+            return plainRandomAccess ? openPlainFile().read() : openMappedFile().read();
         } else {
             if (arrayInPtr >= arrayIn.length) {
                 return -1;
@@ -213,8 +212,7 @@ public class RandomAccessFileOrArray implements DataInput, Closeable {
             }
         }
         if (arrayIn == null) {
-            insureOpen();
-            return (plainRandomAccess ? trf.read(b, off, len) : rf.read(b, off, len)) + n;
+            return (plainRandomAccess ? openPlainFile().read(b, off, len) : openMappedFile().read(b, off, len)) + n;
         } else {
             if (arrayInPtr >= arrayIn.length) {
                 return -1;
@@ -298,6 +296,36 @@ public class RandomAccessFileOrArray implements DataInput, Closeable {
         }
     }
 
+    /**
+     * Returns the open plain {@link RandomAccessFile} backing this object, reopening it if
+     * needed. Never returns {@code null}.
+     *
+     * @throws IOException if there is no backing file or it cannot be reopened
+     */
+    private RandomAccessFile openPlainFile() throws IOException {
+        insureOpen();
+        RandomAccessFile file = trf;
+        if (file == null) {
+            throw new IOException("RandomAccessFileOrArray: the backing file is not open");
+        }
+        return file;
+    }
+
+    /**
+     * Returns the open {@link MappedRandomAccessFile} backing this object, reopening it if
+     * needed. Never returns {@code null}.
+     *
+     * @throws IOException if there is no backing file or it cannot be reopened
+     */
+    private MappedRandomAccessFile openMappedFile() throws IOException {
+        insureOpen();
+        MappedRandomAccessFile file = rf;
+        if (file == null) {
+            throw new IOException("RandomAccessFileOrArray: the backing file is not open");
+        }
+        return file;
+    }
+
     public boolean isOpen() {
         return (filename == null || rf != null || trf != null);
     }
@@ -319,8 +347,7 @@ public class RandomAccessFileOrArray implements DataInput, Closeable {
 
     public long length() throws IOException {
         if (arrayIn == null) {
-            insureOpen();
-            return (plainRandomAccess ? trf.length() : rf.length()) - startOffset;
+            return (plainRandomAccess ? openPlainFile().length() : openMappedFile().length()) - startOffset;
         } else {
             return arrayIn.length - startOffset;
         }
@@ -334,11 +361,10 @@ public class RandomAccessFileOrArray implements DataInput, Closeable {
         pos += startOffset;
         isBack = false;
         if (arrayIn == null) {
-            insureOpen();
             if (plainRandomAccess) {
-                trf.seek(pos);
+                openPlainFile().seek(pos);
             } else {
-                rf.seek(pos);
+                openMappedFile().seek(pos);
             }
         } else {
             arrayInPtr = (int) pos;
@@ -346,10 +372,10 @@ public class RandomAccessFileOrArray implements DataInput, Closeable {
     }
 
     public long getFilePointer() throws IOException {
-        insureOpen();
         int n = isBack ? 1 : 0;
         if (arrayIn == null) {
-            return (plainRandomAccess ? trf.getFilePointer() : rf.getFilePointer()) - n - startOffset;
+            return (plainRandomAccess ? openPlainFile().getFilePointer() : openMappedFile().getFilePointer())
+                    - n - startOffset;
         } else {
             return arrayInPtr - n - startOffset;
         }
@@ -643,12 +669,7 @@ public class RandomAccessFileOrArray implements DataInput, Closeable {
      */
     public java.nio.ByteBuffer getNioByteBuffer() throws IOException {
         if (filename != null) {
-            FileChannel channel;
-            if (plainRandomAccess) {
-                channel = trf.getChannel();
-            } else {
-                channel = rf.getChannel();
-            }
+            FileChannel channel = plainRandomAccess ? openPlainFile().getChannel() : openMappedFile().getChannel();
             return channel.map(FileChannel.MapMode.READ_ONLY, 0, channel.size());
         }
         return java.nio.ByteBuffer.wrap(arrayIn);

--- a/openpdf-core/src/main/java/org/openpdf/text/pdf/RandomAccessFileOrArray.java
+++ b/openpdf-core/src/main/java/org/openpdf/text/pdf/RandomAccessFileOrArray.java
@@ -186,6 +186,7 @@ public class RandomAccessFileOrArray implements DataInput, Closeable {
             return back & 0xff;
         }
         if (arrayIn == null) {
+            insureOpen();
             return plainRandomAccess ? trf.read() : rf.read();
         } else {
             if (arrayInPtr >= arrayIn.length) {
@@ -212,6 +213,7 @@ public class RandomAccessFileOrArray implements DataInput, Closeable {
             }
         }
         if (arrayIn == null) {
+            insureOpen();
             return (plainRandomAccess ? trf.read(b, off, len) : rf.read(b, off, len)) + n;
         } else {
             if (arrayInPtr >= arrayIn.length) {

--- a/openpdf-core/src/main/java/org/openpdf/text/pdf/TrueTypeFont.java
+++ b/openpdf-core/src/main/java/org/openpdf/text/pdf/TrueTypeFont.java
@@ -516,7 +516,7 @@ class TrueTypeFont extends BaseFont {
             int length = rf.readUnsignedShort();
             int offset = rf.readUnsignedShort();
             if (nameID == id) {
-                int pos = rf.getFilePointer();
+                long pos = rf.getFilePointer();
                 rf.seek(table_location[0] + startOfStorage + offset);
                 String name;
                 if (platformID == 0 || platformID == 3 || (platformID == 2 && platformEncodingID == 1)) {
@@ -559,7 +559,7 @@ class TrueTypeFont extends BaseFont {
             int nameID = rf.readUnsignedShort();
             int length = rf.readUnsignedShort();
             int offset = rf.readUnsignedShort();
-            int pos = rf.getFilePointer();
+            long pos = rf.getFilePointer();
             rf.seek(table_location[0] + startOfStorage + offset);
             String name;
             if (platformID == 0 || platformID == 3 || (platformID == 2 && platformEncodingID == 1)) {
@@ -1257,7 +1257,7 @@ class TrueTypeFont extends BaseFont {
         try {
             rf2 = new RandomAccessFileOrArray(rf);
             rf2.reOpen();
-            byte[] b = new byte[rf2.length()];
+            byte[] b = new byte[(int) rf2.length()];
             rf2.readFully(b);
             return b;
         } finally {

--- a/openpdf-core/src/main/java/org/openpdf/text/pdf/Type1Font.java
+++ b/openpdf-core/src/main/java/org/openpdf/text/pdf/Type1Font.java
@@ -566,7 +566,7 @@ class Type1Font extends BaseFont {
             } else {
                 rf = new RandomAccessFileOrArray(pfb);
             }
-            int fileLength = rf.length();
+            int fileLength = (int) rf.length();
             byte[] st = new byte[fileLength - 18];
             int[] lengths = new int[3];
             int bytePtr = 0;

--- a/openpdf-core/src/test/java/org/openpdf/text/pdf/LargeFilePdfReaderTest.java
+++ b/openpdf-core/src/test/java/org/openpdf/text/pdf/LargeFilePdfReaderTest.java
@@ -69,9 +69,9 @@ class LargeFilePdfReaderTest {
         long xrefPos = off3 + obj3.length();
         String xref = "xref\n0 4\n"
                 + "0000000000 65535 f \n"
-                + String.format("%010d 00000 n \n", off1)
-                + String.format("%010d 00000 n \n", off2)
-                + String.format("%010d 00000 n \n", off3)
+                + xrefEntry(off1)
+                + xrefEntry(off2)
+                + xrefEntry(off3)
                 + "trailer\n<< /Size 4 /Root 1 0 R >>\nstartxref\n" + xrefPos + "\n%%EOF";
 
         try (SeekableByteChannel ch = open(file)) {
@@ -90,6 +90,15 @@ class LargeFilePdfReaderTest {
         } finally {
             reader.close();
         }
+    }
+
+    /**
+     * Builds a 20-byte cross-reference table entry. The xref format mandates a single LF (or CR LF)
+     * ending the 20-byte record, so the line ending is deliberately not platform-specific.
+     */
+    private static String xrefEntry(long offset) {
+        String digits = Long.toString(offset);
+        return "0".repeat(10 - digits.length()) + digits + " 00000 n \n";
     }
 
     private static SeekableByteChannel open(Path file) throws IOException {

--- a/openpdf-core/src/test/java/org/openpdf/text/pdf/LargeFilePdfReaderTest.java
+++ b/openpdf-core/src/test/java/org/openpdf/text/pdf/LargeFilePdfReaderTest.java
@@ -1,0 +1,112 @@
+package org.openpdf.text.pdf;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.SeekableByteChannel;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Tests for issue #1582: PDF files larger than ~2 GB could not be read because file positions
+ * were tracked as {@code int} in {@link RandomAccessFileOrArray}, {@link PRTokeniser} and the
+ * {@link PdfReader} xref table, overflowing for offsets beyond {@code Integer.MAX_VALUE}.
+ * <p>
+ * The tests build a <em>sparse</em> file whose PDF objects live above the 2 GB boundary, so only
+ * a few kilobytes of real data are written while all file offsets require 64-bit arithmetic.
+ * With the fix in place both tests complete in well under a second; the timeout guards against a
+ * regression, where the overflowed offsets would send the reader scanning gigabytes of data.
+ */
+@Timeout(value = 30, unit = TimeUnit.SECONDS)
+class LargeFilePdfReaderTest {
+
+    /** All PDF objects are placed above this offset, safely beyond Integer.MAX_VALUE (2^31-1). */
+    private static final long BASE = 3_000_000_000L;
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void filePointerAndLengthBeyond2GB() throws Exception {
+        Path file = tempDir.resolve("large-raw.bin");
+        long length = BASE + 16;
+        try (SeekableByteChannel ch = open(file)) {
+            ch.position(length - 1);
+            ch.write(ByteBuffer.wrap(new byte[]{(byte) 0x42}));
+        }
+        assumeSparse(file);
+
+        RandomAccessFileOrArray raf = new RandomAccessFileOrArray(file.toString(), false, true);
+        try {
+            assertEquals(length, raf.length(), "length() must not overflow for files > 2 GB");
+            raf.seek(length - 1);
+            assertEquals(length - 1, raf.getFilePointer(), "getFilePointer() must not overflow beyond 2 GB");
+            assertEquals(0x42, raf.read(), "Byte at an offset beyond 2 GB must be readable");
+            assertEquals(length, raf.getFilePointer());
+        } finally {
+            raf.close();
+        }
+    }
+
+    @Test
+    void readPdfLargerThan2GB() throws Exception {
+        Path file = tempDir.resolve("large.pdf");
+
+        String obj1 = "1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n";
+        String obj2 = "2 0 obj\n<< /Type /Pages /Kids [3 0 R] /Count 1 >>\nendobj\n";
+        String obj3 = "3 0 obj\n<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] >>\nendobj\n";
+        long off1 = BASE;
+        long off2 = off1 + obj1.length();
+        long off3 = off2 + obj2.length();
+        long xrefPos = off3 + obj3.length();
+        String xref = "xref\n0 4\n"
+                + "0000000000 65535 f \n"
+                + String.format("%010d 00000 n \n", off1)
+                + String.format("%010d 00000 n \n", off2)
+                + String.format("%010d 00000 n \n", off3)
+                + "trailer\n<< /Size 4 /Root 1 0 R >>\nstartxref\n" + xrefPos + "\n%%EOF";
+
+        try (SeekableByteChannel ch = open(file)) {
+            ch.write(ByteBuffer.wrap("%PDF-1.5\n".getBytes(StandardCharsets.ISO_8859_1)));
+            ch.position(BASE);
+            ch.write(ByteBuffer.wrap((obj1 + obj2 + obj3 + xref).getBytes(StandardCharsets.ISO_8859_1)));
+        }
+        assumeSparse(file);
+
+        // Partial-read path, plain random access — the combination reported in the issue.
+        PdfReader reader = new PdfReader(new RandomAccessFileOrArray(file.toString(), false, true), new byte[0]);
+        try {
+            assertEquals(1, reader.getNumberOfPages(), "Page count of a > 2 GB PDF");
+            assertEquals(612, (int) reader.getPageSize(1).getWidth(), "Page width of a > 2 GB PDF");
+            assertEquals(xrefPos, reader.getLastXref(), "startxref offset beyond 2 GB");
+        } finally {
+            reader.close();
+        }
+    }
+
+    private static SeekableByteChannel open(Path file) throws IOException {
+        return Files.newByteChannel(file, StandardOpenOption.CREATE_NEW, StandardOpenOption.WRITE,
+                StandardOpenOption.SPARSE);
+    }
+
+    /**
+     * Skips the test when the filesystem materialized the sparse file (needing > 2 GB of real
+     * disk), to avoid hammering machines without sparse-file support.
+     */
+    private static void assumeSparse(Path file) {
+        try {
+            long usableSpace = Files.getFileStore(file).getUsableSpace();
+            assumeTrue(usableSpace > BASE, "Not enough free disk space to run large-file test");
+        } catch (IOException e) {
+            assumeTrue(false, "Cannot determine free disk space: " + e.getMessage());
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #1582.

Reading a PDF larger than ~2 GB failed with `InvalidPdfException: Rebuild failed: Position out of bounds; Original message: PDF startxref not found` (after potentially scanning the file for a very long time). File positions were tracked as `int` in `RandomAccessFileOrArray`, `PRTokeniser`, `PRStream` and the `PdfReader` xref table, so any offset beyond `Integer.MAX_VALUE` overflowed.

## Changes

The read path now uses 64-bit offsets end to end (the same migration iText 5 did for large-file support):

- **`RandomAccessFileOrArray`**: `length()`, `getFilePointer()`, `getStartOffset()`/`setStartOffset()` and `skip()` are `long`-based; `seek(long)` is the real implementation (`seek(int)` delegates). The backing `MappedRandomAccessFile` was already `long`-based via `LongMappedByteBuffer`.
- **`PRTokeniser`**: `seek`/`getFilePointer`/`length`/`getStartxref` use `long`; new `longValue()` parses 10-digit offsets.
- **`PdfReader`**: the xref table is `long[]`, `lastXref`/`eofPos`/`fileLength` are `long`, xref-stream type-1 offsets are read as `long`, `objStmToOffset` is now `Map<Integer, Long>`, `rebuildXref()` collects `long` positions. `getLastXref()`, `getEofPos()`, `getFileLength()` return `long`.
- **`PRStream`**: the stream offset is `long`.
- **`PdfNumber`**: new `longValue()` accessor (used for `startxref`, `/Prev`, `/XRefStm`).
- **`PdfWriter`**: `prevxref` is `long`, so incremental updates (`PdfStamper` in append mode) of large files write a correct `/Prev`.
- Font-parsing call sites (`TrueTypeFont`, `Type1Font`, `EnumerateTTC`, `CFFFont`) updated for the new signatures; font files themselves remain int-sized.

### API note

Some `protected` fields and public getters changed from `int` to `long` (`PdfReader.xref`, `getLastXref()`, `getEofPos()`, `getFileLength()`, `RandomAccessFileOrArray.length()`/`getFilePointer()`, `PRStream.getOffset()`). Callers passing `int` positions still compile via widening; only code *storing* these values into `int` needs a cast. This mirrors iText 5's large-file migration.

## Tests

`LargeFilePdfReaderTest` builds a **sparse** PDF whose objects live above the 2 GB boundary — only a few KB of real data are written, so the tests run in ~0.5 s:

- `filePointerAndLengthBeyond2GB`: `length()`, `seek()`, `getFilePointer()` and `read()` at offsets beyond 2^31.
- `readPdfLargerThan2GB`: full `PdfReader` open of a >2 GB PDF (partial-read path with plain random access, as in the issue report), asserting page count, page size and `getLastXref()`.

The class carries a 30 s `@Timeout` because a regression here manifests as a long file scan rather than a fast failure. A skip-guard (`assumeTrue`) avoids running on filesystems without sparse-file support / insufficient disk. Full `openpdf-core` suite passes (2087 tests, 0 failures), and all modules compile.


