### PR TITLE
Fix #1163: throw DocumentException instead of writing 'ERROR: Infinite table loop' into the PDF

### DIFF
--- a/openpdf-core/src/main/java/org/openpdf/text/pdf/PdfDocument.java
+++ b/openpdf-core/src/main/java/org/openpdf/text/pdf/PdfDocument.java
@@ -2641,8 +2641,7 @@ public class PdfDocument extends Document {
                 loop = 0;
             }
             if (loop == 3) {
-                add(new Paragraph("ERROR: Infinite table loop"));
-                break;
+                throw new DocumentException(MessageLocalization.getComposedMessage("infinite.table.loop"));
             }
             newPage();
         }

--- a/openpdf-core/src/main/resources/org/openpdf/text/error_messages/en.lng
+++ b/openpdf-core/src/main/resources/org/openpdf/text/error_messages/en.lng
@@ -154,6 +154,7 @@ incomplete.palette=incomplete palette
 inconsistent.mapping=Inconsistent mapping.
 inconsistent.writers.are.you.mixing.two.documents=Inconsistent writers. Are you mixing two documents?
 incorrect.segment.type.in.1=Incorrect segment type in {1}
+infinite.table.loop=Could not add the table to the document: a table row does not fit on a page. Check for rows or cells whose (fixed) height is larger than the available page height.
 insertion.of.illegal.element.1=Insertion of illegal Element: {1}
 inserttable.point.has.null.value=insertTable - point has null-value
 inserttable.table.has.null.value=insertTable - table has null-value

--- a/openpdf-core/src/test/java/org/openpdf/text/pdf/table/TableRowTooTallTest.java
+++ b/openpdf-core/src/test/java/org/openpdf/text/pdf/table/TableRowTooTallTest.java
@@ -1,0 +1,72 @@
+package org.openpdf.text.pdf.table;
+
+import static java.time.Duration.ofSeconds;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
+
+import java.io.ByteArrayOutputStream;
+import org.junit.jupiter.api.Test;
+import org.openpdf.text.Document;
+import org.openpdf.text.DocumentException;
+import org.openpdf.text.PageSize;
+import org.openpdf.text.Phrase;
+import org.openpdf.text.pdf.PdfPCell;
+import org.openpdf.text.pdf.PdfPTable;
+import org.openpdf.text.pdf.PdfReader;
+import org.openpdf.text.pdf.PdfWriter;
+import org.openpdf.text.pdf.parser.PdfTextExtractor;
+
+/**
+ * Tests for issue #1163: adding a table with a row that can never fit on a page (e.g. a cell with
+ * a fixed height larger than the page) silently wrote the text "ERROR: Infinite table loop" into
+ * the generated document instead of failing. It now throws a descriptive DocumentException.
+ */
+class TableRowTooTallTest {
+
+    @Test
+    void rowTallerThanPageThrowsInsteadOfWritingErrorText() {
+        assertTimeoutPreemptively(ofSeconds(10), () -> {
+            Document document = new Document(PageSize.A4);
+            PdfWriter.getInstance(document, new ByteArrayOutputStream());
+            document.open();
+
+            PdfPTable table = new PdfPTable(1);
+            table.setTotalWidth(new float[]{100});
+            table.setLockedWidth(true);
+            PdfPCell cell = new PdfPCell(new Phrase("This row can never fit on a page"));
+            cell.setFixedHeight(PageSize.A4.getHeight() + 100);
+            table.addCell(cell);
+
+            DocumentException e = assertThrows(DocumentException.class, () -> document.add(table),
+                    "A table row that can never fit must fail instead of corrupting the document");
+            assertNotNull(e.getMessage());
+        });
+    }
+
+    @Test
+    void fittingTableIsUnaffected() throws Exception {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        Document document = new Document(PageSize.A4);
+        PdfWriter.getInstance(document, out);
+        document.open();
+
+        PdfPTable table = new PdfPTable(1);
+        table.setTotalWidth(new float[]{100});
+        table.setLockedWidth(true);
+        PdfPCell cell = new PdfPCell(new Phrase("A perfectly reasonable row"));
+        cell.setFixedHeight(100);
+        table.addCell(cell);
+        document.add(table);
+        document.close();
+
+        PdfReader reader = new PdfReader(out.toByteArray());
+        try {
+            String text = new PdfTextExtractor(reader).getTextFromPage(1);
+            assertFalse(text.contains("Infinite table loop"), "No error text may leak into the document");
+        } finally {
+            reader.close();
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #1163.

When a `PdfPTable` row can never fit on a page — typically a cell with a fixed height larger than the page height, as in the issue's reproduction — the layout loop in `PdfDocument.addPTable` gave up after three attempts and **silently wrote the literal text `ERROR: Infinite table loop` into the generated document**. The caller received a corrupted PDF and no signal that anything went wrong; the reporter only discovered the text on the last page of the output.

## Fix

Throw a `DocumentException` with a descriptive, localized message instead:

> Could not add the table to the document: a table row does not fit on a page. Check for rows or cells whose (fixed) height is larger than the available page height.

This surfaces the error through the normal `Document.add(...)` error channel (which already declares `DocumentException`), so callers can catch it and fix their layout, rather than shipping a broken document.

Note on behavior: code that previously "succeeded" while producing a PDF containing the error text will now get an exception. That is the intent — the old behavior corrupted the output silently.

## Tests

New `TableRowTooTallTest`:
- `rowTallerThanPageThrowsInsteadOfWritingErrorText` — a one-cell table with `fixedHeight = pageHeight + 100` now throws `DocumentException` (previously: silently produced a PDF containing the error text). Guarded by a preemptive timeout so a regression to a genuine infinite loop fails fast.
- `fittingTableIsUnaffected` — normal tables still render, with no error text in the extracted output.

Full `openpdf-core` suite passes (the existing `TableEndlessTest` scenarios are unaffected).


