### PR TITLE
Fix #1296: ExceptionConverter.getStackTrace() no longer returns an empty array

### DIFF
--- a/openpdf-core/src/main/java/org/openpdf/text/ExceptionConverter.java
+++ b/openpdf-core/src/main/java/org/openpdf/text/ExceptionConverter.java
@@ -69,18 +69,15 @@ package org.openpdf.text;
 
 /**
  * The ExceptionConverter changes a checked exception into an unchecked exception.
+ * <p>
+ * The wrapped exception is set as the {@linkplain #getCause() cause}, so logging frameworks and
+ * {@link #getStackTrace()} see the complete stack trace of both the conversion point and the
+ * original exception (issue #1296 reported {@code getStackTrace()} returning an empty array
+ * because the stack trace was suppressed and the original exception was not set as the cause).
  */
 public class ExceptionConverter extends RuntimeException {
 
     private static final long serialVersionUID = 8657630363395849399L;
-    /**
-     * we keep a handle to the wrapped exception
-     */
-    private Exception ex;
-    /**
-     * prefix for the exception
-     */
-    private String prefix;
 
     /**
      * Construct a RuntimeException based on another Exception
@@ -88,8 +85,7 @@ public class ExceptionConverter extends RuntimeException {
      * @param ex the exception that has to be turned into a RuntimeException
      */
     public ExceptionConverter(Exception ex) {
-        this.ex = ex;
-        prefix = (ex instanceof RuntimeException) ? "" : "ExceptionConverter: ";
+        super(ex);
     }
 
     /**
@@ -113,7 +109,7 @@ public class ExceptionConverter extends RuntimeException {
      * @return the original exception
      */
     public Exception getException() {
-        return ex;
+        return (Exception) getCause();
     }
 
     /**
@@ -121,8 +117,9 @@ public class ExceptionConverter extends RuntimeException {
      *
      * @return message of the original exception
      */
+    @Override
     public String getMessage() {
-        return ex.getMessage();
+        return getCause().getMessage();
     }
 
     /**
@@ -130,8 +127,9 @@ public class ExceptionConverter extends RuntimeException {
      *
      * @return localized version of the message
      */
+    @Override
     public String getLocalizedMessage() {
-        return ex.getLocalizedMessage();
+        return getCause().getLocalizedMessage();
     }
 
     /**
@@ -139,48 +137,9 @@ public class ExceptionConverter extends RuntimeException {
      *
      * @return String version of the exception
      */
+    @Override
     public String toString() {
-        return prefix + ex;
-    }
-
-    /**
-     * we have to override this as well
-     */
-    public void printStackTrace() {
-        printStackTrace(System.err);
-    }
-
-    /**
-     * here we prefix, with printStream.print(), not printStream.println(), the stack trace with "ExceptionConverter:"
-     *
-     * @param printStream printStream
-     */
-    public void printStackTrace(java.io.PrintStream printStream) {
-        synchronized (printStream) {
-            printStream.print(prefix);
-            ex.printStackTrace(printStream);
-        }
-    }
-
-    /**
-     * Again, we prefix the stack trace with "ExceptionConverter:"
-     *
-     * @param printWriter printWriter
-     */
-    public void printStackTrace(java.io.PrintWriter printWriter) {
-        synchronized (printWriter) {
-            printWriter.print(prefix);
-            ex.printStackTrace(printWriter);
-        }
-    }
-
-    /**
-     * requests to fill in the stack trace we will have to ignore. We can't throw an exception here, because this method
-     * is called by the constructor of Throwable
-     *
-     * @return a Throwable
-     */
-    public synchronized Throwable fillInStackTrace() {
-        return this;
+        Throwable cause = getCause();
+        return (cause instanceof RuntimeException ? "" : "ExceptionConverter: ") + String.valueOf(cause);
     }
 }

--- a/openpdf-core/src/test/java/org/openpdf/text/ExceptionConverterTest.java
+++ b/openpdf-core/src/test/java/org/openpdf/text/ExceptionConverterTest.java
@@ -1,0 +1,64 @@
+package org.openpdf.text;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for issue #1296: {@code ExceptionConverter.getStackTrace()} always returned an empty
+ * array because {@code fillInStackTrace()} was suppressed, and {@code getCause()} returned null
+ * because the wrapped exception was kept in a private field. Logging frameworks therefore printed
+ * no stack trace at all when an ExceptionConverter propagated to user code.
+ */
+class ExceptionConverterTest {
+
+    @Test
+    void stackTraceIsNotEmpty() {
+        ExceptionConverter converter = new ExceptionConverter(new IOException("test"));
+        assertTrue(converter.getStackTrace().length > 0, "getStackTrace() must not be empty");
+    }
+
+    @Test
+    void wrappedExceptionIsTheCause() {
+        IOException wrapped = new IOException("test");
+        ExceptionConverter converter = new ExceptionConverter(wrapped);
+        assertSame(wrapped, converter.getCause(), "The wrapped exception must be the cause");
+        assertSame(wrapped, converter.getException(), "getException() must return the wrapped exception");
+    }
+
+    @Test
+    void messageDelegatesToWrappedException() {
+        ExceptionConverter converter = new ExceptionConverter(new IOException("test"));
+        assertEquals("test", converter.getMessage());
+        assertEquals("ExceptionConverter: java.io.IOException: test", converter.toString());
+        // no prefix when the wrapped exception is already unchecked
+        assertEquals("java.lang.IllegalStateException: oops",
+                new ExceptionConverter(new IllegalStateException("oops")).toString());
+    }
+
+    @Test
+    void printStackTraceContainsWrappedExceptionTrace() {
+        ExceptionConverter converter = new ExceptionConverter(new IOException("test"));
+        StringWriter out = new StringWriter();
+        converter.printStackTrace(new PrintWriter(out));
+        String trace = out.toString();
+        assertTrue(trace.contains("java.io.IOException: test"),
+                "The stack trace must contain the wrapped exception");
+        assertTrue(trace.contains("printStackTraceContainsWrappedExceptionTrace"),
+                "The stack trace must contain the frame where the exception was converted");
+    }
+
+    @Test
+    void convertExceptionReturnsRuntimeExceptionsUnwrapped() {
+        IllegalStateException unchecked = new IllegalStateException("oops");
+        assertSame(unchecked, ExceptionConverter.convertException(unchecked));
+        IOException checked = new IOException("test");
+        RuntimeException converted = ExceptionConverter.convertException(checked);
+        assertSame(checked, converted.getCause());
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #1296.

`new ExceptionConverter(new IOException("test")).getStackTrace()` returned an **empty array**, and `getCause()` returned **null**. Any logging framework or error reporter that relies on `getStackTrace()`/`getCause()` (i.e. essentially all of them) printed no stack trace at all when an `ExceptionConverter` propagated to user code. The information was only reachable through the class's custom `printStackTrace()` overrides.

## Root cause

The class suppressed stack-trace collection (`fillInStackTrace()` returned `this` without filling) and kept the wrapped exception in a private field instead of setting it as the exception cause.

## Fix

As suggested in the issue, make it a regular wrapper:

- The original exception is passed to `super(ex)` and becomes the **cause** — `getCause()`, `getStackTrace()` and standard `printStackTrace()` now show the full picture: the conversion point plus `Caused by:` with the original exception. No information is lost.
- The `fillInStackTrace()` and custom `printStackTrace(...)` overrides are removed; standard `Throwable` behavior takes over.
- Backwards-compatible surface kept: `getException()` (now returns the cause), `getMessage()`/`getLocalizedMessage()` (still delegate to the wrapped exception), `toString()` (still prefixed with `ExceptionConverter: ` for checked exceptions, unprefixed for runtime exceptions), and `convertException(...)`.

Behavior note: `printStackTrace()` output now follows the standard JDK format (wrapper frames + `Caused by:` section) instead of printing only the wrapped exception's trace with a prefix — strictly more information, in the format every Java developer and tool expects.

## Tests

New `ExceptionConverterTest` covers: non-empty `getStackTrace()`, cause wiring, `getException()`, message/localized-message delegation, `toString()` prefix behavior for checked vs unchecked, `printStackTrace` containing both the original exception and the conversion frame, and `convertException` pass-through for runtime exceptions. The stack-trace and cause assertions fail on master. Full `openpdf-core` suite passes.

