### PR TITLE
openpdf-renderer: render annotation appearance streams (/AP /N)

### DIFF
--- a/openpdf-renderer/README.md
+++ b/openpdf-renderer/README.md
@@ -151,19 +151,6 @@ colors and type 3 font glyph operators are silently ignored. Pages that
 rely heavily on those features may render with missing content. Adding more
 operators is a localized change in `OpenPdfCorePageRenderer`.
 
-Annotations: after the page content stream, each entry in `/Annots` has its
-normal appearance stream (`/AP /N` &mdash; directly a stream, or a
-sub-dictionary of named states selected by `/AS`, e.g. a checkbox's
-`/Yes`/`/Off`) rendered at its `/Rect`, per the PDF §12.5.5 placement
-algorithm (the appearance's `/BBox` is mapped through its own `/Matrix`,
-then fitted to `/Rect` by independent X/Y scale + translate). This covers
-stamps, highlights, free text callouts, square/circle markup, and filled-in
-form field appearances &mdash; anything a PDF producer already baked into an
-appearance stream. Annotations flagged Hidden or NoView (`/F` bits 2/6),
-Popup annotations, and annotations with no usable `/AP` (or an `/AS` that
-doesn't resolve to a state) are skipped; the renderer doesn't synthesize an
-appearance (e.g. a Link's default invisible border) when one isn't present.
-
 For pages that need features outside this supported subset and you want
 pixel-perfect output today, the deprecated `PDFFile` / `PDFPage.getImage(...)`
 API still works.
@@ -421,7 +408,7 @@ mvn javadoc:javadoc
 | ICC Profiles | ✅ Full |
 | Images (JPEG, PNG) | ✅ Full |
 | Transparency | ✅ Partial |
-| Annotations | ⚠️ Appearance streams only (no synthesized default appearances) |
+| Annotations | ⚠️ Basic |
 | Forms | ⚠️ Limited |
 | Encryption | ❌ Removed |
 

--- a/openpdf-renderer/README.md
+++ b/openpdf-renderer/README.md
@@ -151,6 +151,19 @@ colors and type 3 font glyph operators are silently ignored. Pages that
 rely heavily on those features may render with missing content. Adding more
 operators is a localized change in `OpenPdfCorePageRenderer`.
 
+Annotations: after the page content stream, each entry in `/Annots` has its
+normal appearance stream (`/AP /N` &mdash; directly a stream, or a
+sub-dictionary of named states selected by `/AS`, e.g. a checkbox's
+`/Yes`/`/Off`) rendered at its `/Rect`, per the PDF §12.5.5 placement
+algorithm (the appearance's `/BBox` is mapped through its own `/Matrix`,
+then fitted to `/Rect` by independent X/Y scale + translate). This covers
+stamps, highlights, free text callouts, square/circle markup, and filled-in
+form field appearances &mdash; anything a PDF producer already baked into an
+appearance stream. Annotations flagged Hidden or NoView (`/F` bits 2/6),
+Popup annotations, and annotations with no usable `/AP` (or an `/AS` that
+doesn't resolve to a state) are skipped; the renderer doesn't synthesize an
+appearance (e.g. a Link's default invisible border) when one isn't present.
+
 For pages that need features outside this supported subset and you want
 pixel-perfect output today, the deprecated `PDFFile` / `PDFPage.getImage(...)`
 API still works.
@@ -408,7 +421,7 @@ mvn javadoc:javadoc
 | ICC Profiles | ✅ Full |
 | Images (JPEG, PNG) | ✅ Full |
 | Transparency | ✅ Partial |
-| Annotations | ⚠️ Basic |
+| Annotations | ⚠️ Appearance streams only (no synthesized default appearances) |
 | Forms | ⚠️ Limited |
 | Encryption | ❌ Removed |
 

--- a/openpdf-renderer/src/main/java/org/openpdf/renderer/core/OpenPdfCorePageRenderer.java
+++ b/openpdf-renderer/src/main/java/org/openpdf/renderer/core/OpenPdfCorePageRenderer.java
@@ -165,6 +165,9 @@ final class OpenPdfCorePageRenderer {
     private static final Set<PdfName> DEVICE_CMYK_NAMES = Set.of(
             PdfName.DEVICECMYK, new PdfName("CMYK"));
 
+    private static final int ANNOTATION_FLAG_HIDDEN = 1 << 1; // PDF §12.5.3, bit position 2
+    private static final int ANNOTATION_FLAG_NOVIEW = 1 << 5; // PDF §12.5.3, bit position 6
+
     /**
      * Synthetic XObject-name prefix used for inline images that have been promoted out
      * of the content stream into {@link #inlineImages}. Keeping a clearly distinctive
@@ -1228,9 +1231,6 @@ final class OpenPdfCorePageRenderer {
     }
 
     // ---------- Annotation appearance streams ----------
-
-    private static final int ANNOTATION_FLAG_HIDDEN = 1 << 1; // PDF §12.5.3, bit position 2
-    private static final int ANNOTATION_FLAG_NOVIEW = 1 << 5; // PDF §12.5.3, bit position 6
 
     /**
      * Renders each page annotation's normal appearance stream ({@code /AP /N}), positioned per

--- a/openpdf-renderer/src/main/java/org/openpdf/renderer/core/OpenPdfCorePageRenderer.java
+++ b/openpdf-renderer/src/main/java/org/openpdf/renderer/core/OpenPdfCorePageRenderer.java
@@ -101,6 +101,14 @@ import org.openpdf.text.pdf.PdfString;
  * ignored. Pages that rely heavily on those features may render with missing
  * content.</p>
  *
+ * <h2>Annotations</h2>
+ * <p>After the page content stream, each {@code /Annots} entry's normal
+ * appearance stream ({@code /AP /N}, resolving an {@code /AS} state name when
+ * {@code /N} is a sub-dictionary of states) is rendered at its {@code /Rect}
+ * per the PDF §12.5.5 placement algorithm. Hidden/NoView-flagged and Popup
+ * annotations, and annotations with no usable appearance stream, are
+ * skipped &mdash; no default appearance is synthesized.</p>
+ *
  * <h2>Text rendering</h2>
  * <p>For each {@code Tf}-selected font, the renderer pulls the embedded font
  * program ({@code FontFile2}, {@code FontFile3} or {@code FontFile} on the
@@ -281,6 +289,14 @@ final class OpenPdfCorePageRenderer {
 
         OpenPdfCorePageRenderer renderer = new OpenPdfCorePageRenderer(g2, resources);
         renderer.processContent(reader.getPageContent(pageNumber));
+
+        // Annotation /Rect coordinates are defined in the same page space "initial" maps to
+        // device space. A malformed content stream with unbalanced q/Q (or a top-level cm) can
+        // leave g2's transform/clip in an arbitrary state after processContent returns, so reset
+        // both explicitly rather than assuming the content stream cleaned up after itself.
+        g2.setTransform(initial);
+        g2.setClip(null);
+        renderer.renderAnnotations(pageDict);
     }
 
     private void processContent(byte[] contentBytes) throws IOException {
@@ -1170,14 +1186,7 @@ final class OpenPdfCorePageRenderer {
         GState savedState = state;
         try {
             state = new GState(state);
-            PdfArray matrix = form.getAsArray(PdfName.MATRIX);
-            if (matrix != null && matrix.size() >= 6) {
-                AffineTransform m = new AffineTransform(
-                        floatAt(matrix, 0), floatAt(matrix, 1),
-                        floatAt(matrix, 2), floatAt(matrix, 3),
-                        floatAt(matrix, 4), floatAt(matrix, 5));
-                g2.transform(m);
-            }
+            g2.transform(formMatrixOf(form));
             PdfArray bbox = form.getAsArray(PdfName.BBOX);
             if (bbox != null && bbox.size() >= 4) {
                 float x = floatAt(bbox, 0);
@@ -1201,6 +1210,158 @@ final class OpenPdfCorePageRenderer {
             g2.setTransform(savedTx);
             g2.setClip(savedClip);
         }
+    }
+
+    /**
+     * Reads a stream's {@code /Matrix} entry (a Form XObject or annotation appearance stream),
+     * or the identity transform if absent/malformed.
+     */
+    private static AffineTransform formMatrixOf(PRStream form) {
+        PdfArray matrix = form.getAsArray(PdfName.MATRIX);
+        if (matrix == null || matrix.size() < 6) {
+            return new AffineTransform();
+        }
+        return new AffineTransform(
+                floatAt(matrix, 0), floatAt(matrix, 1),
+                floatAt(matrix, 2), floatAt(matrix, 3),
+                floatAt(matrix, 4), floatAt(matrix, 5));
+    }
+
+    // ---------- Annotation appearance streams ----------
+
+    private static final int ANNOTATION_FLAG_HIDDEN = 1 << 1; // PDF §12.5.3, bit position 2
+    private static final int ANNOTATION_FLAG_NOVIEW = 1 << 5; // PDF §12.5.3, bit position 6
+
+    /**
+     * Renders each page annotation's normal appearance stream ({@code /AP /N}), positioned per
+     * PDF §12.5.5's Rect/BBox/Matrix algorithm. Annotations without a usable appearance stream
+     * (no {@code /AP}, or a missing {@code /AS} into a sub-dictionary of states) are skipped
+     * rather than synthesized &mdash; e.g. a checkbox's "Off" vs "Yes" appearance, or a Link's
+     * usually-invisible default border, are exactly what {@code /AP} is meant to capture, so
+     * there's no reasonable fallback to draw when it's absent.
+     */
+    private void renderAnnotations(PdfDictionary pageDict) {
+        PdfArray annots = pageDict == null ? null : pageDict.getAsArray(PdfName.ANNOTS);
+        if (annots == null) {
+            return;
+        }
+        for (PdfObject annotObj : annots.getElements()) {
+            PdfObject direct = annotObj instanceof PRIndirectReference ref
+                    ? PdfReader.getPdfObject(ref) : annotObj;
+            if (direct instanceof PdfDictionary annotDict) {
+                renderAnnotation(annotDict);
+            }
+        }
+    }
+
+    private void renderAnnotation(PdfDictionary annot) {
+        if (isHiddenOrNoView(annot) || PdfName.POPUP.equals(annot.getAsName(PdfName.SUBTYPE))) {
+            return;
+        }
+        PRStream appearance = normalAppearanceOf(annot);
+        if (appearance == null) {
+            return;
+        }
+        PdfArray rect = annot.getAsArray(PdfName.RECT);
+        if (rect == null || rect.size() < 4) {
+            return;
+        }
+        AffineTransform placement = appearancePlacementTransform(appearance, rect);
+        if (placement == null) {
+            return;
+        }
+        AffineTransform savedTx = g2.getTransform();
+        Shape savedClip = g2.getClip();
+        try {
+            g2.transform(placement);
+            renderForm(appearance);
+        } catch (RuntimeException e) {
+            LOG.log(Level.FINE, "Skipping annotation appearance due to: {0}", e);
+        } finally {
+            g2.setTransform(savedTx);
+            g2.setClip(savedClip);
+        }
+    }
+
+    private static boolean isHiddenOrNoView(PdfDictionary annot) {
+        PdfNumber flags = annot.getAsNumber(PdfName.F);
+        if (flags == null) {
+            return false;
+        }
+        int f = flags.intValue();
+        return (f & ANNOTATION_FLAG_HIDDEN) != 0 || (f & ANNOTATION_FLAG_NOVIEW) != 0;
+    }
+
+    /**
+     * Resolves an annotation's {@code /AP /N} entry to a concrete appearance stream. {@code /N}
+     * is either directly a stream (the common case) or a sub-dictionary of named appearance
+     * states (e.g. a checkbox's {@code /Yes} / {@code /Off}), selected by the annotation's
+     * {@code /AS} name.
+     */
+    private static PRStream normalAppearanceOf(PdfDictionary annot) {
+        PdfDictionary apDict = annot.getAsDict(PdfName.AP);
+        if (apDict == null) {
+            return null;
+        }
+        PdfObject direct = resolveIndirect(apDict.get(PdfName.N));
+        if (direct instanceof PRStream stream) {
+            return stream;
+        }
+        if (!(direct instanceof PdfDictionary states)) {
+            return null;
+        }
+        PdfName stateName = annot.getAsName(PdfName.AS);
+        if (stateName == null) {
+            return null;
+        }
+        PdfObject state = resolveIndirect(states.get(stateName));
+        return state instanceof PRStream stream ? stream : null;
+    }
+
+    private static PdfObject resolveIndirect(PdfObject obj) {
+        return obj instanceof PRIndirectReference ref ? PdfReader.getPdfObject(ref) : obj;
+    }
+
+    /**
+     * Computes the transform that positions an annotation's appearance stream per PDF §12.5.5:
+     * the stream's own {@code /BBox} corners are mapped through its {@code /Matrix} and reduced
+     * to their axis-aligned bounding box, which is then scaled/translated (independently in X
+     * and Y, no rotation) to align with the annotation's {@code /Rect}. {@link #renderForm}
+     * applies {@code /Matrix} itself when it subsequently renders the stream, so this transform
+     * only supplies that alignment step, not {@code /Matrix} again.
+     *
+     * @return the placement transform, or {@code null} if the stream has no usable {@code /BBox}
+     */
+    private static AffineTransform appearancePlacementTransform(PRStream appearance, PdfArray rect) {
+        PdfArray bbox = appearance.getAsArray(PdfName.BBOX);
+        if (bbox == null || bbox.size() < 4) {
+            return null;
+        }
+        double[] corners = {
+                floatAt(bbox, 0), floatAt(bbox, 1),
+                floatAt(bbox, 2), floatAt(bbox, 1),
+                floatAt(bbox, 2), floatAt(bbox, 3),
+                floatAt(bbox, 0), floatAt(bbox, 3),
+        };
+        formMatrixOf(appearance).transform(corners, 0, corners, 0, 4);
+        double tx0 = Math.min(Math.min(corners[0], corners[2]), Math.min(corners[4], corners[6]));
+        double tx1 = Math.max(Math.max(corners[0], corners[2]), Math.max(corners[4], corners[6]));
+        double ty0 = Math.min(Math.min(corners[1], corners[3]), Math.min(corners[5], corners[7]));
+        double ty1 = Math.max(Math.max(corners[1], corners[3]), Math.max(corners[5], corners[7]));
+
+        float rx0 = Math.min(floatAt(rect, 0), floatAt(rect, 2));
+        float ry0 = Math.min(floatAt(rect, 1), floatAt(rect, 3));
+        float rx1 = Math.max(floatAt(rect, 0), floatAt(rect, 2));
+        float ry1 = Math.max(floatAt(rect, 1), floatAt(rect, 3));
+
+        double sx = tx1 != tx0 ? (rx1 - rx0) / (tx1 - tx0) : 1;
+        double sy = ty1 != ty0 ? (ry1 - ry0) / (ty1 - ty0) : 1;
+
+        AffineTransform placement = new AffineTransform();
+        placement.translate(rx0, ry0);
+        placement.scale(sx, sy);
+        placement.translate(-tx0, -ty0);
+        return placement;
     }
 
     /**

--- a/openpdf-renderer/src/test/java/org/openpdf/renderer/core/OpenPdfCorePageRendererOperatorsTest.java
+++ b/openpdf-renderer/src/test/java/org/openpdf/renderer/core/OpenPdfCorePageRendererOperatorsTest.java
@@ -298,6 +298,77 @@ class OpenPdfCorePageRendererOperatorsTest {
         }
     }
 
+    /**
+     * PDF §12.5.5: an annotation's visible content is its {@code /AP /N} appearance stream,
+     * positioned in the page by mapping the stream's {@code /BBox} (through its {@code /Matrix})
+     * onto the annotation's {@code /Rect}. Before this support, {@code OpenPdfCorePageRenderer}
+     * only walked the page content stream and never looked at {@code /Annots} at all, so stamps,
+     * highlights, and form-field appearances were invisible no matter what. This builds an
+     * annotation whose appearance is an orange-filled template and checks it actually paints at
+     * its {@code /Rect} location.
+     */
+    @Test
+    void rendersAnnotationNormalAppearanceStream() throws Exception {
+        byte[] pdf = buildPdf(cb -> {
+            org.openpdf.text.pdf.PdfTemplate appearance = cb.createTemplate(100f, 60f);
+            appearance.setRGBColorFillF(1f, 0.5f, 0f); // orange
+            appearance.rectangle(0f, 0f, 100f, 60f);
+            appearance.fill();
+
+            org.openpdf.text.pdf.PdfWriter writer = cb.getPdfWriter();
+            org.openpdf.text.pdf.PdfAnnotation annotation =
+                    new org.openpdf.text.pdf.PdfAnnotation(writer,
+                            new org.openpdf.text.Rectangle(40f, 120f, 140f, 180f));
+            annotation.put(org.openpdf.text.pdf.PdfName.SUBTYPE, org.openpdf.text.pdf.PdfName.SQUARE);
+            annotation.setAppearance(org.openpdf.text.pdf.PdfAnnotation.APPEARANCE_NORMAL, appearance);
+            writer.addAnnotation(annotation);
+        });
+
+        try (OpenPdfCoreRenderer r = new OpenPdfCoreRenderer(pdf)) {
+            BufferedImage img = r.renderPage(1, 150f);
+            saveForInspection(img, "annotation-appearance.png");
+            int orangeish = countPixelsMatching(img, (red, green, blue) ->
+                    red > 200 && green > 80 && green < 200 && blue < 80);
+            assertThat(orangeish)
+                    .as("an annotation's /AP /N appearance stream must be painted at its /Rect")
+                    .isGreaterThan(100);
+        }
+    }
+
+    /**
+     * PDF §12.5.3: the Hidden flag (bit 2 of {@code /F}) means the annotation shall not be
+     * rendered at all, in any context. This is the same annotation/appearance as above, but
+     * flagged Hidden -- the orange fill must not appear anywhere on the page.
+     */
+    @Test
+    void skipsHiddenAnnotationAppearance() throws Exception {
+        byte[] pdf = buildPdf(cb -> {
+            org.openpdf.text.pdf.PdfTemplate appearance = cb.createTemplate(100f, 60f);
+            appearance.setRGBColorFillF(1f, 0.5f, 0f); // orange
+            appearance.rectangle(0f, 0f, 100f, 60f);
+            appearance.fill();
+
+            org.openpdf.text.pdf.PdfWriter writer = cb.getPdfWriter();
+            org.openpdf.text.pdf.PdfAnnotation annotation =
+                    new org.openpdf.text.pdf.PdfAnnotation(writer,
+                            new org.openpdf.text.Rectangle(40f, 120f, 140f, 180f));
+            annotation.put(org.openpdf.text.pdf.PdfName.SUBTYPE, org.openpdf.text.pdf.PdfName.SQUARE);
+            annotation.setAppearance(org.openpdf.text.pdf.PdfAnnotation.APPEARANCE_NORMAL, appearance);
+            annotation.setFlags(org.openpdf.text.pdf.PdfAnnotation.FLAGS_HIDDEN);
+            writer.addAnnotation(annotation);
+        });
+
+        try (OpenPdfCoreRenderer r = new OpenPdfCoreRenderer(pdf)) {
+            BufferedImage img = r.renderPage(1, 150f);
+            saveForInspection(img, "annotation-hidden.png");
+            int orangeish = countPixelsMatching(img, (red, green, blue) ->
+                    red > 200 && green > 80 && green < 200 && blue < 80);
+            assertThat(orangeish)
+                    .as("a Hidden-flagged annotation must not be painted")
+                    .isZero();
+        }
+    }
+
     @Test
     void inlineImageRendersAtCtmLocation() throws Exception {
         // Build a content stream by hand: a 2x2 DeviceGray inline image whose pixels are

--- a/openpdf-renderer/src/test/java/org/openpdf/renderer/core/OpenPdfCorePageRendererOperatorsTest.java
+++ b/openpdf-renderer/src/test/java/org/openpdf/renderer/core/OpenPdfCorePageRendererOperatorsTest.java
@@ -299,30 +299,40 @@ class OpenPdfCorePageRendererOperatorsTest {
     }
 
     /**
-     * PDF §12.5.5: an annotation's visible content is its {@code /AP /N} appearance stream,
-     * positioned in the page by mapping the stream's {@code /BBox} (through its {@code /Matrix})
-     * onto the annotation's {@code /Rect}. Before this support, {@code OpenPdfCorePageRenderer}
-     * only walked the page content stream and never looked at {@code /Annots} at all, so stamps,
-     * highlights, and form-field appearances were invisible no matter what. This builds an
-     * annotation whose appearance is an orange-filled template and checks it actually paints at
-     * its {@code /Rect} location.
+     * Builds a single-page PDF with a Square annotation whose {@code /AP /N} appearance is an
+     * orange-filled template at Rect {@code [40, 120, 140, 180]}, optionally Hidden-flagged.
+     * Shared by {@link #rendersAnnotationNormalAppearanceStream()} and
+     * {@link #skipsHiddenAnnotationAppearance()}.
      */
-    @Test
-    void rendersAnnotationNormalAppearanceStream() throws Exception {
-        byte[] pdf = buildPdf(cb -> {
+    private static byte[] buildAnnotatedPdf(boolean hidden) throws Exception {
+        return buildPdf(cb -> {
             org.openpdf.text.pdf.PdfTemplate appearance = cb.createTemplate(100f, 60f);
             appearance.setRGBColorFillF(1f, 0.5f, 0f); // orange
             appearance.rectangle(0f, 0f, 100f, 60f);
             appearance.fill();
 
-            org.openpdf.text.pdf.PdfWriter writer = cb.getPdfWriter();
+            PdfWriter writer = cb.getPdfWriter();
             org.openpdf.text.pdf.PdfAnnotation annotation =
-                    new org.openpdf.text.pdf.PdfAnnotation(writer,
-                            new org.openpdf.text.Rectangle(40f, 120f, 140f, 180f));
+                    new org.openpdf.text.pdf.PdfAnnotation(writer, new Rectangle(40f, 120f, 140f, 180f));
             annotation.put(org.openpdf.text.pdf.PdfName.SUBTYPE, org.openpdf.text.pdf.PdfName.SQUARE);
             annotation.setAppearance(org.openpdf.text.pdf.PdfAnnotation.APPEARANCE_NORMAL, appearance);
+            if (hidden) {
+                annotation.setFlags(org.openpdf.text.pdf.PdfAnnotation.FLAGS_HIDDEN);
+            }
             writer.addAnnotation(annotation);
         });
+    }
+
+    /**
+     * PDF §12.5.5: an annotation's visible content is its {@code /AP /N} appearance stream,
+     * positioned in the page by mapping the stream's {@code /BBox} (through its {@code /Matrix})
+     * onto the annotation's {@code /Rect}. Before this support, {@code OpenPdfCorePageRenderer}
+     * only walked the page content stream and never looked at {@code /Annots} at all, so stamps,
+     * highlights, and form-field appearances were invisible no matter what.
+     */
+    @Test
+    void rendersAnnotationNormalAppearanceStream() throws Exception {
+        byte[] pdf = buildAnnotatedPdf(false);
 
         try (OpenPdfCoreRenderer r = new OpenPdfCoreRenderer(pdf)) {
             BufferedImage img = r.renderPage(1, 150f);
@@ -342,21 +352,7 @@ class OpenPdfCorePageRendererOperatorsTest {
      */
     @Test
     void skipsHiddenAnnotationAppearance() throws Exception {
-        byte[] pdf = buildPdf(cb -> {
-            org.openpdf.text.pdf.PdfTemplate appearance = cb.createTemplate(100f, 60f);
-            appearance.setRGBColorFillF(1f, 0.5f, 0f); // orange
-            appearance.rectangle(0f, 0f, 100f, 60f);
-            appearance.fill();
-
-            org.openpdf.text.pdf.PdfWriter writer = cb.getPdfWriter();
-            org.openpdf.text.pdf.PdfAnnotation annotation =
-                    new org.openpdf.text.pdf.PdfAnnotation(writer,
-                            new org.openpdf.text.Rectangle(40f, 120f, 140f, 180f));
-            annotation.put(org.openpdf.text.pdf.PdfName.SUBTYPE, org.openpdf.text.pdf.PdfName.SQUARE);
-            annotation.setAppearance(org.openpdf.text.pdf.PdfAnnotation.APPEARANCE_NORMAL, appearance);
-            annotation.setFlags(org.openpdf.text.pdf.PdfAnnotation.FLAGS_HIDDEN);
-            writer.addAnnotation(annotation);
-        });
+        byte[] pdf = buildAnnotatedPdf(true);
 
         try (OpenPdfCoreRenderer r = new OpenPdfCoreRenderer(pdf)) {
             BufferedImage img = r.renderPage(1, 150f);


### PR DESCRIPTION
## Summary
- `OpenPdfCorePageRenderer` only ever walked the page content stream, so annotations — stamps, highlights, square/circle markup, free-text callouts, filled-in form field appearances — never rendered at all, regardless of what the PDF producer baked into their `/AP` appearance streams. Any PDF using form fields or markup annotations rendered as if it had none.
- After the page content stream finishes, each `/Annots` entry's normal appearance (`/AP /N` — directly a stream, or a sub-dictionary of states selected by `/AS`, e.g. a checkbox's `/Yes` vs `/Off`) is now rendered at its `/Rect`, per the PDF §12.5.5 placement algorithm: the appearance's `/BBox` is mapped through its own `/Matrix`, reduced to an axis-aligned bounding box, then fitted to `/Rect` by independent X/Y scale + translate (no rotation/shear beyond what `/Matrix` itself already encodes).
- Reuses the existing `renderForm()` for the actual `/Matrix`/`/BBox`-clip/content-stream handling, since an appearance stream is structurally a Form XObject — added a small shared `formMatrixOf()` helper so both call sites parse `/Matrix` the same way.
- Skips Hidden/NoView-flagged annotations (`/F` bits 2/6) and Popup annotations, and skips annotations with no usable appearance stream. Deliberately does **not** synthesize a default appearance (e.g. a Link's usually-invisible border, or a Square/Circle's `/IC`/`/C`/`/BS`-derived look) when the PDF doesn't provide one — that's a separate, larger feature.
- Also resets the page transform/clip to their initial (page-to-device) state before rendering annotations, since `/Rect` coordinates are defined in page space and a content stream with unbalanced `q`/`Q` (or a top-level `cm`) could otherwise leave stale transform/clip state behind from content-stream processing.
- Updated `openpdf-renderer/README.md` (XObject/annotation coverage prose + the supported-features table) and the class-level Javadoc.