### PR TITLE
Fix #1534: TIFF/1-bit indexed images rendered inverted

### DIFF
--- a/openpdf-core/src/main/java/org/openpdf/text/Image.java
+++ b/openpdf-core/src/main/java/org/openpdf/text/Image.java
@@ -872,8 +872,10 @@ public abstract class Image extends Rectangle {
                     int width = bi.getWidth();
                     int height = bi.getHeight();
                     byte[] pixelData = generateIndexedColorPixelData(width, bitsPerPixel, height, bi.getRaster());
-                    // Create indexed image with palette
-                    Image img = Image.getInstance(width, height, 1, bitsPerPixel, pixelData);
+                    // Create the image directly as raw data. Image.getInstance(width, height, 1, 1, data) must
+                    // not be used here: it CCITT-G4 encodes 1-bit data as black/white, which discards the
+                    // palette and inverts images whose palette is {black, white} (see issue #1534).
+                    Image img = new ImgRaw(width, height, 1, bitsPerPixel, pixelData);
 
                     // Set up indexed colorspace: [/Indexed /DeviceRGB maxIndex palette]
                     PdfArray indexed = new PdfArray();

--- a/openpdf-core/src/test/java/org/openpdf/text/ImageTest.java
+++ b/openpdf-core/src/test/java/org/openpdf/text/ImageTest.java
@@ -4,12 +4,18 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
+import java.awt.Color;
+import java.awt.Graphics2D;
 import java.awt.image.BufferedImage;
 import java.awt.image.IndexColorModel;
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import javax.imageio.ImageIO;
 import org.junit.jupiter.api.Test;
+import org.openpdf.text.pdf.PdfArray;
 import org.openpdf.text.pdf.PdfName;
+import org.openpdf.text.pdf.PdfString;
 
 class ImageTest {
 
@@ -210,6 +216,76 @@ class ImageTest {
         assertThat(image.getImageMask()).isNotNull();
         assertThat(image.getImageMask().isMask()).isTrue();
         assertThat(image.isSmask()).isTrue();
+    }
+
+    @Test
+    void shouldPreservePaletteFor1BitIndexedImage() throws Exception {
+        // Palette with index 0 = white, index 1 = black, as produced when reading a
+        // bilevel TIFF with PhotometricInterpretation "WhiteIsZero" (issue #1534)
+        byte[] whiteBlack = {(byte) 255, 0};
+        IndexColorModel colorModel = new IndexColorModel(1, 2, whiteBlack, whiteBlack, whiteBlack);
+        BufferedImage bufferedImage = new BufferedImage(16, 16, BufferedImage.TYPE_BYTE_BINARY, colorModel);
+        Graphics2D g = bufferedImage.createGraphics();
+        g.setColor(Color.WHITE);
+        g.fillRect(0, 0, 16, 16);
+        g.setColor(Color.BLACK);
+        g.fillRect(0, 0, 8, 16);
+        g.dispose();
+
+        Image image = Image.getInstance(bufferedImage, null);
+
+        // Must stay a raw 1-bit indexed image; CCITT encoding would drop the palette and invert the colors
+        assertThat(image.getBpc()).isEqualTo(1);
+        assertThat(image.getColorspace()).isEqualTo(1);
+        assertImageMatches(bufferedImage, image);
+    }
+
+    @Test
+    void shouldRenderBlackAndWhitePngWithCorrectColors() throws Exception {
+        // Black text on white background, encoded to PNG bytes as in issue #1534
+        BufferedImage bufferedImage = new BufferedImage(16, 16, BufferedImage.TYPE_BYTE_BINARY);
+        Graphics2D g = bufferedImage.createGraphics();
+        g.setColor(Color.WHITE);
+        g.fillRect(0, 0, 16, 16);
+        g.setColor(Color.BLACK);
+        g.fillRect(0, 0, 8, 16);
+        g.dispose();
+
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        ImageIO.write(bufferedImage, "png", baos);
+
+        Image image = Image.getInstance(baos.toByteArray());
+
+        assertThat(image.getBpc()).isEqualTo(1);
+        assertImageMatches(bufferedImage, image);
+    }
+
+    /**
+     * Resolves each pixel of a raw 1-bit indexed {@link Image} through its palette and compares it to the
+     * corresponding pixel of the original {@link BufferedImage}.
+     */
+    private static void assertImageMatches(BufferedImage expected, Image image) {
+        PdfArray colorspace = (PdfArray) image.getAdditional().get(PdfName.COLORSPACE);
+        assertThat(colorspace).isNotNull();
+        assertThat(colorspace.getPdfObject(0)).isEqualTo(PdfName.INDEXED);
+        byte[] palette = ((PdfString) colorspace.getPdfObject(3)).getBytes();
+
+        byte[] data = image.getRawData();
+        int width = (int) image.getWidth();
+        int height = (int) image.getHeight();
+        int rowStride = (width + 7) / 8;
+        for (int y = 0; y < height; y++) {
+            for (int x = 0; x < width; x++) {
+                int index = (data[y * rowStride + x / 8] >> (7 - x % 8)) & 1;
+                int rgb = 0xff000000
+                        | ((palette[index * 3] & 0xff) << 16)
+                        | ((palette[index * 3 + 1] & 0xff) << 8)
+                        | (palette[index * 3 + 2] & 0xff);
+                assertThat(rgb)
+                        .as("pixel at (%d, %d)", x, y)
+                        .isEqualTo(expected.getRGB(x, y));
+            }
+        }
     }
 
 }


### PR DESCRIPTION
Fixes #1534.

## Root cause
The indexed-color fast path added in #1499 (3.0.1) and reworked in #1524 (3.0.2) builds the PDF image via `Image.getInstance(width, height, 1, bitsPerPixel, pixelData)`. For 1-bit data that factory has a special case that CCITT-G4-compresses the pixels and returns a CCITT image with `CCITT_BLACKIS1` semantics:

```java
if (components == 1 && bpc == 1) {
    byte[] g4 = CCITTG4Encoder.compress(data, width, height);
    return Image.getInstance(width, height, false, Image.CCITTG4, Image.CCITT_BLACKIS1, g4, transparency);
}
```

This breaks 1-bit *indexed* images twice over:
- `PdfImage` never applies the `additional` `/Indexed` colorspace dictionary to CCITT images, so the palette is silently dropped and the data is rendered as DeviceGray.
- With `BlackIs1`, palette index 1 renders as **black**. A bilevel TIFF with `PhotometricInterpretation = WhiteIsZero` decodes to a `TYPE_BYTE_BINARY` `BufferedImage` with palette `{0 = white, 1 = black}`, so black and white swap — exactly the inversion reported in the issue. 3.0.0 was unaffected because this code path didn't exist yet (images went through the generic RGB path).

## Fix
Create the `ImgRaw` directly in the indexed path so the pixel data stays palette indices and the `/Indexed` colorspace is preserved. The image is still flate-compressed by `PdfImage` as before.

## Verification
- Two new regression tests: a 1-bit `TYPE_BYTE_BINARY` image with a `{white, black}` palette, and the issue's exact flow (binary image → PNG bytes → `Image.getInstance(byte[])`). Both resolve every pixel of the resulting image through the embedded palette and compare with the source `BufferedImage`; both fail before the fix and pass after.
- End-to-end check with the `sample.tif` attached to #1534 (decoded with TwelveMonkeys, converted with the reporter's reproduction code): the image embedded in the produced PDF now matches all 8,748,480 pixels of the original TIFF exactly (previously fully inverted).
- Full `openpdf-core` test suite passes (2082 tests, 0 failures).
