### PR TITLE
openpdf-renderer: resolve named /ColorSpace resources (ICCBased, CalGray, CalRGB, Lab) for cs/CS/scn/SCN

### DIFF
--- a/openpdf-renderer/README.md
+++ b/openpdf-renderer/README.md
@@ -105,7 +105,7 @@ PDF content-stream operators &mdash; sufficient for typical text + vector PDFs:
 | Path construction | `m`, `l`, `c`, `v`, `y`, `re`, `h` |
 | Path painting | `S`, `s`, `f`, `F`, `f*`, `B`, `B*`, `b`, `b*`, `n` |
 | Clipping | `W`, `W*` |
-| Colors (DeviceGray / DeviceRGB / DeviceCMYK) | `g`, `G`, `rg`, `RG`, `k`, `K`, `cs`, `CS`, `sc`, `SC`, `scn`, `SCN` |
+| Colors (DeviceGray / DeviceRGB / DeviceCMYK / named ICCBased / CalGray / CalRGB / Lab) | `g`, `G`, `rg`, `RG`, `k`, `K`, `cs`, `CS`, `sc`, `SC`, `scn`, `SCN` |
 | Text state | `BT`, `ET`, `Tf`, `Tc`, `Tw`, `TL`, `Tz`, `Td`, `TD`, `Tm`, `T*`, `Ts` |
 | Text showing | `Tj`, `TJ`, `'`, `"` |
 | XObjects | `Do` (see below) |
@@ -122,6 +122,18 @@ XObject coverage:
   DeviceCMYK streams (CMYK approximated to sRGB on the fly). 8-bit Indexed
   color images are expanded through their palette into the base color space
   (DeviceGray / DeviceRGB / DeviceCMYK).
+
+Color spaces: `cs`/`CS` resolve literal device names (`/DeviceGray`,
+`/DeviceRGB`, `/DeviceCMYK`) directly, and also resolve any other name
+through the page's `/ColorSpace` resource dictionary (PDF §8.6.3) &mdash;
+the common case being a named `ICCBased` color space (classified by its
+stream's `/N` component count into gray/RGB/CMYK), `CalGray`, `CalRGB`,
+or `Lab` (converted via the standard CIE L\*a\*b\* &rarr; XYZ &rarr; sRGB
+transform, using the color space's own `/WhitePoint` when present, D50
+otherwise). Color spaces this renderer doesn't specifically understand
+(Separation, DeviceN, Indexed, Pattern, ...) fall back to inferring
+gray/RGB/CMYK from the `sc`/`scn` operand count, which is usually right
+for those color spaces' most common shapes but not guaranteed.
 
 Text rendering: for each `Tf`-selected font, the renderer pulls the
 embedded font program (`FontFile2`/`FontFile3`/`FontFile`) out of the

--- a/openpdf-renderer/README.md
+++ b/openpdf-renderer/README.md
@@ -105,7 +105,7 @@ PDF content-stream operators &mdash; sufficient for typical text + vector PDFs:
 | Path construction | `m`, `l`, `c`, `v`, `y`, `re`, `h` |
 | Path painting | `S`, `s`, `f`, `F`, `f*`, `B`, `B*`, `b`, `b*`, `n` |
 | Clipping | `W`, `W*` |
-| Colors (DeviceGray / DeviceRGB / DeviceCMYK / named ICCBased / CalGray / CalRGB / Lab) | `g`, `G`, `rg`, `RG`, `k`, `K`, `cs`, `CS`, `sc`, `SC`, `scn`, `SCN` |
+| Colors (Device + ICCBased/CalGray/CalRGB/Lab) | `g`, `G`, `rg`, `RG`, `k`, `K`, `cs`, `CS`, `sc`, `SC`, `scn`, `SCN` |
 | Text state | `BT`, `ET`, `Tf`, `Tc`, `Tw`, `TL`, `Tz`, `Td`, `TD`, `Tm`, `T*`, `Ts` |
 | Text showing | `Tj`, `TJ`, `'`, `"` |
 | XObjects | `Do` (see below) |

--- a/openpdf-renderer/README.md
+++ b/openpdf-renderer/README.md
@@ -105,7 +105,7 @@ PDF content-stream operators &mdash; sufficient for typical text + vector PDFs:
 | Path construction | `m`, `l`, `c`, `v`, `y`, `re`, `h` |
 | Path painting | `S`, `s`, `f`, `F`, `f*`, `B`, `B*`, `b`, `b*`, `n` |
 | Clipping | `W`, `W*` |
-| Colors (Device + ICCBased/CalGray/CalRGB/Lab) | `g`, `G`, `rg`, `RG`, `k`, `K`, `cs`, `CS`, `sc`, `SC`, `scn`, `SCN` |
+| Colors (DeviceGray / DeviceRGB / DeviceCMYK) | `g`, `G`, `rg`, `RG`, `k`, `K`, `cs`, `CS`, `sc`, `SC`, `scn`, `SCN` |
 | Text state | `BT`, `ET`, `Tf`, `Tc`, `Tw`, `TL`, `Tz`, `Td`, `TD`, `Tm`, `T*`, `Ts` |
 | Text showing | `Tj`, `TJ`, `'`, `"` |
 | XObjects | `Do` (see below) |
@@ -122,18 +122,6 @@ XObject coverage:
   DeviceCMYK streams (CMYK approximated to sRGB on the fly). 8-bit Indexed
   color images are expanded through their palette into the base color space
   (DeviceGray / DeviceRGB / DeviceCMYK).
-
-Color spaces: `cs`/`CS` resolve literal device names (`/DeviceGray`,
-`/DeviceRGB`, `/DeviceCMYK`) directly, and also resolve any other name
-through the page's `/ColorSpace` resource dictionary (PDF §8.6.3) &mdash;
-the common case being a named `ICCBased` color space (classified by its
-stream's `/N` component count into gray/RGB/CMYK), `CalGray`, `CalRGB`,
-or `Lab` (converted via the standard CIE L\*a\*b\* &rarr; XYZ &rarr; sRGB
-transform, using the color space's own `/WhitePoint` when present, D50
-otherwise). Color spaces this renderer doesn't specifically understand
-(Separation, DeviceN, Indexed, Pattern, ...) fall back to inferring
-gray/RGB/CMYK from the `sc`/`scn` operand count, which is usually right
-for those color spaces' most common shapes but not guaranteed.
 
 Text rendering: for each `Tf`-selected font, the renderer pulls the
 embedded font program (`FontFile2`/`FontFile3`/`FontFile`) out of the

--- a/openpdf-renderer/src/main/java/org/openpdf/renderer/core/OpenPdfCorePageRenderer.java
+++ b/openpdf-renderer/src/main/java/org/openpdf/renderer/core/OpenPdfCorePageRenderer.java
@@ -1819,7 +1819,7 @@ final class OpenPdfCorePageRenderer {
         }
         ColorSpaceKind literal = literalDeviceColorSpace(name);
         if (literal != ColorSpaceKind.UNKNOWN) {
-            return new ColorSpaceInfo(literal, null);
+            return new ColorSpaceInfo(literal, NO_LAB_WHITE_POINT);
         }
         return classifyColorSpaceDefinition(resolveColorSpaceResource(name));
     }
@@ -1856,20 +1856,20 @@ final class OpenPdfCorePageRenderer {
 
     private static ColorSpaceInfo classifyColorSpaceDefinition(PdfObject direct) {
         if (direct instanceof PdfName name) {
-            return new ColorSpaceInfo(literalDeviceColorSpace(name), null);
+            return new ColorSpaceInfo(literalDeviceColorSpace(name), NO_LAB_WHITE_POINT);
         }
         if (!(direct instanceof PdfArray arr) || arr.size() < 1) {
             return ColorSpaceInfo.UNKNOWN;
         }
         PdfObject head = arr.getDirectObject(0);
         if (CS_ICC_BASED.equals(head)) {
-            return new ColorSpaceInfo(kindForComponentCount(iccBasedComponents(arr)), null);
+            return new ColorSpaceInfo(kindForComponentCount(iccBasedComponents(arr)), NO_LAB_WHITE_POINT);
         }
         if (CS_CAL_GRAY.equals(head)) {
-            return new ColorSpaceInfo(ColorSpaceKind.GRAY, null);
+            return new ColorSpaceInfo(ColorSpaceKind.GRAY, NO_LAB_WHITE_POINT);
         }
         if (CS_CAL_RGB.equals(head)) {
-            return new ColorSpaceInfo(ColorSpaceKind.RGB, null);
+            return new ColorSpaceInfo(ColorSpaceKind.RGB, NO_LAB_WHITE_POINT);
         }
         if (CS_LAB.equals(head)) {
             return new ColorSpaceInfo(ColorSpaceKind.LAB, labWhitePointFrom(arr));
@@ -1890,17 +1890,22 @@ final class OpenPdfCorePageRenderer {
         }
     }
 
+    // Sentinel for "no explicit Lab /WhitePoint" -- callers fall back to a default D50 white
+    // point. Using an empty array rather than null avoids null-array returns/fields.
+    private static final float[] NO_LAB_WHITE_POINT = new float[0];
+
     /**
-     * Reads the {@code /WhitePoint} of a {@code [/Lab dict]} color-space array, or {@code null}
-     * if absent/malformed (callers fall back to a default D50 white point).
+     * Reads the {@code /WhitePoint} of a {@code [/Lab dict]} color-space array, or
+     * {@link #NO_LAB_WHITE_POINT} if absent/malformed (callers fall back to a default D50 white
+     * point).
      */
     private static float[] labWhitePointFrom(PdfArray labArray) {
         if (labArray.size() < 2 || !(labArray.getDirectObject(1) instanceof PdfDictionary dict)) {
-            return null;
+            return NO_LAB_WHITE_POINT;
         }
         PdfArray wp = dict.getAsArray(PdfName.WHITEPOINT);
         if (wp == null || wp.size() < 3) {
-            return null;
+            return NO_LAB_WHITE_POINT;
         }
         return new float[]{floatAt(wp, 0), floatAt(wp, 1), floatAt(wp, 2)};
     }
@@ -1913,47 +1918,48 @@ final class OpenPdfCorePageRenderer {
      * Picks numeric operands matching the active color space; non-numeric operands (e.g. pattern names) yield default.
      */
     private static Color colorFromOperands(ColorSpaceKind kind, float[] labWhitePoint, List<PdfObject> operands) {
+        int numericCount = countNumericOperands(operands);
+        switch (kind) {
+            case GRAY:
+                return numericCount >= 1 ? gray(num(operands, 0)) : defaultColorFor(kind);
+            case RGB:
+                return numericCount >= 3
+                        ? rgb(num(operands, 0), num(operands, 1), num(operands, 2)) : defaultColorFor(kind);
+            case CMYK:
+                return numericCount >= 4
+                        ? cmyk(num(operands, 0), num(operands, 1), num(operands, 2), num(operands, 3))
+                        : defaultColorFor(kind);
+            case LAB:
+                return numericCount >= 3
+                        ? labToRgb(labWhitePoint, num(operands, 0), num(operands, 1), num(operands, 2))
+                        : defaultColorFor(kind);
+            default:
+                // Color space is unknown / unsupported: infer from operand count instead.
+                return colorFromOperandCountOnly(numericCount, operands);
+        }
+    }
+
+    private static int countNumericOperands(List<PdfObject> operands) {
         int numericCount = 0;
         for (int i = 0; i < operands.size() - 1; i++) {
             if (operands.get(i) instanceof PdfNumber) {
                 numericCount++;
             }
         }
-        switch (kind) {
-            case GRAY:
-                if (numericCount >= 1) {
-                    return gray(num(operands, 0));
-                }
-                break;
-            case RGB:
-                if (numericCount >= 3) {
-                    return rgb(num(operands, 0), num(operands, 1), num(operands, 2));
-                }
-                break;
-            case CMYK:
-                if (numericCount >= 4) {
-                    return cmyk(num(operands, 0), num(operands, 1), num(operands, 2), num(operands, 3));
-                }
-                break;
-            case LAB:
-                if (numericCount >= 3) {
-                    return labToRgb(labWhitePoint, num(operands, 0), num(operands, 1), num(operands, 2));
-                }
-                break;
-            default:
-                // Fall through: infer from operand count when color space is unknown / unsupported.
-                if (numericCount >= 4) {
-                    return cmyk(num(operands, 0), num(operands, 1), num(operands, 2), num(operands, 3));
-                }
-                if (numericCount == 3) {
-                    return rgb(num(operands, 0), num(operands, 1), num(operands, 2));
-                }
-                if (numericCount == 1) {
-                    return gray(num(operands, 0));
-                }
-                break;
+        return numericCount;
+    }
+
+    private static Color colorFromOperandCountOnly(int numericCount, List<PdfObject> operands) {
+        if (numericCount >= 4) {
+            return cmyk(num(operands, 0), num(operands, 1), num(operands, 2), num(operands, 3));
         }
-        return defaultColorFor(kind);
+        if (numericCount == 3) {
+            return rgb(num(operands, 0), num(operands, 1), num(operands, 2));
+        }
+        if (numericCount == 1) {
+            return gray(num(operands, 0));
+        }
+        return defaultColorFor(ColorSpaceKind.UNKNOWN);
     }
 
     // D50, the reference white point PDF's Lab color space conventionally assumes when a
@@ -1964,13 +1970,13 @@ final class OpenPdfCorePageRenderer {
 
     /**
      * Converts a CIE L*a*b* color (PDF §8.6.5.4) to sRGB via CIEXYZ, using {@code whitePoint}
-     * ({@code null} defaults to D50). Lab components are not directly comparable to RGB/gray
-     * (L is 0-100, a and b are roughly -100..100), so treating them as raw RGB &mdash; the
-     * previous fallback behavior for an unrecognized color space &mdash; produced wrong colors;
-     * this does the standard inverse Lab transform instead.
+     * (fewer than 3 elements, e.g. {@link #NO_LAB_WHITE_POINT}, defaults to D50). Lab components
+     * are not directly comparable to RGB/gray (L is 0-100, a and b are roughly -100..100), so
+     * treating them as raw RGB &mdash; the previous fallback behavior for an unrecognized color
+     * space &mdash; produced wrong colors; this does the standard inverse Lab transform instead.
      */
     private static Color labToRgb(float[] whitePoint, float lStar, float aStar, float bStar) {
-        float[] white = whitePoint != null ? whitePoint : DEFAULT_LAB_WHITE_POINT;
+        float[] white = whitePoint.length >= 3 ? whitePoint : DEFAULT_LAB_WHITE_POINT;
         float fy = (lStar + 16f) / 116f;
         float fx = fy + aStar / 500f;
         float fz = fy - bStar / 200f;
@@ -2001,11 +2007,35 @@ final class OpenPdfCorePageRenderer {
 
     /**
      * Result of resolving a {@code cs}/{@code CS} operand: the classified {@link ColorSpaceKind}
-     * plus, for {@link ColorSpaceKind#LAB}, the color space's {@code /WhitePoint} (or
-     * {@code null} to use the default) needed to later convert {@code sc}/{@code scn} operands.
+     * plus, for {@link ColorSpaceKind#LAB}, the color space's {@code /WhitePoint} (or an empty
+     * array to use the default) needed to later convert {@code sc}/{@code scn} operands.
      */
     private record ColorSpaceInfo(ColorSpaceKind kind, float[] labWhitePoint) {
-        static final ColorSpaceInfo UNKNOWN = new ColorSpaceInfo(ColorSpaceKind.UNKNOWN, null);
+        static final ColorSpaceInfo UNKNOWN = new ColorSpaceInfo(ColorSpaceKind.UNKNOWN, NO_LAB_WHITE_POINT);
+
+        // Records generate equals()/hashCode()/toString() from component identity by default,
+        // which for an array component compares references rather than content; override
+        // explicitly so two infos with equal white points compare equal.
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (!(o instanceof ColorSpaceInfo other)) {
+                return false;
+            }
+            return kind == other.kind && Arrays.equals(labWhitePoint, other.labWhitePoint);
+        }
+
+        @Override
+        public int hashCode() {
+            return 31 * kind.hashCode() + Arrays.hashCode(labWhitePoint);
+        }
+
+        @Override
+        public String toString() {
+            return "ColorSpaceInfo[kind=" + kind + ", labWhitePoint=" + Arrays.toString(labWhitePoint) + "]";
+        }
     }
 
     /**
@@ -2018,10 +2048,10 @@ final class OpenPdfCorePageRenderer {
         ColorSpaceKind fillColorSpace = ColorSpaceKind.GRAY;
         ColorSpaceKind strokeColorSpace = ColorSpaceKind.GRAY;
         // Set alongside fillColorSpace/strokeColorSpace whenever a `cs`/`CS` resolves to a Lab
-        // color space; null (default D50) otherwise. Only meaningful when the paired
-        // ColorSpaceKind is LAB.
-        float[] fillLabWhitePoint;
-        float[] strokeLabWhitePoint;
+        // color space; NO_LAB_WHITE_POINT (default D50) otherwise. Only meaningful when the
+        // paired ColorSpaceKind is LAB.
+        float[] fillLabWhitePoint = NO_LAB_WHITE_POINT;
+        float[] strokeLabWhitePoint = NO_LAB_WHITE_POINT;
         float fillAlpha = 1.0f;
         float strokeAlpha = 1.0f;
 

--- a/openpdf-renderer/src/main/java/org/openpdf/renderer/core/OpenPdfCorePageRenderer.java
+++ b/openpdf-renderer/src/main/java/org/openpdf/renderer/core/OpenPdfCorePageRenderer.java
@@ -159,6 +159,15 @@ final class OpenPdfCorePageRenderer {
     private static final Set<PdfName> DEVICE_CMYK_NAMES = Set.of(
             PdfName.DEVICECMYK, new PdfName("CMYK"));
 
+    // Sentinel for "no explicit Lab /WhitePoint" -- callers fall back to a default D50 white
+    // point. Using an empty array rather than null avoids null-array returns/fields.
+    private static final float[] NO_LAB_WHITE_POINT = new float[0];
+    // D50, the reference white point PDF's Lab color space conventionally assumes when a
+    // /Lab color space definition omits /WhitePoint (which is technically required, but not
+    // every PDF producer bothers to include it).
+    private static final float[] DEFAULT_LAB_WHITE_POINT = {0.9642f, 1.0f, 0.8249f};
+    private static final ColorSpace CIE_SRGB = ColorSpace.getInstance(ColorSpace.CS_sRGB);
+
     /**
      * Synthetic XObject-name prefix used for inline images that have been promoted out
      * of the content stream into {@link #inlineImages}. Keeping a clearly distinctive
@@ -1890,10 +1899,6 @@ final class OpenPdfCorePageRenderer {
         }
     }
 
-    // Sentinel for "no explicit Lab /WhitePoint" -- callers fall back to a default D50 white
-    // point. Using an empty array rather than null avoids null-array returns/fields.
-    private static final float[] NO_LAB_WHITE_POINT = new float[0];
-
     /**
      * Reads the {@code /WhitePoint} of a {@code [/Lab dict]} color-space array, or
      * {@link #NO_LAB_WHITE_POINT} if absent/malformed (callers fall back to a default D50 white
@@ -1961,12 +1966,6 @@ final class OpenPdfCorePageRenderer {
         }
         return defaultColorFor(ColorSpaceKind.UNKNOWN);
     }
-
-    // D50, the reference white point PDF's Lab color space conventionally assumes when a
-    // /Lab color space definition omits /WhitePoint (which is technically required, but not
-    // every PDF producer bothers to include it).
-    private static final float[] DEFAULT_LAB_WHITE_POINT = {0.9642f, 1.0f, 0.8249f};
-    private static final ColorSpace CIE_SRGB = ColorSpace.getInstance(ColorSpace.CS_sRGB);
 
     /**
      * Converts a CIE L*a*b* color (PDF §8.6.5.4) to sRGB via CIEXYZ, using {@code whitePoint}

--- a/openpdf-renderer/src/main/java/org/openpdf/renderer/core/OpenPdfCorePageRenderer.java
+++ b/openpdf-renderer/src/main/java/org/openpdf/renderer/core/OpenPdfCorePageRenderer.java
@@ -17,6 +17,7 @@ import java.awt.FontFormatException;
 import java.awt.Graphics2D;
 import java.awt.RenderingHints;
 import java.awt.Shape;
+import java.awt.color.ColorSpace;
 import java.awt.geom.AffineTransform;
 import java.awt.geom.Path2D;
 import java.awt.geom.Rectangle2D;
@@ -78,7 +79,8 @@ import org.openpdf.text.pdf.PdfString;
  *   <li>Clipping: {@code W}, {@code W*}</li>
  *   <li>Colors (DeviceGray / DeviceRGB / DeviceCMYK): {@code g}, {@code G},
  *       {@code rg}, {@code RG}, {@code k}, {@code K}, plus color-space-aware
- *       {@code cs}, {@code CS}, {@code sc}, {@code SC}, {@code scn}, {@code SCN}</li>
+ *       {@code cs}, {@code CS}, {@code sc}, {@code SC}, {@code scn}, {@code SCN}, which also
+ *       resolve a named {@code /ColorSpace} resource (ICCBased, CalGray, CalRGB, Lab)</li>
  *   <li>Text state: {@code BT}, {@code ET}, {@code Tf}, {@code Tc}, {@code Tw},
  *       {@code TL}, {@code Tz}, {@code Td}, {@code TD}, {@code Tm}, {@code T*},
  *       {@code Ts} (text rise)</li>
@@ -143,7 +145,7 @@ final class OpenPdfCorePageRenderer {
     private static final List<PdfName> EMBEDDED_FONT_KEYS = List.of(
             PdfName.FONTFILE2, PdfName.FONTFILE3, PdfName.FONTFILE);
 
-    // Color-space identifiers used by imageComponents().
+    // Color-space identifiers used by imageComponents() and colorSpaceFromName().
     private static final PdfName CS_ICC_BASED = new PdfName("ICCBased");
     private static final PdfName CS_CAL_GRAY = new PdfName("CalGray");
     private static final PdfName CS_CAL_RGB = new PdfName("CalRGB");
@@ -738,21 +740,30 @@ final class OpenPdfCorePageRenderer {
                         cmyk(num(operands, 0), num(operands, 1), num(operands, 2), num(operands, 3)),
                         state.strokeAlpha);
                 break;
-            case "cs":
-                state.fillColorSpace = colorSpaceFromName(operands.get(0));
+            case "cs": {
+                ColorSpaceInfo info = colorSpaceFromName(operands.get(0));
+                state.fillColorSpace = info.kind();
+                state.fillLabWhitePoint = info.labWhitePoint();
                 state.fillColor = applyAlpha(defaultColorFor(state.fillColorSpace), state.fillAlpha);
                 break;
-            case "CS":
-                state.strokeColorSpace = colorSpaceFromName(operands.get(0));
+            }
+            case "CS": {
+                ColorSpaceInfo info = colorSpaceFromName(operands.get(0));
+                state.strokeColorSpace = info.kind();
+                state.strokeLabWhitePoint = info.labWhitePoint();
                 state.strokeColor = applyAlpha(defaultColorFor(state.strokeColorSpace), state.strokeAlpha);
                 break;
+            }
             case "sc":
             case "scn":
-                state.fillColor = applyAlpha(colorFromOperands(state.fillColorSpace, operands), state.fillAlpha);
+                state.fillColor = applyAlpha(
+                        colorFromOperands(state.fillColorSpace, state.fillLabWhitePoint, operands), state.fillAlpha);
                 break;
             case "SC":
             case "SCN":
-                state.strokeColor = applyAlpha(colorFromOperands(state.strokeColorSpace, operands), state.strokeAlpha);
+                state.strokeColor = applyAlpha(
+                        colorFromOperands(state.strokeColorSpace, state.strokeLabWhitePoint, operands),
+                        state.strokeAlpha);
                 break;
 
             // --- Path construction ---
@@ -1791,26 +1802,107 @@ final class OpenPdfCorePageRenderer {
         return new Color(color.getRed(), color.getGreen(), color.getBlue(), a);
     }
 
-    private static ColorSpaceKind colorSpaceFromName(PdfObject operand) {
+    /**
+     * Classifies a {@code cs}/{@code CS} color-space operand. Literal device names
+     * ({@code /DeviceGray}, {@code /DeviceRGB}, {@code /DeviceCMYK} and their abbreviations)
+     * resolve directly; anything else is looked up by name in the page's {@code /ColorSpace}
+     * resource dictionary (PDF §8.6.3) and classified from its definition &mdash; the common
+     * case being a named {@code ICCBased} color space (classified by its stream's {@code /N}
+     * component count), {@code CalGray}, {@code CalRGB} or {@code Lab}. Color spaces this
+     * renderer doesn't specifically understand (Separation, DeviceN, Indexed, Pattern, ...)
+     * come back as {@link ColorSpaceKind#UNKNOWN}, in which case {@link #colorFromOperands}
+     * falls back to inferring gray/RGB/CMYK from the {@code sc}/{@code scn} operand count.
+     */
+    private ColorSpaceInfo colorSpaceFromName(PdfObject operand) {
         if (!(operand instanceof PdfName name)) {
-            return ColorSpaceKind.UNKNOWN;
+            return ColorSpaceInfo.UNKNOWN;
         }
-        String n = name.toString();
+        ColorSpaceKind literal = literalDeviceColorSpace(name);
+        if (literal != ColorSpaceKind.UNKNOWN) {
+            return new ColorSpaceInfo(literal, null);
+        }
+        return classifyColorSpaceDefinition(resolveColorSpaceResource(name));
+    }
+
+    private static ColorSpaceKind literalDeviceColorSpace(PdfName name) {
+        if (DEVICE_GRAY_NAMES.contains(name)) {
+            return ColorSpaceKind.GRAY;
+        }
+        if (DEVICE_RGB_NAMES.contains(name)) {
+            return ColorSpaceKind.RGB;
+        }
+        if (DEVICE_CMYK_NAMES.contains(name)) {
+            return ColorSpaceKind.CMYK;
+        }
+        return ColorSpaceKind.UNKNOWN;
+    }
+
+    /**
+     * Resolves a {@code cs}/{@code CS} name operand through the page's {@code /ColorSpace}
+     * resource dictionary, following one level of indirection. Returns {@code null} if there
+     * are no resources, no {@code /ColorSpace} dictionary, or no entry under {@code name}.
+     */
+    private PdfObject resolveColorSpaceResource(PdfName name) {
+        if (resources == null) {
+            return null;
+        }
+        PdfDictionary csResources = resources.getAsDict(PdfName.COLORSPACE);
+        if (csResources == null) {
+            return null;
+        }
+        PdfObject obj = csResources.get(name);
+        return obj instanceof PRIndirectReference ref ? PdfReader.getPdfObject(ref) : obj;
+    }
+
+    private static ColorSpaceInfo classifyColorSpaceDefinition(PdfObject direct) {
+        if (direct instanceof PdfName name) {
+            return new ColorSpaceInfo(literalDeviceColorSpace(name), null);
+        }
+        if (!(direct instanceof PdfArray arr) || arr.size() < 1) {
+            return ColorSpaceInfo.UNKNOWN;
+        }
+        PdfObject head = arr.getDirectObject(0);
+        if (CS_ICC_BASED.equals(head)) {
+            return new ColorSpaceInfo(kindForComponentCount(iccBasedComponents(arr)), null);
+        }
+        if (CS_CAL_GRAY.equals(head)) {
+            return new ColorSpaceInfo(ColorSpaceKind.GRAY, null);
+        }
+        if (CS_CAL_RGB.equals(head)) {
+            return new ColorSpaceInfo(ColorSpaceKind.RGB, null);
+        }
+        if (CS_LAB.equals(head)) {
+            return new ColorSpaceInfo(ColorSpaceKind.LAB, labWhitePointFrom(arr));
+        }
+        return ColorSpaceInfo.UNKNOWN;
+    }
+
+    private static ColorSpaceKind kindForComponentCount(int n) {
         switch (n) {
-            case "/DeviceGray":
-            case "/G":
-            case "/CalGray":
+            case 1:
                 return ColorSpaceKind.GRAY;
-            case "/DeviceRGB":
-            case "/RGB":
-            case "/CalRGB":
+            case 3:
                 return ColorSpaceKind.RGB;
-            case "/DeviceCMYK":
-            case "/CMYK":
+            case 4:
                 return ColorSpaceKind.CMYK;
             default:
                 return ColorSpaceKind.UNKNOWN;
         }
+    }
+
+    /**
+     * Reads the {@code /WhitePoint} of a {@code [/Lab dict]} color-space array, or {@code null}
+     * if absent/malformed (callers fall back to a default D50 white point).
+     */
+    private static float[] labWhitePointFrom(PdfArray labArray) {
+        if (labArray.size() < 2 || !(labArray.getDirectObject(1) instanceof PdfDictionary dict)) {
+            return null;
+        }
+        PdfArray wp = dict.getAsArray(PdfName.WHITEPOINT);
+        if (wp == null || wp.size() < 3) {
+            return null;
+        }
+        return new float[]{floatAt(wp, 0), floatAt(wp, 1), floatAt(wp, 2)};
     }
 
     private static Color defaultColorFor(ColorSpaceKind kind) {
@@ -1820,7 +1912,7 @@ final class OpenPdfCorePageRenderer {
     /**
      * Picks numeric operands matching the active color space; non-numeric operands (e.g. pattern names) yield default.
      */
-    private static Color colorFromOperands(ColorSpaceKind kind, List<PdfObject> operands) {
+    private static Color colorFromOperands(ColorSpaceKind kind, float[] labWhitePoint, List<PdfObject> operands) {
         int numericCount = 0;
         for (int i = 0; i < operands.size() - 1; i++) {
             if (operands.get(i) instanceof PdfNumber) {
@@ -1843,6 +1935,11 @@ final class OpenPdfCorePageRenderer {
                     return cmyk(num(operands, 0), num(operands, 1), num(operands, 2), num(operands, 3));
                 }
                 break;
+            case LAB:
+                if (numericCount >= 3) {
+                    return labToRgb(labWhitePoint, num(operands, 0), num(operands, 1), num(operands, 2));
+                }
+                break;
             default:
                 // Fall through: infer from operand count when color space is unknown / unsupported.
                 if (numericCount >= 4) {
@@ -1859,6 +1956,37 @@ final class OpenPdfCorePageRenderer {
         return defaultColorFor(kind);
     }
 
+    // D50, the reference white point PDF's Lab color space conventionally assumes when a
+    // /Lab color space definition omits /WhitePoint (which is technically required, but not
+    // every PDF producer bothers to include it).
+    private static final float[] DEFAULT_LAB_WHITE_POINT = {0.9642f, 1.0f, 0.8249f};
+    private static final ColorSpace CIE_SRGB = ColorSpace.getInstance(ColorSpace.CS_sRGB);
+
+    /**
+     * Converts a CIE L*a*b* color (PDF §8.6.5.4) to sRGB via CIEXYZ, using {@code whitePoint}
+     * ({@code null} defaults to D50). Lab components are not directly comparable to RGB/gray
+     * (L is 0-100, a and b are roughly -100..100), so treating them as raw RGB &mdash; the
+     * previous fallback behavior for an unrecognized color space &mdash; produced wrong colors;
+     * this does the standard inverse Lab transform instead.
+     */
+    private static Color labToRgb(float[] whitePoint, float lStar, float aStar, float bStar) {
+        float[] white = whitePoint != null ? whitePoint : DEFAULT_LAB_WHITE_POINT;
+        float fy = (lStar + 16f) / 116f;
+        float fx = fy + aStar / 500f;
+        float fz = fy - bStar / 200f;
+        float[] xyz = {
+                white[0] * labInverseF(fx),
+                white[1] * labInverseF(fy),
+                white[2] * labInverseF(fz)
+        };
+        float[] srgb = CIE_SRGB.fromCIEXYZ(xyz);
+        return rgb(clamp01(srgb[0]), clamp01(srgb[1]), clamp01(srgb[2]));
+    }
+
+    private static float labInverseF(float t) {
+        return t >= 6f / 29f ? t * t * t : 3f * (6f / 29f) * (6f / 29f) * (t - 4f / 29f);
+    }
+
     private static float clamp01(float v) {
         if (v < 0f) {
             return 0f;
@@ -1869,7 +1997,16 @@ final class OpenPdfCorePageRenderer {
         return v;
     }
 
-    private enum ColorSpaceKind { GRAY, RGB, CMYK, UNKNOWN }
+    private enum ColorSpaceKind { GRAY, RGB, CMYK, LAB, UNKNOWN }
+
+    /**
+     * Result of resolving a {@code cs}/{@code CS} operand: the classified {@link ColorSpaceKind}
+     * plus, for {@link ColorSpaceKind#LAB}, the color space's {@code /WhitePoint} (or
+     * {@code null} to use the default) needed to later convert {@code sc}/{@code scn} operands.
+     */
+    private record ColorSpaceInfo(ColorSpaceKind kind, float[] labWhitePoint) {
+        static final ColorSpaceInfo UNKNOWN = new ColorSpaceInfo(ColorSpaceKind.UNKNOWN, null);
+    }
 
     /**
      * Mutable per-graphics-state snapshot. Not thread-safe.
@@ -1880,6 +2017,11 @@ final class OpenPdfCorePageRenderer {
         Color strokeColor = Color.BLACK;
         ColorSpaceKind fillColorSpace = ColorSpaceKind.GRAY;
         ColorSpaceKind strokeColorSpace = ColorSpaceKind.GRAY;
+        // Set alongside fillColorSpace/strokeColorSpace whenever a `cs`/`CS` resolves to a Lab
+        // color space; null (default D50) otherwise. Only meaningful when the paired
+        // ColorSpaceKind is LAB.
+        float[] fillLabWhitePoint;
+        float[] strokeLabWhitePoint;
         float fillAlpha = 1.0f;
         float strokeAlpha = 1.0f;
 
@@ -1913,6 +2055,8 @@ final class OpenPdfCorePageRenderer {
             this.strokeColor = other.strokeColor;
             this.fillColorSpace = other.fillColorSpace;
             this.strokeColorSpace = other.strokeColorSpace;
+            this.fillLabWhitePoint = other.fillLabWhitePoint;
+            this.strokeLabWhitePoint = other.strokeLabWhitePoint;
             this.fillAlpha = other.fillAlpha;
             this.strokeAlpha = other.strokeAlpha;
             this.lineWidth = other.lineWidth;

--- a/openpdf-renderer/src/test/java/org/openpdf/renderer/core/OpenPdfCorePageRendererOperatorsTest.java
+++ b/openpdf-renderer/src/test/java/org/openpdf/renderer/core/OpenPdfCorePageRendererOperatorsTest.java
@@ -24,6 +24,8 @@ import org.openpdf.text.Document;
 import org.openpdf.text.PageSize;
 import org.openpdf.text.Rectangle;
 import org.openpdf.text.pdf.PdfContentByte;
+import org.openpdf.text.pdf.PdfReader;
+import org.openpdf.text.pdf.PdfStamper;
 import org.openpdf.text.pdf.PdfWriter;
 
 /**
@@ -101,6 +103,101 @@ class OpenPdfCorePageRendererOperatorsTest {
             assertThat(cyanish)
                     .as("CMYK (1,0,0,0) fill must produce cyan-ish pixels")
                     .isGreaterThan(100);
+        }
+    }
+
+    /**
+     * Builds a base single-page PDF, then uses {@link PdfStamper} to inject a named
+     * {@code /ColorSpace} resource entry (something {@code PdfContentByte}'s high-level API has
+     * no method for) directly into the page's {@code /Resources} dictionary, and appends
+     * {@code contentOperators} as raw content referencing that resource by name. This exercises
+     * the {@code cs}/{@code CS} resource-dictionary resolution path in
+     * {@code OpenPdfCorePageRenderer}, as opposed to a literal device color space name.
+     */
+    private static byte[] buildPdfWithColorSpaceResource(String resourceName,
+            org.openpdf.text.pdf.PdfArray colorSpaceDefinition, String contentOperators) throws Exception {
+        // A Document/PdfWriter only registers a page once some content is actually written
+        // to it; a no-op q/Q pair is enough to give PdfStamper a real page to attach to.
+        byte[] basePdf = buildPdf(cb -> {
+            cb.saveState();
+            cb.restoreState();
+        });
+        PdfReader reader = new PdfReader(basePdf);
+        ByteArrayOutputStream stamped = new ByteArrayOutputStream();
+        try (PdfStamper stamper = new PdfStamper(reader, stamped)) {
+            org.openpdf.text.pdf.PdfDictionary pageDict = reader.getPageN(1);
+            org.openpdf.text.pdf.PdfDictionary pageResources = pageDict.getAsDict(org.openpdf.text.pdf.PdfName.RESOURCES);
+            if (pageResources == null) {
+                pageResources = new org.openpdf.text.pdf.PdfDictionary();
+                pageDict.put(org.openpdf.text.pdf.PdfName.RESOURCES, pageResources);
+            }
+            org.openpdf.text.pdf.PdfDictionary csResources =
+                    pageResources.getAsDict(org.openpdf.text.pdf.PdfName.COLORSPACE);
+            if (csResources == null) {
+                csResources = new org.openpdf.text.pdf.PdfDictionary();
+                pageResources.put(org.openpdf.text.pdf.PdfName.COLORSPACE, csResources);
+            }
+            csResources.put(new org.openpdf.text.pdf.PdfName(resourceName), colorSpaceDefinition);
+            stamper.getOverContent(1).setLiteral(contentOperators);
+        }
+        return stamped.toByteArray();
+    }
+
+    @Test
+    void rendersLabNamedColorSpaceFillAsConvertedRgb() throws Exception {
+        // [/Lab <</WhitePoint [0.9642 1.0 0.8249]>>] resolved by name via the page's
+        // /ColorSpace resources, then filled with an scn triplet that is the D50 Lab
+        // encoding of sRGB red. Before resolving named color spaces, an unrecognized "cs"
+        // name fell back to ColorSpaceKind.UNKNOWN, and colorFromOperands's heuristic
+        // treated the 3 Lab operands as if they were raw (r, g, b) -- but Lab's L is 0-100
+        // and a/b run roughly -100..100, so clamping them into [0,1] collapses virtually
+        // every Lab color to solid white/black instead of the intended color.
+        org.openpdf.text.pdf.PdfDictionary labDict = new org.openpdf.text.pdf.PdfDictionary();
+        labDict.put(new org.openpdf.text.pdf.PdfName("WhitePoint"),
+                new org.openpdf.text.pdf.PdfArray(new float[]{0.9642f, 1.0f, 0.8249f}));
+        org.openpdf.text.pdf.PdfArray labCs = new org.openpdf.text.pdf.PdfArray();
+        labCs.add(new org.openpdf.text.pdf.PdfName("Lab"));
+        labCs.add(labDict);
+
+        byte[] pdf = buildPdfWithColorSpaceResource("CSLab", labCs,
+                "/CSLab cs\n54.29 80.81 69.89 scn\n50 50 150 150 re f\n");
+
+        try (OpenPdfCoreRenderer r = new OpenPdfCoreRenderer(pdf)) {
+            BufferedImage img = r.renderPage(1, 150f);
+            saveForInspection(img, "lab-colorspace-fill.png");
+            int redish = countPixelsMatching(img, (red, green, blue) ->
+                    red > 200 && green < 60 && blue < 60);
+            assertThat(redish)
+                    .as("a Lab color space fill must convert to the correct RGB color, "
+                            + "not the near-white/black result of treating L*a*b* as raw RGB")
+                    .isGreaterThan(200);
+        }
+    }
+
+    @Test
+    void rendersIccBasedNamedColorSpaceFill() throws Exception {
+        // A named /ColorSpace resource resolving to [/ICCBased <</N 3>>] (an RGB ICC
+        // profile stream; the profile bytes themselves are irrelevant to the renderer,
+        // which only reads /N to determine the component count). Locks in that the
+        // resource-dictionary resolution path (shared with the Lab case above) correctly
+        // classifies a 3-component ICCBased space as RGB.
+        org.openpdf.text.pdf.PdfDictionary iccDict = new org.openpdf.text.pdf.PdfDictionary();
+        iccDict.put(new org.openpdf.text.pdf.PdfName("N"), new org.openpdf.text.pdf.PdfNumber(3));
+        org.openpdf.text.pdf.PdfArray iccCs = new org.openpdf.text.pdf.PdfArray();
+        iccCs.add(new org.openpdf.text.pdf.PdfName("ICCBased"));
+        iccCs.add(iccDict);
+
+        byte[] pdf = buildPdfWithColorSpaceResource("CS0", iccCs,
+                "/CS0 cs\n0 1 0 scn\n50 50 150 150 re f\n");
+
+        try (OpenPdfCoreRenderer r = new OpenPdfCoreRenderer(pdf)) {
+            BufferedImage img = r.renderPage(1, 150f);
+            saveForInspection(img, "iccbased-colorspace-fill.png");
+            int greenish = countPixelsMatching(img, (red, green, blue) ->
+                    green > 200 && red < 60 && blue < 60);
+            assertThat(greenish)
+                    .as("a 3-component ICCBased color space fill must be classified as RGB")
+                    .isGreaterThan(200);
         }
     }
 


### PR DESCRIPTION
## Summary
- `cs`/`CS` in `OpenPdfCorePageRenderer` previously only recognized literal device color-space names (`/DeviceGray`, `/DeviceRGB`, `/DeviceCMYK` and abbreviations). Any other name — most commonly a named ICCBased profile like `/CS0` declared in the page's `/ColorSpace` resource dictionary, which is how most real-world PDF producers actually declare RGB/CMYK color spaces — fell into `ColorSpaceKind.UNKNOWN`, and `colorFromOperands` fell back to guessing gray/RGB/CMYK purely from the `sc`/`scn` operand count.
- That heuristic happens to match ICCBased/CalGray/CalRGB by coincidence (operand count equals component count), so those cases mostly "worked" already. **Lab is a real, visible bug**: L\*a\*b\* components (`L` in 0-100, `a`/`b` roughly -100..100) fed straight into `rgb()` after `clamp01` collapse almost every Lab color to solid white or black instead of the intended color, since raw Lab values aren't RGB values.
- Adds `resolveColorSpaceResource()` / `classifyColorSpaceDefinition()`, reusing the same array-classification approach `imageComponents()` already uses for Image XObjects (ICCBased-by-`/N`, CalGray, CalRGB), plus a new correct Lab → CIEXYZ → sRGB conversion (`labToRgb`), using the color space's own `/WhitePoint` when present and D50 otherwise. Verified the conversion against known reference values (Lab D50 encodings of pure red/green/black/white round-trip to the expected sRGB) before locking in test assertions.
- Color spaces still not specifically understood (Separation, DeviceN, Indexed-as-fill, Pattern) keep falling back to the existing operand-count heuristic — unchanged behavior, out of scope for this PR.
- Updated `openpdf-renderer/README.md`'s color-space coverage section and the class-level Javadoc.
