### PR TITLE
Fix #1585: handle /P permissions written as unsigned int32 in encrypted PDFs

### DIFF
--- a/openpdf-core/src/main/java/org/openpdf/text/pdf/PdfNumber.java
+++ b/openpdf-core/src/main/java/org/openpdf/text/pdf/PdfNumber.java
@@ -135,11 +135,17 @@ public class PdfNumber extends PdfObject implements Comparable<PdfNumber> {
 
     /**
      * Returns the primitive <CODE>int</CODE> value of this object.
+     * <p>
+     * The conversion goes through <CODE>long</CODE> to preserve two's complement semantics for
+     * values written as unsigned 32-bit integers. Some PDF producers (e.g. mPDF) store the
+     * <CODE>/P</CODE> permissions entry as an unsigned value such as 4294963412 instead of the
+     * signed -3884 required by ISO 32000; a direct double-to-int cast would clamp such values to
+     * <CODE>Integer.MAX_VALUE</CODE> (JLS 5.1.3) and break the encryption key derivation.
      *
      * @return The value as <CODE>int</CODE>
      */
     public int intValue() {
-        return (int) value;
+        return (int) (long) value;
     }
 
     /**

--- a/openpdf-core/src/test/java/org/openpdf/text/pdf/PdfNumberTest.java
+++ b/openpdf-core/src/test/java/org/openpdf/text/pdf/PdfNumberTest.java
@@ -1,0 +1,36 @@
+package org.openpdf.text.pdf;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for issue #1585: some PDF producers (e.g. mPDF) write the /P permissions entry of the
+ * encryption dictionary as an unsigned 32-bit integer (4294963412) instead of the signed value
+ * required by ISO 32000 (-3884). {@link PdfNumber#intValue()} used a direct double-to-int cast,
+ * which clamps values above {@code Integer.MAX_VALUE} (JLS 5.1.3) instead of preserving the bit
+ * pattern, so the RC4/AES key derivation used a wrong /P and threw BadPasswordException even for
+ * documents with an empty user password.
+ */
+class PdfNumberTest {
+
+    @Test
+    void intValueWrapsUnsignedInt32() {
+        // 4294963412 == 0xFFFFF0D4 == -3884 as signed int32 (the mPDF example from the issue)
+        assertEquals(-3884, new PdfNumber("4294963412").intValue(),
+                "Unsigned int32 must wrap to its two's complement value, not clamp to Integer.MAX_VALUE");
+        assertEquals(-4, new PdfNumber("4294967292").intValue());
+        assertEquals(Integer.MIN_VALUE, new PdfNumber("2147483648").intValue());
+    }
+
+    @Test
+    void intValueUnchangedForSignedRange() {
+        assertEquals(-3884, new PdfNumber("-3884").intValue());
+        assertEquals(0, new PdfNumber("0").intValue());
+        assertEquals(42, new PdfNumber(42).intValue());
+        assertEquals(Integer.MAX_VALUE, new PdfNumber(Integer.MAX_VALUE).intValue());
+        assertEquals(Integer.MIN_VALUE, new PdfNumber(Integer.MIN_VALUE).intValue());
+        assertEquals(3, new PdfNumber(3.9).intValue(), "Fractional values still truncate toward zero");
+        assertEquals(-3, new PdfNumber(-3.9).intValue(), "Fractional values still truncate toward zero");
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #1585.

PDFs encrypted with RC4 40-bit (R=2, V=1) by producers like **mPDF** threw `BadPasswordException: Bad user password` even with an empty user password, while Acrobat, qpdf, PDFBox and Evince all open the same files fine.

## Root cause

mPDF writes the `/P` permissions entry as an **unsigned** 32-bit integer (e.g. `4294963412`) instead of the signed value required by ISO 32000 (`-3884`) — the bit pattern is identical. `PdfNumber` stores values as `double`, and `intValue()` did a direct `(int) value` cast. Per JLS §5.1.3, a double-to-int cast **clamps** values above `Integer.MAX_VALUE` to `2147483647` rather than wrapping, so the `pValue` fed into the MD5 that derives the RC4 key was wrong and no longer matched the `/U` entry.

## Fix

```java
// before
return (int) value;
// after — through long, preserving two's complement semantics
return (int) (long) value;
```

`4294963412` now converts to `-3884` as other readers do. All values in the signed 32-bit range are unaffected (including fractional truncation semantics).

## Tests

New `PdfNumberTest`:
- `intValueWrapsUnsignedInt32` — the mPDF value `4294963412 → -3884`, plus `4294967292 → -4` and `2147483648 → Integer.MIN_VALUE`. Fails on master, passes with the fix.
- `intValueUnchangedForSignedRange` — guards existing behavior for normal, boundary and fractional values.

Full `openpdf-core` suite passes: 2086 tests, 0 failures — confirming nothing relied on the old clamping behavior.
