### PR TITLE
Fix #1268: cache parsed fonts during content stream processing

### DIFF
--- a/openpdf-core/src/main/java/org/openpdf/text/pdf/parser/PdfContentStreamHandler.java
+++ b/openpdf-core/src/main/java/org/openpdf/text/pdf/parser/PdfContentStreamHandler.java
@@ -90,6 +90,13 @@ public abstract class PdfContentStreamHandler {
      */
     protected Stack<GraphicsState> gsStack;
     /**
+     * Fonts already parsed by this handler, keyed by the object number of their font dictionary.
+     * Constructing a {@link CMapAwareDocumentFont} parses the embedded font program and the
+     * ToUnicode CMap, which is far too expensive to repeat for every Tf operator in the content
+     * stream (issue #1268: a page selecting fonts hundreds of times used gigabytes of memory).
+     */
+    private final Map<Integer, CMapAwareDocumentFont> documentFontCache = new HashMap<>();
+    /**
      * Text matrix.
      */
     protected Matrix textMatrix;
@@ -122,6 +129,18 @@ public abstract class PdfContentStreamHandler {
      * @param operator the operator that will receive notification when the operator is encountered
      * @since 2.1.7
      */
+    /**
+     * Returns the parsed font for the given font dictionary reference, reusing a previously
+     * parsed instance when the same font is selected more than once by this content stream.
+     *
+     * @param fontRef indirect reference to the font dictionary
+     * @return the parsed font
+     */
+    protected CMapAwareDocumentFont getFont(PRIndirectReference fontRef) {
+        return documentFontCache.computeIfAbsent(fontRef.getNumber(),
+                n -> new CMapAwareDocumentFont(fontRef));
+    }
+
     public void registerContentOperator(ContentOperator operator) {
         String operatorString = operator.getOperatorName();
         if (operators.containsKey(operatorString)) {
@@ -555,7 +574,7 @@ public abstract class PdfContentStreamHandler {
 
             PdfDictionary fontsDictionary = resources.getAsDict(PdfName.FONT);
             PdfObject pdfObject = fontsDictionary.get(fontResourceName);
-            CMapAwareDocumentFont font = new CMapAwareDocumentFont((PRIndirectReference) pdfObject);
+            CMapAwareDocumentFont font = handler.getFont((PRIndirectReference) pdfObject);
 
             handler.graphicsState().setFont(font);
             handler.graphicsState().setFontSize(size);

--- a/openpdf-core/src/test/java/org/openpdf/text/pdf/parser/PdfContentStreamHandlerFontCacheTest.java
+++ b/openpdf-core/src/test/java/org/openpdf/text/pdf/parser/PdfContentStreamHandlerFontCacheTest.java
@@ -41,18 +41,22 @@ class PdfContentStreamHandlerFontCacheTest {
             PdfContentStreamHandler handler = new PdfContentStreamHandler(new MarkedUpTextAssembler(reader)) {
                 @Override
                 void popContext() {
+                    // not needed for the font cache test
                 }
 
                 @Override
                 void pushContext(String newContextName) {
+                    // not needed for the font cache test
                 }
 
                 @Override
                 public void reset() {
+                    // not needed for the font cache test
                 }
 
                 @Override
                 void displayPdfString(PdfString string) {
+                    // not needed for the font cache test
                 }
 
                 @Override

--- a/openpdf-core/src/test/java/org/openpdf/text/pdf/parser/PdfContentStreamHandlerFontCacheTest.java
+++ b/openpdf-core/src/test/java/org/openpdf/text/pdf/parser/PdfContentStreamHandlerFontCacheTest.java
@@ -1,0 +1,72 @@
+package org.openpdf.text.pdf.parser;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+import java.io.ByteArrayOutputStream;
+import org.junit.jupiter.api.Test;
+import org.openpdf.text.Document;
+import org.openpdf.text.Paragraph;
+import org.openpdf.text.pdf.CMapAwareDocumentFont;
+import org.openpdf.text.pdf.PRIndirectReference;
+import org.openpdf.text.pdf.PdfDictionary;
+import org.openpdf.text.pdf.PdfName;
+import org.openpdf.text.pdf.PdfReader;
+import org.openpdf.text.pdf.PdfString;
+import org.openpdf.text.pdf.PdfWriter;
+import org.openpdf.text.pdf.parser.PdfTextExtractor;
+
+/**
+ * Tests for issue #1268: every Tf operator in a content stream constructed a fresh
+ * {@link CMapAwareDocumentFont}, re-parsing the embedded font program and ToUnicode CMap. A page
+ * that selects fonts hundreds of times allocated gigabytes while being processed. The handler now
+ * caches parsed fonts by the object number of the font dictionary.
+ */
+class PdfContentStreamHandlerFontCacheTest {
+
+    @Test
+    void fontIsParsedOnlyOncePerReference() throws Exception {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        Document document = new Document();
+        PdfWriter.getInstance(document, out);
+        document.open();
+        document.add(new Paragraph("Hello font cache"));
+        document.close();
+
+        PdfReader reader = new PdfReader(out.toByteArray());
+        try {
+            PdfDictionary fonts = reader.getPageN(1).getAsDict(PdfName.RESOURCES).getAsDict(PdfName.FONT);
+            PRIndirectReference fontRef = (PRIndirectReference) fonts.get(fonts.getKeys().iterator().next());
+
+            PdfContentStreamHandler handler = new PdfContentStreamHandler(new MarkedUpTextAssembler(reader)) {
+                @Override
+                void popContext() {
+                }
+
+                @Override
+                void pushContext(String newContextName) {
+                }
+
+                @Override
+                public void reset() {
+                }
+
+                @Override
+                void displayPdfString(PdfString string) {
+                }
+
+                @Override
+                public String getResultantText() {
+                    return "";
+                }
+            };
+            assertSame(handler.getFont(fontRef), handler.getFont(fontRef),
+                    "The handler must reuse the parsed font for repeated Tf operators");
+
+            assertEquals("Hello font cache", new PdfTextExtractor(reader).getTextFromPage(1),
+                    "Text extraction must still work with the font cache");
+        } finally {
+            reader.close();
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #1268.

Extracting text from the PDF attached to the issue used ~17 GB of memory on page 4. Reproduced locally: with a 1 GB heap, `PdfTextExtractor.getTextFromPage(4)` dies with `OutOfMemoryError` inside the CMap parser; pages 1–3 use ~30 MB.

## Root cause

`PdfContentStreamHandler$SetTextFont` (the `Tf` operator) constructed a **new** `CMapAwareDocumentFont` for every font-selection operator in the content stream:

```java
CMapAwareDocumentFont font = new CMapAwareDocumentFont((PRIndirectReference) pdfObject);
```

Constructing that font parses the embedded font program and the ToUnicode CMap from scratch. Page 4 of the issue's PDF contains **386 `Tf` operators** across 12 fonts (vs ≤73 on other pages), so the same dozen fonts were fully re-parsed hundreds of times, allocating gigabytes of short-lived objects.

## Fix

`PdfContentStreamHandler` now caches parsed fonts by the object number of their font dictionary; each font is parsed once per handler instead of once per `Tf` operator. This mirrors the font caching iText later added to its content stream processor.

**Measured on the issue's PDF** (all 7 pages, page-by-page extraction):

| | before | after |
|---|---|---|
| page 4 | `OutOfMemoryError` at 1 GB heap (~17 GB reported) | 116 ms, extraction completes |
| whole document | fails | ~0.5 s within a 256 MB heap |

Extracted text is unchanged for the pages that completed before the fix.

## Tests

New `PdfContentStreamHandlerFontCacheTest` asserts that the handler returns the same parsed font instance for repeated lookups of the same font reference, and that text extraction output is unaffected. Full `openpdf-core` suite passes.
